### PR TITLE
Validate OperaFS metadata during parsing

### DIFF
--- a/src/error.hpp
+++ b/src/error.hpp
@@ -26,6 +26,11 @@ struct Error
   {
   }
 
+  Error(const Error &err_)
+    : str(err_.str)
+  {
+  }
+
   Error(Error &&err_)
     : str(std::move(err_.str))
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,8 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
+#include "error.hpp"
+#include "log.hpp"
 #include "subcommand.hpp"
 
 #include "CLI11.hpp"
@@ -261,6 +263,11 @@ main(int    argc_,
   catch(const CLI::ParseError &e)
     {
       return app.exit(e);
+    }
+  catch(const Error &err)
+    {
+      Log::error(err);
+      return 1;
     }
 
   return 0;

--- a/src/subcommand_info.cpp
+++ b/src/subcommand_info.cpp
@@ -154,12 +154,17 @@ namespace
   get_label(TDO::FileStream &stream_,
             TDO::DiscLabel  &label_)
   {
-    Error err;
+    try
+      {
+        stream_.data_byte_seek(0);
+        stream_.read(label_);
 
-    stream_.data_byte_seek(0);
-    stream_.read(label_);
-
-    return {};
+        return {};
+      }
+    catch(const Error &err)
+      {
+        return err;
+      }
   }
 
   static

--- a/src/subcommand_romtags.cpp
+++ b/src/subcommand_romtags.cpp
@@ -134,28 +134,35 @@ Subcommand::romtags(const Options::ROMTags &opts_)
 
   for(const auto &filepath : opts_.filepaths)
     {
-      Error err;
-      TDO::FileStream stream;
+      try
+        {
+          Error err;
+          TDO::FileStream stream;
 
-      err = stream.open(filepath);
-      if(err)
+          err = stream.open(filepath);
+          if(err)
+            {
+              fmt::print(stderr,"3dt: {} - {}\n",err.str,filepath);
+              continue;
+            }
+
+          if(!stream.has_romtags())
+            {
+              fmt::print(stderr,"3dt: {} does not contain ROMTags\n",filepath);
+              continue;
+            }
+
+          if(printed_header == false)
+            {
+              print_romtags_csv_header();
+              printed_header = true;
+            }
+
+          ::romtags_human(filepath,stream);
+        }
+      catch(const Error &err)
         {
           fmt::print(stderr,"3dt: {} - {}\n",err.str,filepath);
-          break;
         }
-
-      if(!stream.has_romtags())
-        {
-          fmt::print(stderr,"3dt: {} does not contain ROMTags\n",filepath);
-          break;
-        }
-
-      if(printed_header == false)
-        {
-          print_romtags_csv_header();
-          printed_header = true;
-        }
-
-      ::romtags_human(filepath,stream);
     }
 }

--- a/src/subcommand_to-iso.cpp
+++ b/src/subcommand_to-iso.cpp
@@ -51,7 +51,6 @@ namespace Subcommand
   to_iso(const Options::ToISO &options_)
   {
     Error err;
-    std::int64_t i;
     std::uint64_t blocks;
     std::ofstream ofs;
     fs::path output_path;
@@ -76,23 +75,34 @@ namespace Subcommand
         return Log::error_stream_open(output_path);
       }
 
-    i = 0;
-    blocks = stream.device_block_count() - 1;
-    while(stream.good() && !stream.eof())
+    const std::uint64_t leading_blocks =
+      (stream.data_offset() / stream.device_block_data_size());
+    const std::uint64_t device_blocks = stream.device_block_count();
+
+    if(device_blocks > leading_blocks)
+      blocks = (device_blocks - leading_blocks);
+    else
+      blocks = 0;
+    try
       {
-        stream.data_block_seek(i);
+        for(std::uint64_t block = 0; block < blocks; block++)
+          {
+            stream.data_byte_seek(block * stream.device_block_data_size());
+            stream.read(buf);
 
-        stream.read(buf);
-        if(!stream.good())
-          break;
+            ofs.write(buf.data(),buf.size());
+            if(ofs.bad())
+              return Log::error({"write failed"});
 
-        ofs.write(buf.data(),buf.size());
-        if(ofs.bad())
-          return Log::error({"write failed"});
-
-        fmt::print("\r{}: block {} of {} written",output_path,i,blocks);
-
-        i++;
+            fmt::print("\r{}: block {} of {} written",
+                       output_path,
+                       block,
+                       (blocks == 0 ? 0 : (blocks - 1)));
+          }
+      }
+    catch(const Error &err)
+      {
+        return Log::error(err);
       }
 
     fmt::print("\n");

