### PR TITLE
Use dir header first_free_byte as additional termination

### DIFF
--- a/src/tdo_dev_stream.cpp
+++ b/src/tdo_dev_stream.cpp
@@ -126,7 +126,7 @@ TDO::DevStream::setup()
 
   {
     PosGuard guard(*this);
-    _read(label);
+    read(label);
     _device_block_data_size = label.volume_block_size;
   }
 
@@ -262,7 +262,7 @@ TDO::DevStream::read(int32_t &i32_)
 }
 
 void
-TDO::DevStream::_read(TDO::DiscLabel &dl_)
+TDO::DevStream::read(TDO::DiscLabel &dl_)
 {
   read(dl_.record_type);
   read(dl_.volume_sync_bytes);
@@ -281,20 +281,8 @@ TDO::DevStream::_read(TDO::DiscLabel &dl_)
 }
 
 void
-TDO::DevStream::read(TDO::DiscLabel &dl_)
-{
-  dl_.file_offset = file_tell();
-  dl_.data_offset = data_byte_tell();
-
-  _read(dl_);
-}
-
-void
 TDO::DevStream::read(TDO::DirectoryHeader &dh_)
 {
-  dh_.file_offset = file_tell();
-  dh_.data_offset = data_byte_tell();
-
   read(dh_.next_block);
   read(dh_.prev_block);
   read(dh_.flags);
@@ -305,9 +293,6 @@ TDO::DevStream::read(TDO::DirectoryHeader &dh_)
 void
 TDO::DevStream::read(TDO::DirectoryRecord &dr_)
 {
-  dr_.file_offset = file_tell();
-  dr_.data_offset = data_byte_tell();
-
   read(dr_.flags);
   read(dr_.unique_identifier);
   read(dr_.type);

--- a/src/tdo_dev_stream.hpp
+++ b/src/tdo_dev_stream.hpp
@@ -59,14 +59,12 @@ namespace TDO
   public:
     std::int64_t file_tell() const;
     std::int64_t data_byte_tell() const;
-    std::int64_t device_block_tell() const;
 
   public:
     void read(char *buf, uint32_t size);
     void read(char &c);
     void read(uint32_t &u32);
     void read(int32_t &i32);
-    void _read(TDO::DiscLabel &);    
     void read(TDO::DiscLabel &);
     void read(TDO::DirectoryHeader &);
     void read(TDO::DirectoryRecord &);

--- a/src/tdo_directory_header.hpp
+++ b/src/tdo_directory_header.hpp
@@ -24,9 +24,6 @@ namespace TDO
 {
   struct DirectoryHeader
   {
-    uint32_t file_offset;
-    uint32_t data_offset;
-
     int32_t  next_block;
     int32_t  prev_block;
     uint32_t flags;

--- a/src/tdo_directory_record.hpp
+++ b/src/tdo_directory_record.hpp
@@ -42,10 +42,6 @@ namespace TDO
   struct DirectoryRecord
   {
   public:
-    uint32_t file_offset;
-    uint32_t data_offset;
-
-  public:
     uint32_t flags;
     uint32_t unique_identifier;
     uint32_t type;

--- a/src/tdo_disc_label.hpp
+++ b/src/tdo_disc_label.hpp
@@ -44,11 +44,6 @@ namespace TDO
 
   struct DiscLabel
   {
-  public:
-    uint32_t file_offset;
-    uint32_t data_offset;
-
-  public:
     char     record_type;       /* Should equal 0x01 */
     VSBArray volume_sync_bytes; /* Synchronization bytes: 0x5A5A5A5A5A */
     char     volume_structure_version; /* Should equal 0x01 */

--- a/src/tdo_fs_walker.hpp
+++ b/src/tdo_fs_walker.hpp
@@ -37,7 +37,7 @@ namespace TDO
       void
       operator()(const std::filesystem::path&,
                  const TDO::DirectoryHeader&,
-                 DevStream&)
+                 TDO::DevStream&)
       {
       }
 
@@ -45,7 +45,7 @@ namespace TDO
       void
       operator()(const std::filesystem::path&,
                  const TDO::DirectoryRecord&,
-                 DevStream&)
+                 TDO::DevStream&)
       {
       }
     };


### PR DESCRIPTION
Directory entries at the end of the block are supposed to be flagged as such.
However, some images built with 3doiso.exe appear to not set the appropriate
flag indicating the end of a block. Need to additionally use the first_free_byte
value from the directory header and exit once that relative offset is hit.