--- a/src/tdo_dev_stream.cpp
+++ b/src/tdo_dev_stream.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "error_unknown_image_format.hpp"
+#include "fmt.hpp"
 #include "tdo_dev_stream.hpp"
 #include "tdo_linked_mem_file_entry.hpp"
 
@@ -31,19 +32,21 @@
 static constexpr int TDO_SECTOR_SIZE   = 2048;
 static constexpr int CDROM_SECTOR_SIZE = 2352;
 static constexpr int SYNC_PATTERN_SIZE = 12;
+static constexpr std::uint32_t MAX_DIRECTORY_AVATAR_INDEX = ROOT_HIGHEST_AVATAR;
+static constexpr std::uint32_t DIRECTORY_HEADER_SIZE = sizeof(TDO::DirectoryHeader);
 typedef std::array<uint8_t,CDROM_SECTOR_SIZE> CDROMSectorBuf;
 typedef std::array<uint8_t,SYNC_PATTERN_SIZE> CDROMSyncPatternBuf;
 typedef std::array<uint8_t,VOLUME_SYNC_BYTE_LEN> VolumeSyncByteBuf;
 static constexpr CDROMSyncPatternBuf MODE1_SYNC_PATTERN = {0x00,0xFF,0xFF,0xFF,
-  0xFF,0xFF,0xFF,0xFF,
-  0xFF,0xFF,0xFF,0x00};
+                                                           0xFF,0xFF,0xFF,0xFF,
+                                                           0xFF,0xFF,0xFF,0x00};
 static constexpr VolumeSyncByteBuf VOLUME_SYNC_BYTES = {0x5A,0x5A,0x5A,0x5A,0x5A};
 static constexpr std::array<uint8_t,4> ARM_NOOP = {0xE1,0xA0,0x10,01};
 
 static
 inline
 void
-swap(uint32_t &u32_)
+_swap(uint32_t &u32_)
 {
   u32_ = __builtin_bswap32(u32_);
 }
@@ -51,50 +54,41 @@ swap(uint32_t &u32_)
 static
 inline
 void
-swap(int32_t &i32_)
+_swap(int32_t &i32_)
 {
   i32_ = __builtin_bswap32(i32_);
 }
 
 static
-bool
-is_mode1_2352(std::istream &is_)
+inline
+void
+_swap(uint16_t &u16_)
 {
-  CDROMSectorBuf buf;
-
-  is_.seekg(0);
-  is_.read((char*)&buf[0],buf.size());
-
-  if(memcmp(&buf[0],&MODE1_SYNC_PATTERN[0],MODE1_SYNC_PATTERN.size()) != 0)
-    return false;
-
-  if(buf[0x0F] != 0x01)
-    return false;
-
-  return true;
+  u16_ = __builtin_bswap16(u16_);
 }
 
 static
-std::uint32_t
-count_m1_romtags(TDO::DevStream     &stream_,
-                 const std::int64_t  pos_)
+inline
+void
+_swap(int16_t &i16_)
 {
-  uint32_t count;
-  TDO::ROMTag tag;
-  TDO::PosGuard guard(stream_);
+  i16_ = __builtin_bswap16(i16_);
+}
 
-  stream_.data_block_seek(pos_);
+static
+inline
+void
+_swap(uint64_t &u64_)
+{
+  u64_ = __builtin_bswap64(u64_);
+}
 
-  count = 0;
-  while(true)
-    {
-      stream_.read(tag);
-      if((tag.sub_systype == 0) || (tag.type == 0))
-        break;
-      count++;
-    }
-
-  return count;
+static
+inline
+void
+_swap(int64_t &i64_)
+{
+  i64_ = __builtin_bswap64(i64_);
 }
 
 TDO::DevStream::DevStream(std::istream &is_)
@@ -135,13 +129,48 @@ TDO::DevStream::find_label()
     }
 }
 
-Error
+bool
+TDO::DevStream::is_mode1_2352()
+{
+  CDROMSectorBuf buf;
+
+  _is.seekg(0);
+  _is.read((char*)&buf[0],buf.size());
+
+  const bool has_mode1_sync_pattern =
+    (memcmp(&buf[0],&MODE1_SYNC_PATTERN[0],MODE1_SYNC_PATTERN.size()) == 0);
+  const bool has_mode1_sector_marker = (buf[0x0F] == 0x01);
+
+  return (has_mode1_sync_pattern && has_mode1_sector_marker);
+}
+
+std::uint32_t
+TDO::DevStream::count_m1_romtags(const std::int64_t pos_)
+{
+  uint32_t count;
+  TDO::ROMTag tag;
+  TDO::PosGuard guard(*this);
+
+  data_block_seek(pos_);
+
+  count = 0;
+  while(true)
+    {
+      read(tag);
+      if((tag.sub_systype == 0) || (tag.type == 0))
+        break;
+      count++;
+    }
+
+  return count;
+}
+
+void
 TDO::DevStream::setup()
 {
-  Error err;
   TDO::DiscLabel label;
 
-  if(::is_mode1_2352(_is))
+  if(is_mode1_2352())
     {
       _device_block_header = 16;
       _device_block_footer = 288;
@@ -149,7 +178,7 @@ TDO::DevStream::setup()
 
   find_label();
   if(eof())
-    return {"unable to find OperaFS in image"};
+    _throw("unable to find OperaFS in image");
 
   {
     PosGuard guard(*this);
@@ -160,8 +189,6 @@ TDO::DevStream::setup()
   _initialized = true;
 
   _data_offset = data_byte_tell();
-
-  return {};
 }
 
 static
@@ -180,18 +207,21 @@ is_konami_m2(TDO::DevStream &stream_)
   TDO::DiscLabel dl;
 
   stream_.find_label();
-  if(stream_.eof())
-    return false;
+  const bool found_label = !stream_.eof();
+
+  if(!found_label)
+    return found_label;
   stream_.read(dl);
 
-  if(dl.volume_flags != (VOLUME_FLAG_M2 | VOLUME_FLAG_BLESSED))
-    return false;
-  if(strcmp(&dl.volume_identifier[0],"cd-rom") != 0)
-    return false;
-  if(dl.num_rom_tags != 9)
-    return false;
+  const bool has_expected_volume_flags =
+    (dl.volume_flags == (VOLUME_FLAG_M2 | VOLUME_FLAG_BLESSED));
+  const bool has_expected_volume_identifier =
+    (strcmp(&dl.volume_identifier[0],"cd-rom") == 0);
+  const bool has_expected_rom_tag_count = (dl.num_rom_tags == 9);
 
-  return true;
+  return (has_expected_volume_flags &&
+          has_expected_volume_identifier &&
+          has_expected_rom_tag_count);
 }
 
 bool
@@ -199,12 +229,10 @@ TDO::DevStream::has_romtags()
 {
   TDO::PosGuard pos_guard(*this);
 
-  if(::is_romfs(*this))
-    return false;
-  if(::is_konami_m2(*this))
-    return false;
+  const bool uses_romfs_layout = ::is_romfs(*this);
+  const bool uses_konami_m2_layout = ::is_konami_m2(*this);
 
-  return true;
+  return (!uses_romfs_layout && !uses_konami_m2_layout);
 }
 
 TDO::ROMTagVec
@@ -222,7 +250,7 @@ TDO::DevStream::romtags()
   read(dl);
 
   if(dl.num_rom_tags == 0)
-    dl.num_rom_tags = ::count_m1_romtags(*this,pos+1);
+    dl.num_rom_tags = count_m1_romtags(pos+1);
 
   data_block_seek(pos+1);
   for(uint32_t i = 0; i < dl.num_rom_tags; i++)
@@ -483,7 +511,15 @@ void
 TDO::DevStream::read(char     *buf_,
                      uint32_t  size_)
 {
+  const std::streampos pos = _is.tellg();
+
+  if(!_is.good())
+    _throw("bad stream state before read");
+
   _is.read(buf_,size_);
+
+  if(!_is.good())
+    _throw("bad stream state after read");
 }
 
 void
@@ -502,79 +538,163 @@ void
 TDO::DevStream::read(uint32_t &u32_)
 {
   read((char*)&u32_,sizeof(uint32_t));
-  swap(u32_);
+  _swap(u32_);
 }
 
 void
 TDO::DevStream::read(int32_t &i32_)
 {
   read((char*)&i32_,sizeof(int32_t));
-  swap(i32_);
+  _swap(i32_);
 }
 
 void
 TDO::DevStream::read(TDO::DiscLabel &dl_)
 {
-  read(dl_.record_type);
-  read(dl_.volume_sync_bytes);
-  read(dl_.volume_structure_version);
-  read(dl_.volume_flags);
-  read(dl_.volume_commentary);
-  read(dl_.volume_identifier);
-  read(dl_.volume_unique_identifier);
-  read(dl_.volume_block_size);
-  read(dl_.volume_block_count);
-  read(dl_.root_unique_identifier);
-  read(dl_.root_directory_block_count);
-  read(dl_.root_directory_block_size);
-  read(dl_.root_directory_last_avatar_index);
-  read(dl_.root_directory_avatar_list);
+  TDO::DiscLabel tmp;
 
-  if(dl_.volume_flags & VOLUME_FLAG_M2)
+  read(&tmp.record_type,sizeof(tmp.record_type));
+  read(&tmp.volume_sync_bytes[0],sizeof(tmp.volume_sync_bytes));
+  read(&tmp.volume_structure_version,sizeof(tmp.volume_structure_version));
+  read(&tmp.volume_flags,sizeof(tmp.volume_flags));
+  read(&tmp.volume_commentary[0],sizeof(tmp.volume_commentary));
+  read(&tmp.volume_identifier[0],sizeof(tmp.volume_identifier));
+  read(tmp.volume_unique_identifier);
+  read(tmp.volume_block_size);
+  read(tmp.volume_block_count);
+  read(tmp.root_unique_identifier);
+  read(tmp.root_directory_block_count);
+  read(tmp.root_directory_block_size);
+  read(tmp.root_directory_last_avatar_index);
+
+  for(std::size_t i = 0; i < tmp.root_directory_avatar_list.size(); i++)
+    read(tmp.root_directory_avatar_list[i]);
+
+  if(tmp.volume_flags & VOLUME_FLAG_M2)
     {
-      read(dl_.num_rom_tags);
-      read(dl_.application_id);
+      read(tmp.num_rom_tags);
+      read(tmp.application_id);
+      memset(tmp.reserved,0,sizeof(tmp.reserved));
     }
   else
     {
-      dl_.num_rom_tags = 0;
-      dl_.application_id = 0;
+      tmp.num_rom_tags = 0;
+      tmp.application_id = 0;
     }
+
+  if(tmp.record_type != RECORD_STD_VOLUME)
+    _throw("invalid OperaFS disc label: incorrect record type");
+  if(memcmp(&tmp.volume_sync_bytes[0],&VOLUME_SYNC_BYTES[0],VOLUME_SYNC_BYTE_LEN) != 0)
+    _throw("invalid OperaFS disc label: incorrect volume sync bytes");
+  if((tmp.volume_structure_version != VOLUME_STRUCTURE_OPERA_READONLY) &&
+     (tmp.volume_structure_version != VOLUME_STRUCTURE_LINKED_MEM) &&
+     (tmp.volume_structure_version != VOLUME_STRUCTURE_ACROBAT))
+    _throw("invalid OperaFS disc label: unknown volume structure version");
+  if(tmp.volume_block_size == 0)
+    _throw("invalid OperaFS disc label: zero volume block size");
+  if((tmp.volume_structure_version != VOLUME_STRUCTURE_LINKED_MEM) &&
+     (tmp.volume_block_size != 4) &&
+     (tmp.volume_block_size % TDO_SECTOR_SIZE != 0))
+    _throw("invalid OperaFS disc label: volume block size not sector aligned");
+  if(tmp.root_directory_last_avatar_index > ROOT_HIGHEST_AVATAR)
+    _throw("invalid OperaFS disc label: root directory avatar index exceeds maximum");
+
+  dl_ = tmp;
 }
 
 void
 TDO::DevStream::read(TDO::DirectoryHeader &dh_)
 {
-  read(dh_.next_block);
-  read(dh_.prev_block);
-  read(dh_.flags);
-  read(dh_.first_free_byte);
-  read(dh_.first_entry_offset);
+  TDO::DirectoryHeader tmp;
+
+  read(tmp.next_block);
+  read(tmp.prev_block);
+  read(tmp.flags);
+  read(tmp.first_free_byte);
+  read(tmp.first_entry_offset);
+
+  const std::uint32_t dev_block_count = device_block_count();
+
+  if(tmp.next_block < -1)
+    _throw("unsafe OperaFS directory metadata: invalid next_block");
+  if(tmp.prev_block < -1)
+    _throw("unsafe OperaFS directory metadata: invalid prev_block");
+  if((tmp.next_block != -1) &&
+     (static_cast<std::uint32_t>(tmp.next_block) >= dev_block_count))
+    _throw("unsafe OperaFS directory metadata: next_block exceeds device bounds");
+  if((tmp.prev_block != -1) &&
+     (static_cast<std::uint32_t>(tmp.prev_block) >= dev_block_count))
+    _throw("unsafe OperaFS directory metadata: prev_block exceeds device bounds");
+  if(tmp.first_free_byte < DIRECTORY_HEADER_SIZE)
+    _throw("unsafe OperaFS directory metadata: first_free_byte overlaps header");
+  if(tmp.first_entry_offset < DIRECTORY_HEADER_SIZE)
+    _throw("unsafe OperaFS directory metadata: first_entry_offset overlaps header");
+  if(tmp.first_entry_offset > tmp.first_free_byte)
+    _throw("unsafe OperaFS directory metadata: first_entry_offset exceeds first_free_byte");
+
+  dh_ = tmp;
 }
 
 void
 TDO::DevStream::read(TDO::DirectoryRecord &dr_)
 {
-  read(dr_.flags);
-  read(dr_.unique_identifier);
-  read(dr_.type);
-  read(dr_.block_size);
-  read(dr_.byte_count);
-  read(dr_.block_count);
-  read(dr_.burst);
-  read(dr_.gap);
-  read(dr_.filename,32);
-  read(dr_.last_avatar_index);
-  if(dr_.last_avatar_index >= 7)
-    dr_.last_avatar_index = 7;
+  TDO::DirectoryRecord tmp;
+  std::array<std::uint32_t, MAX_DIRECTORY_AVATAR_INDEX + 1> avatar_list;
 
-  dr_.avatar_list.clear();
-  for(uint32_t i = 0; i <= dr_.last_avatar_index; i++)
-    {
-      uint32_t tmp;
-      read(tmp);
-      dr_.avatar_list.push_back(tmp);
-    }
+  read(tmp.flags);
+  read(tmp.unique_identifier);
+  read(tmp.type);
+  read(tmp.block_size);
+  read(tmp.byte_count);
+  read(tmp.block_count);
+  read(tmp.burst);
+  read(tmp.gap);
+  read(tmp.filename,sizeof(tmp.filename));
+  read(tmp.last_avatar_index);
+
+  if(tmp.last_avatar_index > MAX_DIRECTORY_AVATAR_INDEX)
+    _throw("impossible OperaFS directory record last_avatar_index: %d > %d",
+           tmp.last_avatar_index, MAX_DIRECTORY_AVATAR_INDEX);
+
+  for(std::uint32_t i = 0; i <= tmp.last_avatar_index; i++)
+    read(avatar_list[i]);
+
+  tmp.avatar_list.assign(avatar_list.begin(),
+                         avatar_list.begin() + (tmp.last_avatar_index + 1));
+
+  const std::uint32_t avatar_count = tmp.last_avatar_index + 1;
+  const std::uint32_t data_block_size = device_block_data_size();
+
+  if(tmp.last_avatar_index > MAX_DIRECTORY_AVATAR_INDEX)
+    _throw("impossible OperaFS directory record last_avatar_index: {} > {}",
+           tmp.last_avatar_index,MAX_DIRECTORY_AVATAR_INDEX);
+  if(tmp.avatar_list.size() != avatar_count)
+    _throw("impossible OperaFS directory record avatar count: avatar_list.size()={} last_avatar_index+1={}",
+           tmp.avatar_list.size(),avatar_count);
+  if(tmp.block_size == 0)
+    _throw("unsafe OperaFS directory record metadata: zero block_size");
+  if((data_block_size == 0) || ((tmp.block_size % data_block_size) != 0))
+    _throw("unsafe OperaFS directory record metadata: invalid block_size alignment");
+
+  const std::uint32_t dev_block_count = device_block_count();
+  const std::uint64_t max_byte_count =
+    static_cast<std::uint64_t>(tmp.block_size) * static_cast<std::uint64_t>(tmp.block_count);
+
+  if((tmp.block_count == 0) && (avatar_count > 1))
+    _throw("unsafe OperaFS directory record metadata: avatars without blocks");
+  if((tmp.byte_count != 0) && (tmp.block_count == 0))
+    _throw("unsafe OperaFS directory record metadata: byte_count without blocks");
+  if((tmp.block_count != 0) && (tmp.byte_count > max_byte_count))
+    _throw("unsafe OperaFS directory record metadata: byte_count exceeds block capacity");
+
+  if(tmp.block_count != 0)
+    for(std::uint32_t avatar : tmp.avatar_list)
+      {
+        if(avatar >= dev_block_count)
+          _throw("unsafe OperaFS directory record metadata: avatar exceeds device bounds");
+      }
+
+  dr_ = tmp;
 }
 
 void
@@ -599,13 +719,34 @@ TDO::DevStream::read(TDO::ROMTag &tag_)
 void
 TDO::DevStream::read(TDO::LinkedMemFileEntry &lmfe_)
 {
-  read(lmfe_.fingerprint);
-  read(lmfe_.flink_offset);
-  read(lmfe_.blink_offset);
-  read(lmfe_.block_count);
-  read(lmfe_.header_block_count);
-  read(lmfe_.byte_count);
-  read(lmfe_.unique_identifier);
-  read(lmfe_.type);
-  read(lmfe_.filename,sizeof(lmfe_.filename));
+  TDO::LinkedMemFileEntry tmp;
+
+  read(tmp.fingerprint);
+  read(tmp.flink_offset);
+  read(tmp.blink_offset);
+  read(tmp.block_count);
+  read(tmp.header_block_count);
+  read(tmp.byte_count);
+  read(tmp.unique_identifier);
+  read(tmp.type);
+  read(tmp.filename, sizeof(tmp.filename));
+
+  if((tmp.fingerprint != FINGERPRINT_FILEBLOCK) &&
+     (tmp.fingerprint != FINGERPRINT_FREEBLOCK) &&
+     (tmp.fingerprint != FINGERPRINT_ANCHORBLOCK))
+    _throw("invalid OperaFS linked mem file entry: {}",
+           "unknown fingerprint");
+  if(tmp.flink_offset < sizeof(TDO::LinkedMemFileEntry))
+    _throw("invalid OperaFS linked mem file entry: {}",
+           "flink offset too small");
+  if(tmp.blink_offset < sizeof(TDO::LinkedMemFileEntry))
+    _throw("invalid OperaFS linked mem file entry: {}",
+           "blink offset too small");
+  if((tmp.fingerprint == FINGERPRINT_FILEBLOCK) &&
+     (tmp.block_count != 0) &&
+     (tmp.byte_count == 0))
+    _throw("invalid OperaFS linked mem file entry: {}",
+           "block count without byte count");
+
+  lmfe_ = tmp;
 }

--- a/src/tdo_dev_stream.hpp
+++ b/src/tdo_dev_stream.hpp
@@ -36,8 +36,8 @@ namespace TDO
     DevStream(std::istream &is);
 
   public:
-    void  find_label();
-    Error setup();
+    void find_label();
+    void setup();
 
   public:
     bool good() const { return _is.good(); }
@@ -83,10 +83,10 @@ namespace TDO
 
   public:
     void read(char *buf, uint32_t size);
-    void read(char &c);
-    void read(uint8_t &u8);
-    void read(uint32_t &u32);
-    void read(int32_t &i32);
+    void read(char &);
+    void read(uint8_t &);
+    void read(uint32_t &);
+    void read(int32_t &);
     void read(TDO::DiscLabel &);
     void read(TDO::DirectoryHeader &);
     void read(TDO::DirectoryRecord &);
@@ -100,9 +100,9 @@ namespace TDO
       read(&arr_[0],arr_.size());
     }
 
-    template<std::size_t N>
+    template<typename T, std::size_t N>
     void
-    read(std::array<uint32_t,N> &arr_)
+    read(std::array<T,N> &arr_)
     {
       for(std::size_t i = 0; i < arr_.size(); i++)
         read(arr_[i]);
@@ -115,6 +115,25 @@ namespace TDO
     std::uint32_t  _data_offset;
     std::istream  &_is;
     bool           _initialized;
+
+  private:
+    bool is_mode1_2352();
+    std::uint32_t count_m1_romtags(const std::int64_t pos_);
+
+  private:
+    template<typename... Args>
+    void
+    _throw(const char *fmt_, Args&&... args_)
+    {
+      std::string msg;
+
+      msg = fmt::format(fmt_,std::forward<Args>(args_)...);
+
+      msg += fmt::format(" at offset {}",_is.tellg());
+
+      throw Error(msg);
+    }
+
   };
 
   class PosGuard

--- a/src/tdo_disc_identifier.cpp
+++ b/src/tdo_disc_identifier.cpp
@@ -64,22 +64,27 @@ TDO::DiscIdentifier::DiscIdentifier()
 Error
 TDO::DiscIdentifier::identify(std::istream &is_)
 {
-  Error err;
-  TDO::DevStream stream(is_);
+  try
+    {
+      Error err;
+      TDO::DevStream stream(is_);
 
-  err = stream.setup();
-  if(err)
-    return err;
+      stream.setup();
 
-  stream.data_byte_seek(0);
-  stream.read(label);
+      stream.data_byte_seek(0);
+      stream.read(label);
 
-  err = fsstats.collect(stream);
-  if(err)
-    return err;
+      err = fsstats.collect(stream);
+      if(err)
+        return err;
 
-  ::find_matches(label,fsstats,full_matches,partial_matches);
-  disc_image_ext = ::get_ext_based_on_type(stream);
+      ::find_matches(label,fsstats,full_matches,partial_matches);
+      disc_image_ext = ::get_ext_based_on_type(stream);
 
-  return {};
+      return {};
+    }
+  catch(const Error &err)
+    {
+      return err;
+    }
 }

--- a/src/tdo_file_stream.cpp
+++ b/src/tdo_file_stream.cpp
@@ -34,14 +34,21 @@ namespace TDO
   Error
   FileStream::open(const std::filesystem::path &filepath_)
   {
-    Error err;
-
     close();
 
     _ifs.open(filepath_,std::ios::binary);
-    err = setup();
-    if(err)
-      return err;
+    if(!_ifs.good())
+      return {};
+
+    try
+      {
+        setup();
+      }
+    catch(const Error &err)
+      {
+        close();
+        return err;
+      }
 
     _filepath = filepath_;
 

--- a/src/tdo_fs_walker.cpp
+++ b/src/tdo_fs_walker.cpp
@@ -22,6 +22,7 @@
 
 #include <cstring>
 #include <filesystem>
+#include <string>
 #include <vector>
 
 
@@ -47,6 +48,60 @@ update_record(const TDO::ROMTagVec &tags_,
     }
 }
 
+static
+Error
+decode_v1_filename(const TDO::DirectoryRecord &dr_,
+                   std::string                &filename_)
+{
+  static constexpr std::size_t filename_size = 32;
+
+  const void *terminator;
+
+  terminator = memchr(dr_.filename,'\0',filename_size);
+  if(terminator != nullptr)
+    {
+      const std::size_t length = static_cast<const char*>(terminator) - dr_.filename;
+
+      if(length == 0)
+        return "invalid empty directory record filename";
+
+      filename_.assign(dr_.filename,length);
+    }
+  else
+    {
+      filename_.assign(dr_.filename,filename_size);
+    }
+
+  if(filename_.empty())
+    return "invalid empty directory record filename";
+  if(filename_ == "." || filename_ == "..")
+    return "invalid directory record filename";
+  if(filename_.find_first_of("/\\") != std::string::npos)
+    return "invalid directory record filename";
+
+  return Error();
+}
+
+static
+Error
+validate_v1_dir_block_bounds(const std::int64_t block_start_,
+                             const std::uint32_t block_size_,
+                             const std::int64_t pos_,
+                             const char         *what_)
+{
+  if(block_size_ == 0)
+    return {"invalid OperaFS directory block size"};
+  if(pos_ < block_start_)
+    return {std::string("invalid OperaFS ") + what_ + ": before directory block"};
+
+  const std::int64_t block_end = block_start_ + static_cast<std::int64_t>(block_size_);
+
+  if(pos_ > block_end)
+    return {std::string("invalid OperaFS ") + what_ + ": beyond directory block"};
+
+  return Error();
+}
+
 class Impl
 {
 public:
@@ -62,12 +117,19 @@ public:
 public:
   Error
   walk_v1_dir_block(const TDO::DiscLabel &label_,
-                    const TDO::ROMTagVec &romtags_,
-                    const std::int64_t    dh_data_byte_pos_,
-                    const fs::path       &path_)
+                      const TDO::ROMTagVec &romtags_,
+                      const std::int64_t    active_dir_byte_pos_,
+                      const std::int64_t    active_dir_end_,
+                      const std::int64_t    dh_data_byte_pos_,
+                      const std::uint32_t   dir_block_size_,
+                      const fs::path       &path_)
   {
     TDO::DirectoryHeader dh;
     std::int64_t data_byte_pos;
+    Error err;
+
+    if(dir_block_size_ < sizeof(TDO::DirectoryHeader))
+      return {"invalid OperaFS directory block: smaller than directory header"};
 
     data_byte_pos = dh_data_byte_pos_;
     _stream.data_byte_seek(data_byte_pos);
@@ -76,34 +138,82 @@ public:
     _callbacks(path_,dh,_stream);
 
     data_byte_pos += dh.first_entry_offset;
+    err = validate_v1_dir_block_bounds(dh_data_byte_pos_,dir_block_size_,data_byte_pos,"directory entry offset");
+    if(err)
+      return err;
+
+    const std::int64_t first_free_byte_pos =
+      dh_data_byte_pos_ + static_cast<std::int64_t>(dh.first_free_byte);
+
+    err = validate_v1_dir_block_bounds(dh_data_byte_pos_,dir_block_size_,first_free_byte_pos,"directory free offset");
+    if(err)
+      return err;
+    if(data_byte_pos == first_free_byte_pos)
+      return Error();
+
     _stream.data_byte_seek(data_byte_pos);
 
     while(true)
       {
-        std::uint32_t dr_pos;
+        const std::int64_t dr_pos = _stream.data_byte_tell();
+        const std::uint32_t dr_file_pos = _stream.file_tell();
         TDO::DirectoryRecord dr;
+        std::string decoded_filename;
+        std::int64_t next_pos;
 
-        dr_pos = _stream.file_tell();
+        if(dr_pos < data_byte_pos)
+          return {"invalid OperaFS directory read position: reversed record offset"};
+        if(dr_pos >= first_free_byte_pos)
+          break;
+        err = validate_v1_dir_block_bounds(dh_data_byte_pos_,dir_block_size_,dr_pos,"directory record offset");
+        if(err)
+          return err;
+
         _stream.read(dr);
+
+        next_pos = _stream.data_byte_tell();
+        if(next_pos <= dr_pos)
+          return {"invalid OperaFS directory read position: non-advancing record read"};
+        if(next_pos > first_free_byte_pos)
+          return {"invalid OperaFS directory record: extends beyond directory data"};
+        err = validate_v1_dir_block_bounds(dh_data_byte_pos_,dir_block_size_,next_pos,"directory record end");
+        if(err)
+          return err;
+
         update_record(romtags_,dr);
+        err = decode_v1_filename(dr,decoded_filename);
+        if(err)
+          return err;
 
         {
           TDO::PosGuard guard(_stream);
-          _callbacks(path_ / dr.filename,dr,dr_pos,_stream);
+          _callbacks(path_ / decoded_filename,dr,dr_file_pos,_stream);
         }
 
         if(dr.is_directory())
-          walk_v1_dir(label_,romtags_,dr,path_ / dr.filename);
+          {
+            const std::int64_t child_dir_byte_pos =
+              static_cast<std::int64_t>(dr.avatar_list[0]) * label_.volume_block_size;
+
+            if((child_dir_byte_pos >= active_dir_byte_pos_) && (child_dir_byte_pos < active_dir_end_))
+              return {"invalid OperaFS directory recursion target: non-advancing child directory block"};
+
+            err = walk_v1_dir(label_,romtags_,dr,path_ / decoded_filename);
+            if(err)
+              return err;
+          }
 
         if(dr.last_in_dir())
           break;
         if(dr.last_in_block())
           break;
-        if(_stream.data_byte_tell() >= (dh_data_byte_pos_ + dh.first_free_byte))
+        if(_stream.data_byte_tell() >= first_free_byte_pos)
           break;
+
+        data_byte_pos = next_pos;
       }
 
-    return {};
+    return Error();
   }
 
   Error
@@ -115,16 +225,32 @@ public:
               const fs::path       &path_)
   {
     std::int64_t  dh_data_byte_pos;
+    const std::int64_t active_dir_byte_pos = (dir_block_ * label_.volume_block_size);
+    const std::int64_t active_dir_end =
+      active_dir_byte_pos + (static_cast<std::int64_t>(dir_block_size_) * dir_block_count_);
     TDO::PosGuard pos_guard(_stream);
 
-    dh_data_byte_pos = (dir_block_ * label_.volume_block_size);
+    if((dir_block_count_ != 0) && (dir_block_size_ == 0))
+      return {"invalid OperaFS directory metadata: zero directory block size"};
+
+    dh_data_byte_pos = active_dir_byte_pos;
     for(std::uint32_t block = 0; block < dir_block_count_; block++)
       {
-        walk_v1_dir_block(label_,romtags_,dh_data_byte_pos,path_);
+        Error err;
+
+        err = walk_v1_dir_block(label_,
+                                romtags_,
+                                active_dir_byte_pos,
+                                active_dir_end,
+                                dh_data_byte_pos,
+                                dir_block_size_,
+                                path_);
+        if(err)
+          return err;
         dh_data_byte_pos += dir_block_size_;
       }
 
-    return {};
+    return Error();
   }
 
   Error
@@ -159,6 +285,7 @@ public:
           const fs::path       &path_)
   {
     std::uint32_t pos;
+    Error err;
 
     pos = label_.root_directory_avatar_list[0] * label_.root_directory_block_size;
     while(true)
@@ -191,7 +318,7 @@ public:
         pos = lmfe.flink_offset;
       }
 
-    return {};
+    return Error();
   }
 
   Error
@@ -202,11 +329,10 @@ public:
     TDO::DiscLabel dl;
     TDO::ROMTagVec romtags;
 
-    err = _stream.setup();
-    if(err)
-      return err;
+    _stream.setup();
 
     _stream.read(dl);
+
     romtags = _stream.romtags();
 
     _callbacks.begin();
@@ -250,8 +376,15 @@ namespace TDO
   Error
   FSWalker::walk()
   {
-    Impl impl(_is,_callbacks);
+    try
+      {
+        Impl impl(_is,_callbacks);
 
-    return impl.walk();
+        return impl.walk();
+      }
+    catch(const Error &err)
+      {
+        return err;
+      }
   }
 }


### PR DESCRIPTION
- Throw Error for bad stream states and invalid disc labels
- Validate directory headers, records, filenames, and traversal bounds
- Validate linked-memory file entries before exposing parsed data
- Handle parser errors in commands and continue romtags across inputs
- Export ISO data from the OperaFS data offset without reading past EOF