### PR TITLE
Add OperaFS pack, sign, repack, and verify workflows

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2026, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,22 @@ JOBS := $(shell nproc)
 
 OUTPUT = build/$(EXE)
 
+.DEFAULT_GOAL := all
+
 CC    = $(COMPILER_PREFIX)-gcc
 CXX   = $(COMPILER_PREFIX)-g++
 STRIP = $(COMPILER_PREFIX)-strip
 
-ifeq ($(DEBUG),1)
-OPT := -O0 -ggdb
-else
+ifeq ($(NDEBUG),1)
+BUILD_MODE := release
 OPT := -Os -static
+else
+BUILD_MODE := debug
+OPT := -O0 -ggdb
 endif
 
 ifeq ($(SANITIZE),1)
+BUILD_MODE := $(BUILD_MODE)-sanitize
 OPT += -fsanitize=undefined
 endif
 
@@ -27,11 +32,36 @@ CPPFLAGS ?= -MMD -MP
 SRCS_C   := $(wildcard src/*.c)
 SRCS_CXX := $(wildcard src/*.cpp)
 
-BUILDDIR = build/$(PLATFORM)
+BUILDDIR = build/$(PLATFORM)/$(BUILD_MODE)
 OBJS := $(SRCS_C:src/%.c=$(BUILDDIR)/%.c.o)
 OBJS += $(SRCS_CXX:src/%.cpp=$(BUILDDIR)/%.cpp.o)
 DEPS  = $(OBJS:.o=.d)
 
+
+.PHONY: help
+help:
+	@echo "3dt - 3DO Disc Tool build system"
+	@echo ""
+	@echo "Usage: make [TARGET] [VARIABLE=VALUE]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all       (default) Build debug binary"
+	@echo "  clean     Remove build/ directory"
+	@echo "  distclean Remove all files not tracked by git"
+	@echo "  strip     Strip debug symbols from binary"
+	@echo "  release   Build stripped binaries for Unix, Win32, Win64"
+	@echo "  help      Show this help message"
+	@echo ""
+	@echo "Variables:"
+	@echo "  NDEBUG=1      Release build (-Os -static)"
+	@echo "  SANITIZE=1    Add -fsanitize=undefined"
+	@echo ""
+	@echo "Cross-compile:"
+	@echo "  make -f Makefile.win32    32-bit Windows (MinGW)"
+	@echo "  make -f Makefile.win64    64-bit Windows (MinGW)"
+	@echo "  make -f Makefile.macos    macOS"
+	@echo ""
+	@echo "Output: $(OUTPUT)"
 
 all: $(OUTPUT)
 
@@ -50,14 +80,17 @@ $(BUILDDIR)/%.cpp.o: src/%.cpp
 clean:
 	rm -rfv build/
 
+distclean:
+	git clean -xfd
+
 builddir:
 	mkdir -p $(BUILDDIR)
 
 release:
-	$(MAKE) -f Makefile -j$(JOBS) strip
+	$(MAKE) -f Makefile -j$(JOBS) NDEBUG=1 strip
 	$(MAKE) -f Makefile.win32 -j$(JOBS) strip
 	$(MAKE) -f Makefile.win64 -j$(JOBS) strip
 
-.PHONY: clean builddir release
+.PHONY: clean distclean builddir release
 
 -include $(DEPS)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 * unpack disc and ROM OperaFS contents
 * convert raw disc images to .iso
 * supports reading CD-ROM Mode 1 images and 2048 byte/sector ISOs
+* pack directories into 3DO disc images
+* repack existing images and compact free space
+* sign and re-sign 3DO images
+* verify 3DO signatures
+* encrypt or decrypt 3DO obfuscation payloads (primarily the boot file)
 
 
 ## Usage
@@ -30,9 +35,16 @@ Subcommands:
   info                        prints lowlevel info on disc
   identify                    attempt to identify disc image
   unpack                      unpack disc image
+  pack                        pack a directory into a 3DO disc image
+  repack                      repack a 3DO disc image compacting avatars and empty space
+  verify                      verify RSA sigs
+  sign                        sign 3DO ISO for retail system use
+  sign-file                   sign file with 3DO or APP key
   rename                      rename disc image as identified
   to-iso                      convert a .bin or similar disc image to .iso
   romtags                     print out image romtags
+  decrypt-file                decrypt CD-DIPIR boot payload
+  encrypt-file                encrypt CD-DIPIR boot payload
 ```
 
 Use `--help` on individual subcommands to get specific subcmd options.
@@ -187,13 +199,136 @@ Print rom tags
 
 ```
 $ 3dt romtags Wolfenstein\ 3D\ \(USA\).iso
-File,SubSysType,Type,Version,Revision,Flags,TypeSpecific,Offset,Size
-Wolfenstein 3D (USA).iso,0x0f,NEWKNEWNEWGNUBOOT,2,5,0,0,1,6448
-Wolfenstein 3D (USA).iso,0x0f,OS,24,225,0,0,5,115520
-Wolfenstein 3D (USA).iso,0x0f,BILLSTUFF,0,0,0,0,2893249791,0
-Wolfenstein 3D (USA).iso,0x0f,BLOCKS_ALWAYS,0,0,0,0,42713,47
-Wolfenstein 3D (USA).iso,0x0f,MISCCODE,0,0,0,0,69,2908
-Wolfenstein 3D (USA).iso,0x0f,SIGNATURE_BLOCK,0,0,0,15,42766,57344
+Wolfenstein 3D (USA).iso:
+  - Offset:      1
+    SubSysType:  0x0f
+    Type:        0x0d (NEWKNEWNEWGNUBOOT)
+    Version:     2
+    Revision:    5
+    Flags:       0
+    TypeSpec:    0
+    Size:        6448
+  - Offset:      5
+    SubSysType:  0x0f
+    Type:        0x07 (OS)
+    Version:     24
+    Revision:    225
+    Flags:       0
+    TypeSpec:    0
+    Size:        115520
+  - Offset:      69
+    SubSysType:  0x0f
+    Type:        0x10 (MISCCODE)
+    Version:     0
+    Revision:    0
+    Flags:       0
+    TypeSpec:    0
+    Size:        2908
+  - Offset:      42713
+    SubSysType:  0x0f
+    Type:        0x02 (BLOCKS_ALWAYS)
+    Version:     0
+    Revision:    0
+    Flags:       0
+    TypeSpec:    0
+    Size:        47
+  - Offset:      42766
+    SubSysType:  0x0f
+    Type:        0x05 (SIGNATURE_BLOCK)
+    Version:     0
+    Revision:    0
+    Flags:       0
+    TypeSpec:    15
+    Size:        57344
+```
+
+
+### pack
+
+Build a 3DO disc image from a source tree.
+
+```
+3dt pack /path/to/source --output game.iso
+```
+
+If present, `layout.json` is used automatically; otherwise pass a custom path with `--layout`.
+
+Common options:
+- `--volume-label` / `--volume-commentary`: set label metadata
+- `--volume-unique-id` / `--root-unique-id`: set identifiers
+- `--dry-run`: validate layout and allocations without writing the image
+- `--mark`: write 3dt marker metadata
+- `--sign`: run signing as part of pack
+- `--digest-check-count`: tune signature digest check policy
+- `--no-banner-romtag`: disable RSA_APPSPLASH romtag generation
+- `--billstuff-romtag`: enable RSA_BILLSTUFF romtag generation (off by default)
+
+
+### repack
+
+Rebuild an image while compacting avatars and reclaiming free space.
+
+```
+3dt repack game.iso --output game-repacked.iso
+```
+
+Repack also supports `--sign` and the same romtag/signature options as `pack`.
+
+
+### sign
+
+Sign an existing image for retail playback.
+
+```
+3dt sign game.iso --output game-signed.iso
+```
+
+Useful flags include `--force` for unusual source layouts, `--mark`, `--digest-check-count`, and `--billstuff-romtag`.
+
+
+### verify
+
+Validate signed images and report status.
+
+```
+3dt verify --format=csv game.iso
+```
+
+Output formats are `human`, `csv`, and `json`; add `--no-digest-table` to skip digest-table checks.
+
+
+### sign-file
+
+Sign, verify, or emit signatures for a file payload.
+
+```
+3dt sign-file --verify boot_code
+3dt sign-file --write --append --key-name app boot_code
+```
+
+### decrypt-file
+
+Decrypt signed 3DO file payloads.
+This is mainly used for the boot file (`system/kernel/boot_code`, sometimes
+referred to as `boot_file`) when working with CD-DIPIR-protected images.
+In practice that is the primary real-world use.
+This maps to the Portfolio OS `src/dipir/cdipir.c` boot flow (`DecryptBlock()`).
+Re-run `3dt encrypt-file` on the same file once edits are complete.
+
+```
+3dt decrypt-file boot_code
+```
+
+### encrypt-file
+
+Encrypt a file using the same boot-file obfuscation transform.
+This is effectively the inverse operation of `decrypt-file` and is used when
+you need to restore the encrypted form (typically for `system/kernel/boot_code`).
+The inverse transform corresponds to Portfolio OS CD-DIPIR boot-file logic in
+`src/dipir/cdipir.c`.
+
+```
+3dt encrypt-file boot_code
 ```
 
 

--- a/TODO
+++ b/TODO
@@ -1,0 +1,6 @@
+* dump romtag referenced stuff
+* pack image
+* sign image - WIP
+* decrypt file (boot_code) - DONE
+* ROM listing is broken
+* slayer.iso, starfighter.iso broken?? bin files broken?

--- a/docs/3do_signing_iso_info.txt
+++ b/docs/3do_signing_iso_info.txt
@@ -1,0 +1,45 @@
+* Take the MD5 diget of binary.
+* Convert MD5 diget into string representation; "%02X" per byte.
+* Calculate 64 byte RSA sig from MD5
+
+## Things to get digest and sign
+
+* BannerScreen. get location from ROM tags. Just attach sig to end of
+file. Since the size of banner is 153600 bytes for data + 24 bytes for
+header it spills over into a 76th 2048 byte sector meaning there is
+always room for the sig.
+* Signature file
+* boot_code: already has a sig, just replace to be sure?
+* misc_code: 
+* os_code
+* romtags: put sig at end, 32 * romtags.size() + 1 (last entry is all
+zeros), the md5 digest consists of the disc label, romtags (including
+last entry), and NEWKNEWNEWGNUBOOT.
+
+## How to calculate signatures file
+
+* Create md5 binary digests of every 32K (16 2k blocks)
+* create a "signatures" file with all digests in order
+* ignore block 0
+* ignore block 14?
+* the checker in appdigest.c ignores
+  * 0x080F : third label digest
+  * 0x0306 : Fatty Bear
+  * everything covering signature 
+* TypeSpecific from sig romtag indicates "MaxPain", how many blocks to
+  check
+* Add an additional 2048 block to signature file
+* create md5 digest of signature file with zeroed out additional
+  sector minus 64 bytes for the rsa sig
+* Convert 16 byte digest to "%02X" per byte string and APP sign
+* store to signature size - 64, report the size in romtags minus the
+  extra sector
+
+## How it checks
+
+* Selects TypeSpecific blocks to check from signature romtag
+* Selects from a range of blocks between app_start_block and last_block
+* If RSA_APP romtag exists
+  * app_start_block = ((tag offset + romtag_block) / 16)
+  Else
+  * app_start_block = 256

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,105 @@
+# 3DO Disc Format Technical Reference
+
+This directory contains comprehensive technical documentation for the 3DO Interactive Multiplayer disc format and related technologies.
+
+## Documents
+
+| Document | Description |
+|----------|-------------|
+| [disc-format.md](disc-format.md) | Physical disc structure, sector formats, and DiscLabel |
+| [filesystem.md](filesystem.md) | OperaFS filesystem: directories, files, and avatars |
+| [romtags.md](romtags.md) | ROM Tag metadata structures and component types |
+| [signing.md](signing.md) | RSA-512 signing algorithm, keys, and verification |
+| [encryption.md](encryption.md) | XOR-based file obfuscation algorithm |
+
+## Quick Reference
+
+### Key Constants
+
+| Constant | Value |
+|----------|-------|
+| Block Size | 2048 bytes |
+| Max Filename | 32 characters |
+| Avatar Count | 8 (indices 0-7) |
+| RSA Key Size | 512 bits |
+| Signature Size | 64 bytes |
+| Hash Algorithm | MD5 |
+
+### Data Structures
+
+| Structure | Size | Location |
+|-----------|------|----------|
+| DiscLabel | 132 bytes | Block 0 |
+| DirectoryHeader | 20 bytes | Start of each directory block |
+| DirectoryRecord | 72+ bytes | After DirectoryHeader |
+| ROMTag | 24 bytes | Block after DiscLabel (typically block 1) |
+| RSA Signature | 64 bytes | Appended to signed data |
+
+### Byte Order
+
+All multi-byte integers are **big-endian**.
+
+## File Locations
+
+Standard 3DO disc file paths:
+
+```
+/
+├── signatures                      # Block MD5 digests
+├── bannerscreen                    # Splash screen image
+├── rom_tags                        # Synthetic ROM tag table file
+├── launchme                        # Application startup file
+└── system/
+    └── kernel/
+        ├── boot_code               # Boot executable
+        ├── os_code                 # Operating system
+        └── misc_code               # Miscellaneous code
+```
+
+## Signing Overview
+
+1. Pad image to 32KB boundary
+2. Generate ROM tags for special files
+3. Sign bannerscreen with APP key
+4. Generate and sign signatures file
+5. Sign DiscLabel + ROMTags + boot_code with APP key
+6. OS code and misc_code signed with 3DO key
+
+## Tools
+
+The `3dt` command-line tool provides:
+
+```sh
+3dt list <disc.iso>              # List disc contents
+3dt info <disc.iso>              # Display disc information
+3dt identify <disc.iso>          # Identify disc by database
+3dt unpack <disc.iso> <dir>      # Extract disc contents
+3dt pack <dir> <disc.iso>        # Build disc image from directory
+3dt rename <disc.iso> <name>     # Rename disc volume
+3dt romtags <disc.iso>           # Display ROM tags
+3dt verify <disc.iso>            # Verify RSA signatures
+3dt sign <disc.iso>              # Sign disc image
+3dt sign-file <file>             # Sign individual file
+3dt decrypt-file <file>          # Decrypt obfuscated file
+3dt encrypt-file <file>          # Encrypt obfuscated file
+3dt to-iso <disc.bin> <out.iso>  # Convert BIN to ISO
+```
+
+## References
+
+- 3DO Portfolio OS source tree (`src/dipir/cdipir.c` for CD-DIPIR/boot flow)
+- Opera Filesystem specification
+- RSA PKCS#1 v1.5 standard
+- RFC 1321 (MD5)
+
+## Portfolio OS Reference Map
+
+- `romtags.md` maps to tag and type definitions in:
+  - `portfolio_os/src/includes/rom.h`
+  - `portfolio_os/src/dipir/cdipir.c`
+- `signing.md` aligns with signing flow in:
+  - `portfolio_os/src/dipir/cdipir.c`
+  - `portfolio_os/src/dipir/rsadipir.c`
+- `encryption.md` follows obfuscation behavior described by:
+  - `portfolio_os/src/dipir/rsadipir.c`
+  - `portfolio_os/src/dipir/cdipir.c`

--- a/docs/disc-format.md
+++ b/docs/disc-format.md
@@ -1,0 +1,228 @@
+# 3DO OperaFS Disc Format
+
+## Overview
+
+The 3DO Interactive Multiplayer uses a proprietary disc format called OperaFS (also known as the Opera filesystem). This document describes the low-level structure of 3DO disc images.
+
+## Disc Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DISC_BLOCK_SIZE` | 2048 | Standard data block size in bytes |
+| `DISC_LABEL_OFFSET` | 225 | Byte offset to find the disc label marker |
+| `DISC_LABEL_AVATAR_DELTA` | 32786 | Block offset between avatars |
+| `DISC_LABEL_HIGHEST_AVATAR` | 7 | Maximum avatar index (0-7, total 8 avatars) |
+| `DISC_TOTAL_BLOCKS` | 330000 | Maximum total blocks on disc |
+| `FILESYSTEM_MAX_NAME_LEN` | 32 | Maximum filename length |
+
+## Sector Formats
+
+### Mode 1 Raw (2048 bytes)
+Standard ISO 9660 Mode 1 sectors used by most 3DO images:
+
+```
++------------------+
+| Data (2048 bytes)|
++------------------+
+```
+
+- `device_block_header`: 0 bytes
+- `device_block_data_size`: 2048 bytes
+- `device_block_footer`: 0 bytes
+
+### Mode 1 2352 (CD-ROM Mode 1)
+Raw CD-ROM sectors with sync, header, and error correction:
+
+```
++--------+--------+--------+------------------+--------+
+| Sync   | Header | Sub-   | User Data        | ECC    |
+| 12 bytes| 4 bytes| mode   | 2048 bytes       | 288    |
+|        |        | 1 byte |                  | bytes  |
++--------+--------+--------+------------------+--------+
+```
+
+- `device_block_header`: 16 bytes (sync + header + sub-mode)
+- `device_block_data_size`: 2048 bytes
+- `device_block_footer`: 288 bytes (ECC/EDC)
+
+#### Mode 1 Sync Pattern (12 bytes)
+```
+00 FF FF FF FF FF FF FF FF FF FF 00
+```
+
+#### Mode Byte Location
+At offset 0x0F, the mode byte should be `0x01` for Mode 1.
+
+## Volume Identification
+
+### Record Types
+
+| Value | Name | Description |
+|-------|------|-------------|
+| `0x01` | `RECORD_STD_VOLUME` | Standard volume record |
+| `0xC2` | `RECORD_TINY_VOLUME` | Tiny volume record |
+
+### Volume Sync Bytes
+The disc label is identified by 5 consecutive sync bytes:
+```
+5A 5A 5A 5A 5A
+```
+
+### Volume Structure Versions
+
+| Value | Name | Description |
+|-------|------|-------------|
+| `1` | `VOLUME_STRUCTURE_OPERA_READONLY` | Opera read-only filesystem |
+| `2` | `VOLUME_STRUCTURE_LINKED_MEM` | Linked memory structure |
+| `4` | `VOLUME_STRUCTURE_ACROBAT` | Acrobat structure |
+
+### Volume Flags
+
+| Mask | Name | Description |
+|------|------|-------------|
+| `0x01` | `VOLUME_FLAG_M2` | M2 (Konami) format flag |
+| `0x02` | `VOLUME_FLAG_M2ONLY` | M2 only disc |
+| `0x04` | `VOLUME_FLAG_DATADISC` | Data disc (won't auto-reboot) |
+| `0x08` | `VOLUME_FLAG_BLESSED` | Blessed disc |
+
+**Note:** `VOLUME_FLAG_M1_DATADISC` (0x01) is deprecated and conflicts with M2 flags.
+
+## Disc Label Structure
+
+The DiscLabel is the primary identification structure at the beginning of a 3DO disc.
+
+### Memory Layout (132 bytes minimum)
+
+| Offset | Size | Field | Type | Description |
+|--------|------|-------|------|-------------|
+| 0x00 | 1 | `record_type` | `char` | Should be `0x01` (`RECORD_STD_VOLUME`) |
+| 0x01 | 5 | `volume_sync_bytes` | `char[5]` | Sync bytes: `5A 5A 5A 5A 5A` |
+| 0x06 | 1 | `volume_structure_version` | `char` | Should be `0x01` |
+| 0x07 | 1 | `volume_flags` | `char` | Volume flags (see above) |
+| 0x08 | 32 | `volume_commentary` | `char[32]` | Human-readable disc description |
+| 0x28 | 32 | `volume_identifier` | `char[32]` | Volume/disc name |
+| 0x48 | 4 | `volume_unique_identifier` | `uint32_t` | Random unique ID (big-endian) |
+| 0x4C | 4 | `volume_block_size` | `uint32_t` | Block size (typically 2048) |
+| 0x50 | 4 | `volume_block_count` | `uint32_t` | Total blocks on disc |
+| 0x54 | 4 | `root_unique_identifier` | `uint32_t` | Root directory unique ID |
+| 0x58 | 4 | `root_directory_block_count` | `uint32_t` | Blocks in root directory |
+| 0x5C | 4 | `root_directory_block_size` | `uint32_t` | Root directory block size |
+| 0x60 | 4 | `root_directory_last_avatar_index` | `uint32_t` | Last avatar index (typically 7) |
+| 0x64 | 32 | `root_directory_avatar_list` | `uint32_t[8]` | Avatar block pointers |
+
+**Total size: 132 bytes (0x84)**
+
+### Extended DiscLabel (M2 and later)
+
+For M2 format discs, additional fields follow the base structure:
+
+| Offset | Size | Field | Type | Description |
+|--------|------|-------|------|-------------|
+| 0x84 | 4 | `num_rom_tags` | `uint32_t` | Number of ROM tags |
+| 0x88 | 4 | `application_id` | `uint32_t` | Application identifier |
+| 0x8C | 36 | `reserved` | `uint32_t[9]` | Reserved for future use |
+
+**Extended total: 176 bytes**
+
+### Avatar System
+
+3DO uses an "avatar" system for redundancy and wear leveling. Each avatar is a copy of critical data:
+
+- **Avatar Index**: Range 0-7 (8 avatars total)
+- **Avatar Delta**: 32786 blocks between avatars
+- **Purpose**: Provides fault tolerance - if one copy is damaged, another can be used
+
+### Avatar List Interpretation
+
+The `root_directory_avatar_list` contains up to 8 block pointers:
+- Each pointer indicates a copy (avatar) of the root directory
+- Avatar 0 is the primary copy
+- Avatars 1-7 are redundant copies for fault tolerance
+- `root_directory_last_avatar_index` indicates the highest valid avatar (typically 7)
+
+## Finding the Disc Label
+
+The disc label can be located by scanning for the volume signature:
+
+1. Search for byte `0x01` (`RECORD_STD_VOLUME`)
+2. Verify 5 consecutive `0x5A` bytes follow immediately
+3. The label structure starts at the `0x01` byte
+
+Alternatively, check sector 0 for Mode 1 2352 format:
+1. Read first 12 bytes
+2. Compare against sync pattern: `00 FF FF FF FF FF FF FF FF FF FF 00`
+3. Check byte at offset 0x0F equals `0x01`
+
+## Data Block Addressing
+
+### Block Types
+
+1. **Device Block**: Physical sector on disc
+   - Size depends on sector format (2048 or 2352 bytes)
+   
+2. **Data Block**: Logical data block (always 2048 bytes)
+   - Abstracted from physical format
+
+### Address Calculations
+
+For Mode 1 2352 sectors:
+```
+device_block = data_block
+file_offset = (data_block * 2352) + 16  // skip sync + header
+```
+
+For Mode 1 Raw (2048 bytes):
+```
+device_block = data_block
+file_offset = data_block * 2048
+```
+
+## Block Layout
+
+```
+Block 0:     Disc Label (primary avatar)
+Block 1:     ROM Tags
+Block 2+:    Root Directory (first avatar)
+...          File data
+Block N:     Disc Label (avatar 1)  // at offset DISC_LABEL_AVATAR_DELTA
+...
+```
+
+### ROM Tags Location
+
+ROM tags are stored in the block immediately following the disc label:
+```
+romtags_block = disc_label_block + 1
+```
+
+## Byte Order
+
+All multi-byte integers in OperaFS structures are stored in **big-endian** format:
+- `uint32_t` value `0x12345678` is stored as bytes: `12 34 56 78`
+- Reading on little-endian systems requires byte swapping
+
+## Special Disc Types
+
+### Konami M2 Format
+
+M2 discs are identified by:
+1. `volume_flags` = `VOLUME_FLAG_M2 | VOLUME_FLAG_BLESSED` (0x09)
+2. `volume_identifier` = `"cd-rom"`
+3. Extended DiscLabel structure
+4. Different ROM tag types (0x80+ range)
+
+### ROMFS (Read-Only Memory Filesystem)
+
+Identified by:
+- `device_block_header` = 0
+- `device_block_data_size` = 4
+- `device_block_footer` = 0
+
+ROMFS discs do not contain standard ROM tags.
+
+## Checksums and Integrity
+
+The 3DO system uses multiple integrity mechanisms:
+1. **Avatar redundancy**: Multiple copies of critical structures
+2. **MD5 signatures**: RSA-signed MD5 digests (see signing.md)
+3. **Mode 1 ECC**: Error correction in 2352-byte sectors

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,314 @@
+# 3DO Decryption Algorithm
+
+## Overview
+
+3DO uses a simple XOR-plus-nibble-swap obfuscation algorithm to encrypt certain boot-time files. This is primarily associated with CD dipir boot code and is not a cryptographically strong encryption scheme.
+
+## Algorithm Details
+
+### Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DECRYPT_MASK_1` | `0xF0F0F0F0` | High nibble extraction mask |
+| `DECRYPT_MASK_2` | `0x0F0F0F0F` | Low nibble extraction mask |
+
+### Key Material
+
+The decryption uses a single 64-byte key derived from the 3DO RSA modulus:
+
+#### BOOT_CODE_CRYPT_KEY (64 bytes)
+
+The 3DO key modulus in raw binary form (64 bytes, no leading zero):
+```
+00 B1 94 62 B0 0D 8D 6E 1E C9 09 AB 38 5E 06 FE
+03 4B FD 28 2E 9F FD C5 84 83 8C 15 F1 25 93 DD
+1E 3A 8B 56 26 F1 B9 D0 ED 0C 38 4E F6 C5 D1 45
+12 BD 72 DD B8 5B 44 08 0E 04 72 C0 3D 0A FC 4C
+```
+
+**Note:** The original Portfolio OS `portfolio_os/src/dipir/rsadipir.c` code
+also references `PUBLIC_SIGNATURES_ARRAY` (a 432-byte ASCII credits message),
+but that pointer is overwritten before the first dereference and every 16 words
+thereafter. In practice, only `BOOT_CODE_CRYPT_KEY` (equivalent to
+`PUBLIC_THDOKEY_MOD` without the leading zero) is used.
+
+## Decryption Algorithm
+
+### Process
+
+The algorithm operates on 32-bit words (4 bytes at a time) using a single 64-byte repeating key:
+
+```c
+static uint32_t key_word(uint64_t word_offset) {
+    uint32_t key;
+    uint64_t key_offset = (word_offset % 16) * sizeof(uint32_t);
+    memcpy(&key, &BOOT_CODE_CRYPT_KEY[key_offset], sizeof(key));
+    return key;
+}
+
+void decrypt(void *buffer, uint64_t buffer_length) {
+    uint32_t *p = (uint32_t*)buffer;
+    uint32_t mask_1 = DECRYPT_MASK_1;  // 0xF0F0F0F0
+    uint32_t mask_2 = DECRYPT_MASK_2;  // 0x0F0F0F0F
+    
+    for (uint64_t i = 0; i < buffer_length / 4; i++) {
+        uint32_t key = key_word(i);
+        uint32_t xored = *p ^ key;
+        uint32_t part_a = (xored & mask_1) >> 4;  // Extract high nibbles, shift right
+        uint32_t part_b = (xored & mask_2) << 4;  // Extract low nibbles, shift left
+        *p = part_a | part_b;  // Combine
+        
+        p++;
+    }
+}
+```
+
+### Step-by-Step Explanation
+
+1. **Initialize pointer:**
+   - `p` points to the current 32-bit word in the buffer
+
+2. **Key selection:**
+   - Each word uses `BOOT_CODE_CRYPT_KEY[(i % 16) * 4]` as the 4-byte XOR key
+   - The 64-byte key repeats every 16 words (64 bytes)
+
+3. **XOR with key:**
+   - XOR the current buffer word with the current key word
+
+4. **Nibble swap:**
+   - Extract high nibbles (bits 7, 15, 23, 31) using mask `0xF0F0F0F0`
+   - Shift right by 4 bits
+   - Extract low nibbles (bits 3, 11, 19, 27) using mask `0x0F0F0F0F`
+   - Shift left by 4 bits
+   - Combine the two parts
+
+5. **Advance:**
+   - Move to next word in buffer
+
+### Visualization
+
+```
+Input byte:  0xAB
+Key byte:    0x12
+XOR result:  0xB9
+
+Before nibble swap:
+  0xB9 = 1011 1001
+  & 0xF0 = 1011 0000 (high nibble)
+  & 0x0F = 0000 1001 (low nibble)
+
+After nibble swap:
+  high >> 4 = 0000 1011
+  low << 4  = 1001 0000
+  Combined  = 1001 1011 = 0x9B
+```
+
+## Encryption
+
+Encryption uses the same key schedule, but it is not identical to decryption. Decryption XORs each word with the key word and then swaps nibbles. The inverse operation swaps nibbles first and then XORs with the key word:
+
+```c
+decrypted = swap_nibbles(encrypted ^ key);
+encrypted = swap_nibbles(decrypted) ^ key;
+```
+
+Applying the decryption routine twice does not generally return the original data.
+
+## Usage in 3DO
+
+### File Decryption Command
+
+The `decrypt-file` subcommand applies this algorithm to entire files:
+This is primarily the CD-DIPIR boot payload path and is the CLI equivalent of
+`DecryptBlock()` in Portfolio OS `src/dipir/cdipir.c`.
+
+```cpp
+void decrypt_file(const std::filesystem::path &filepath) {
+    // Read entire file
+    std::vector<char> data = read_file(filepath);
+    
+    // Align size down to 4-byte boundary
+    uint64_t aligned_size = TDO::boot_code_crypto_aligned_size(data.size());
+    
+    // Decrypt in place
+    TDO::decrypt_boot_code_range(data.data(), aligned_size);
+    
+    // Write back
+    write_file(filepath, data);
+}
+```
+
+### CD-DIPIR Workflow
+
+Typical boot payload workflow when auditing a 3DO CD-DIPIR image:
+
+```sh
+3dt unpack game.iso ./game.unpacked
+3dt decrypt-file ./game.unpacked/system/kernel/boot_code   # inspect/patch
+3dt encrypt-file ./game.unpacked/system/kernel/boot_code   # restore obfuscated payload
+```
+
+### File Encryption Command
+
+The new `encrypt-file` subcommand is the inverse transform and is intended to
+return files to the obfuscated form after inspection or patching. In practice,
+this is primarily used for the boot-file path (`System/Kernel/boot_code`).
+
+```cpp
+void encrypt_file(const std::filesystem::path &filepath) {
+    // Read entire file
+    std::vector<char> data = read_file(filepath);
+
+    // Align size down to 4-byte boundary
+    uint64_t aligned_size = TDO::boot_code_crypto_aligned_size(data.size());
+
+    // Encrypt in place
+    TDO::encrypt_boot_code_range(data.data(), aligned_size);
+
+    // Write back
+    write_file(filepath, data);
+}
+```
+
+### Files Typically Encrypted
+
+This scheme is mainly a boot-time dipir mechanism. Most signed files on a 3DO disc are RSA-signed but not encrypted with this transform.
+
+| Filesystem path | ROM tag(s) | Notes |
+|-----------------|------------|-------|
+| `System/Kernel/boot_code` | `RSA_NEWNEWBOOT`, `RSA_NEWNEWGNUBOOT`, `RSA_NEWKNEWNEWGNUBOOT` | The usual CD dipir bootstrap file. The ROM tag points to this payload; dipir verifies it, decrypts it with `DecryptBlock()`, then verifies the decrypted payload again. |
+| `System/Kernel/_boot_code` | Not standardized | Seen on some development, SDK, and homebrew-style images as an alternate boot-code blob. Treat this as a candidate only; the active encrypted payload is the file referenced by the boot ROM tag. |
+| Legacy boot files | `RSA_BOOT`, `RSA_NEWBOOT` | Older boot-code formats may use related signing or key schemes. Not every legacy boot tag uses this exact nibble-swap transform. |
+
+Path case varies between discs. Portfolio OS lookup is case-insensitive for OperaFS entries, so `system/kernel/boot_code` and `System/Kernel/boot_code` should be treated as the same logical path.
+
+### Files Usually Not Encrypted
+
+The following files are commonly signed or digest-covered, but are not normally decrypted with this algorithm:
+
+| Filesystem path | ROM tag(s) | Notes |
+|-----------------|------------|-------|
+| `System/Kernel/os_code` | `RSA_OS` | RSA-signed OS component. |
+| `System/Kernel/misc_code` | `RSA_MISCCODE`, `RSA_OLD_MISCCODE` | RSA-signed misc-code component. |
+| `BannerScreen` | `RSA_APPSPLASH` | APP-key-signed splash image when present. |
+| `signatures` | `RSA_SIGNATURE_BLOCK` | APP-key-signed MD5 digest table for image blocks. |
+| `LaunchMe`, `AppStartup` | `RSA_BLOCKS_ALWAYS` or no ROM tag | Application startup files may be covered by signatures or digest checks, but are not typical `DecryptBlock()` targets. |
+
+### When Decryption is Used
+
+1. **CD dipir boot code** - Retail and late-development discs commonly protect `System/Kernel/boot_code` through the boot ROM tag.
+2. **Legacy boot variants** - Older boot tags such as `RSA_NEWNEWBOOT` and `RSA_NEWNEWGNUBOOT` describe earlier protected boot-code formats.
+3. **Developer artifacts** - Some disc images contain extra boot-code copies, such as `_boot_code`, that may need manual inspection before decrypting.
+
+## Security Analysis
+
+### Weaknesses
+
+1. **Not cryptographically secure**
+   - Simple XOR cipher with fixed key
+   - Known plaintext attack is trivial
+
+2. **Fixed key material**
+   - Both key arrays are public and constant
+   - No key derivation or salting
+
+3. **Short key period**
+   - Key repeats every 64 bytes
+   - Pattern analysis is straightforward
+
+4. **Deterministic**
+   - Same input always produces same output
+   - No initialization vector
+
+### Purpose
+
+The encryption appears designed for:
+- **Obfuscation** rather than security
+- **Preventing casual inspection** of sensitive files
+- **Compatibility** with legacy 3DO tools
+
+### Modern Perspective
+
+By modern standards, this encryption provides no meaningful security:
+- Key is publicly known
+- Algorithm is reversible and deterministic
+- No authentication or integrity verification
+
+## Implementation Notes
+
+### Alignment Requirements
+
+- Input buffer should be 4-byte aligned for optimal performance
+- Buffer length should be a multiple of 4 bytes
+- Trailing bytes (if length % 4 != 0) are not processed
+
+### Endianness
+
+- The algorithm operates on 32-bit words in native byte order
+- On little-endian systems, byte order within words is reversed
+- Results are consistent across platforms for the same input
+
+### Memory Safety
+
+```c
+// Ensure buffer is large enough
+assert(buffer_length >= 4);
+assert(buffer != NULL);
+
+// Process complete 32-bit words only
+uint64_t words = buffer_length / 4;
+```
+
+## Example Implementation
+
+```c
+#include <stdint.h>
+#include <string.h>
+
+static const uint8_t BOOT_CODE_CRYPT_KEY[64] = {
+    0x00, 0xB1, 0x94, 0x62, 0xB0, 0x0D, 0x8D, 0x6E,
+    0x1E, 0xC9, 0x09, 0xAB, 0x38, 0x5E, 0x06, 0xFE,
+    0x03, 0x4B, 0xFD, 0x28, 0x2E, 0x9F, 0xFD, 0xC5,
+    0x84, 0x83, 0x8C, 0x15, 0xF1, 0x25, 0x93, 0xDD,
+    0x1E, 0x3A, 0x8B, 0x56, 0x26, 0xF1, 0xB9, 0xD0,
+    0xED, 0x0C, 0x38, 0x4E, 0xF6, 0xC5, 0xD1, 0x45,
+    0x12, 0xBD, 0x72, 0xDD, 0xB8, 0x5B, 0x44, 0x08,
+    0x0E, 0x04, 0x72, 0xC0, 0x3D, 0x0A, 0xFC, 0x4C,
+};
+
+uint32_t key_word(uint64_t word_offset) {
+    uint32_t key;
+    uint64_t key_offset = (word_offset % 16) * sizeof(uint32_t);
+    memcpy(&key, &BOOT_CODE_CRYPT_KEY[key_offset], sizeof(key));
+    return key;
+}
+
+void tdo_decrypt(void *buffer, uint64_t length) {
+    uint32_t *p = (uint32_t*)buffer;
+
+    for (uint64_t i = 0; i < length / 4; i++) {
+        uint32_t xored = *p ^ key_word(i);
+        uint32_t part_a = (xored & 0xF0F0F0F0) >> 4;
+        uint32_t part_b = (xored & 0x0F0F0F0F) << 4;
+        *p++ = part_a | part_b;
+    }
+}
+
+void tdo_encrypt(void *buffer, uint64_t length) {
+    uint32_t *p = (uint32_t*)buffer;
+
+    for (uint64_t i = 0; i < length / 4; i++) {
+        uint32_t word = *p;
+        uint32_t swapped = ((word & 0xF0F0F0F0) >> 4) |
+                           ((word & 0x0F0F0F0F) << 4);
+        *p++ = swapped ^ key_word(i);
+    }
+}
+```
+
+## Historical Context
+
+This algorithm originates from the Portfolio OS source code, specifically
+`src/dipir/cdipir.c` (CD-DIPIR `DecryptBlock()`). It was used internally by
+3DO developers for boot-time obfuscation in production and validation workflows.

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -1,0 +1,261 @@
+# 3DO OperaFS Filesystem Structure
+
+## Overview
+
+OperaFS is the proprietary filesystem used by the 3DO Interactive Multiplayer. It uses a hierarchical directory structure with unique features like avatars for redundancy.
+
+## Directory Header Structure
+
+Each directory block begins with a DirectoryHeader.
+
+### Memory Layout (20 bytes)
+
+| Offset | Size | Field | Type | Description |
+|--------|------|-------|------|-------------|
+| 0x00 | 4 | `next_block` | `int32_t` | Next directory block (-1 if last) |
+| 0x04 | 4 | `prev_block` | `int32_t` | Previous directory block (-1 if first) |
+| 0x08 | 4 | `flags` | `uint32_t` | Directory flags |
+| 0x0C | 4 | `first_free_byte` | `uint32_t` | Offset to first free byte in block |
+| 0x10 | 4 | `first_entry_offset` | `uint32_t` | Offset to first directory entry |
+
+**Total size: 20 bytes**
+
+### Directory Header Fields
+
+#### `next_block`
+- Block number of the next directory block in the chain
+- Value of `-1` indicates this is the last block
+- Allows directories to span multiple blocks
+
+#### `prev_block`
+- Block number of the previous directory block
+- Value of `-1` indicates this is the first block
+- Enables bidirectional traversal
+
+#### `first_free_byte`
+- Offset from start of block to first unused byte
+- Used when adding new entries
+- Updated after each entry addition
+
+#### `first_entry_offset`
+- Offset from start of block to the first DirectoryRecord
+- Typically follows the header immediately
+
+## Directory Record Structure
+
+DirectoryRecord describes files and subdirectories.
+
+### Memory Layout (68 bytes fixed + avatars)
+
+| Offset | Size | Field | Type | Description |
+|--------|------|-------|------|-------------|
+| 0x00 | 4 | `flags` | `uint32_t` | Entry flags (see below) |
+| 0x04 | 4 | `unique_identifier` | `uint32_t` | Unique entry ID |
+| 0x08 | 4 | `type` | `uint32_t` | Entry type (4CC or hex) |
+| 0x0C | 4 | `block_size` | `uint32_t` | Block size for this entry |
+| 0x10 | 4 | `byte_count` | `uint32_t` | File size in bytes |
+| 0x14 | 4 | `block_count` | `uint32_t` | Blocks allocated |
+| 0x18 | 4 | `burst` | `uint32_t` | Burst parameter |
+| 0x1C | 4 | `gap` | `uint32_t` | Gap parameter |
+| 0x20 | 32 | `filename` | `char[32]` | Null-terminated filename |
+| 0x40 | 4 | `last_avatar_index` | `uint32_t` | Highest avatar index |
+| 0x44 | 4*N | `avatar_list` | `uint32_t[]` | Avatar block pointers (N = last_avatar_index + 1) |
+
+**Minimum size: 72 bytes (with 1 avatar)**
+
+### Directory Record Flags
+
+| Mask | Name | Description |
+|------|------|-------------|
+| `0x00000001` | `DR_FLAG_IS_DIRECTORY` | Entry is a directory |
+| `0x00000002` | `DR_FLAG_IS_READONLY` | Entry is read-only |
+| `0x00000004` | `DR_FLAG_IS_FOR_FILESYSTEM` | Entry is for filesystem use |
+| `0x40000000` | `DR_FLAG_LAST_IN_BLOCK` | Last entry in this block |
+| `0x80000000` | `DR_FLAG_LAST_IN_DIR` | Last entry in directory |
+
+### Directory Record Types
+
+The `type` field is a 4-byte value, often a FourCC (4-character code):
+
+| Value | FourCC | Name | Description |
+|-------|--------|------|-------------|
+| `0x2A646972` | `*dir` | `DR_TYPE_DIRECTORY` | Directory entry |
+| `0x2A6C626C` | `*lbl` | `DR_TYPE_LABEL` | Label entry |
+| `0x2A7A6170` | `*zap` | `DR_TYPE_CATAPULT` | Catapult entry |
+
+**Note:** FourCC values are stored in little-endian on disc. The `type_str()` function reads bytes in reverse order (indices 3,2,1,0) so the character representation reads left-to-right in ASCII.
+
+### Avatar System in Directory Records
+
+Files use avatars for data redundancy:
+
+- **`last_avatar_index`**: Range 0-7, indicates how many avatars exist
+- **`avatar_list`**: Array of block pointers, one per avatar
+- Avatar 0 (`avatar_list[0]`) is the primary data location
+- Avatars 1-7 provide redundant copies
+
+### Calculating Avatar Disc Offset
+
+```c
+uint32_t disc_avatar_offset(uint32_t avatar_index, uint32_t block_size) {
+    return avatar_list[avatar_index] * block_size;
+}
+```
+
+## Linked Memory File Entry Structure
+
+Used for special file entries in linked memory structures.
+
+### Memory Layout
+
+| Offset | Size | Field | Type | Description |
+|--------|------|-------|------|-------------|
+| 0x00 | 4 | `fingerprint` | `uint32_t` | Entry type fingerprint |
+| 0x04 | 4 | `flink_offset` | `uint32_t` | Forward link offset |
+| 0x08 | 4 | `blink_offset` | `uint32_t` | Backward link offset |
+| 0x0C | 4 | `block_count` | `uint32_t` | Number of blocks |
+| 0x10 | 4 | `header_block_count` | `uint32_t` | Header blocks |
+| 0x14 | 4 | `byte_count` | `uint32_t` | File size in bytes |
+| 0x18 | 4 | `unique_identifier` | `uint32_t` | Unique ID |
+| 0x1C | 4 | `type` | `uint32_t` | Entry type |
+| 0x20 | 32 | `filename` | `char[32]` | Filename |
+
+### Fingerprint Values
+
+| Value | Name | Description |
+|-------|------|-------------|
+| `0xBE4F32A6` | `FINGERPRINT_FILEBLOCK` | File block entry |
+| `0x7AA565BD` | `FINGERPRINT_FREEBLOCK` | Free block entry |
+| `0x855A02B6` | `FINGERPRINT_ANCHORBLOCK` | Anchor block entry |
+
+## Directory Traversal
+
+### Reading a Directory
+
+1. Seek to the root directory block (from `DiscLabel.root_directory_avatar_list[0]`)
+2. Read `DirectoryHeader`
+3. Read `DirectoryRecord` entries sequentially
+4. For each entry:
+   - Check flags to determine if file or directory
+   - For directories, recursively traverse using `avatar_list[0]`
+   - For files, access data at `avatar_list[0] * block_size`
+5. Continue until `DR_FLAG_LAST_IN_DIR` is set
+6. If `DR_FLAG_LAST_IN_BLOCK` is not set and `next_block != -1`, continue to next block
+
+### Path Resolution
+
+OperaFS paths use forward slashes:
+```
+system/kernel/boot_code
+bannerscreen
+signatures
+```
+
+Path resolution algorithm:
+1. Start at root directory
+2. Split path into components
+3. For each component:
+   - Scan current directory for matching filename
+   - If found and more components, descend into subdirectory
+   - If found and last component, return the record
+   - If not found, return error
+
+## File Data Access
+
+### Reading File Data
+
+1. Locate file via directory traversal
+2. Get first avatar block from `avatar_list[0]`
+3. Calculate disc offset: `block_offset = avatar_list[0] * block_size`
+4. Read `byte_count` bytes starting at that offset
+
+### Handling Multi-Block Files
+
+For files spanning multiple blocks:
+1. Start at `avatar_list[0]`
+2. Read `block_size` bytes
+3. Continue reading consecutive blocks
+4. Total blocks needed: `block_count` or `(byte_count + block_size - 1) / block_size`
+
+## Filename Handling
+
+### Naming Rules
+- Maximum length: 31 characters (32 bytes including null terminator)
+- Case-insensitive on 3DO hardware
+- Valid characters: A-Z, a-z, 0-9, underscore, period, hyphen
+- No path separators in filename (only in full path)
+
+### Case Handling
+When comparing filenames:
+```c
+// Convert to lowercase for comparison
+std::string lc_filename = to_lower(record.filename);
+if (lc_filename == to_lower(search_name)) {
+    // Match found
+}
+```
+
+## Special Files
+
+### System Files
+
+OperaFS expects certain system files for bootable discs:
+
+| Path | Purpose | ROM Tag Type |
+|------|---------|--------------|
+| `system/kernel/boot_code` | Boot executable | `RSA_NEWKNEWNEWGNUBOOT` |
+| `system/kernel/os_code` | Operating system | `RSA_OS` |
+| `system/kernel/misc_code` | Miscellaneous code | `RSA_MISCCODE` |
+| `bannerscreen` | Splash screen image | `RSA_APPSPLASH` |
+| `signatures` | Block signature database | `RSA_SIGNATURE_BLOCK` |
+
+## Free Space Management
+
+Free space is tracked through:
+1. `DirectoryHeader.first_free_byte` - offset to unused space in directory block
+2. `FINGERPRINT_FREEBLOCK` entries in linked memory
+
+## Example: Parsing Root Directory
+
+```c
+// Open disc and seek to root directory
+uint32_t root_block = disc_label.root_directory_avatar_list[0];
+seek_to_block(root_block);
+
+// Read directory header
+DirectoryHeader header;
+read(&header, sizeof(header));
+
+// Read entries
+while (true) {
+    DirectoryRecord record;
+    read(&record.flags, 4);
+    read(&record.unique_identifier, 4);
+    read(&record.type, 4);
+    read(&record.block_size, 4);
+    read(&record.byte_count, 4);
+    read(&record.block_count, 4);
+    read(&record.burst, 4);
+    read(&record.gap, 4);
+    read(&record.filename, 32);
+    read(&record.last_avatar_index, 4);
+    
+    // Read avatar list
+    for (int i = 0; i <= record.last_avatar_index; i++) {
+        uint32_t avatar;
+        read(&avatar, 4);
+        record.avatar_list.push_back(avatar);
+    }
+    
+    // Process record...
+    
+    if (record.flags & DR_FLAG_LAST_IN_DIR)
+        break;
+}
+```
+
+## Byte Order
+
+All multi-byte integers are big-endian:
+- `uint32_t` values require byte-swapping on little-endian systems
+- Text fields (`filename`, etc.) are byte-order independent

--- a/docs/m2-signing.md
+++ b/docs/m2-signing.md
@@ -1,0 +1,207 @@
+# M2 Disc Signing
+
+## Overview
+
+M2 discs use the same broad MD5 + RSA PKCS#1 v1.5 model as Opera discs, but the signing layout is different enough that it should be treated as a separate workflow.
+
+This document is based on the Portfolio OS M2 source tree at `~/dev/portfolio_os_m2/ws_root/src/`.
+
+## Key Differences From Opera
+
+| Area | Opera / M1 | M2 |
+|------|------------|----|
+| Label | `DiscLabel` | `ExtVolumeLabel` |
+| ROMTag count | Null-terminated table | `dl_NumRomTags` in label |
+| Main signature size | 64 bytes | 128 bytes |
+| Main key | 3DO/App 64-byte keys | M2 128-byte key |
+| ROMTag table max | 2048-byte block convention | Up to 8192 bytes |
+| File signatures | Final 64 bytes | Final 128 bytes |
+
+Relevant source:
+- `includes/file/discdata.h`: `ExtVolumeLabel`, `VF_M2`, `VF_M2ONLY`, `VF_BLESSED`
+- `includes/dipir/rom.h`: `RomTag`, M2 ROMTag types
+- `others/dipir/dipir.h`: `KEY_128`, `SIG_128_LEN`, `MAX_ROMTAG_BLOCK_SIZE`
+
+## Extended Volume Label
+
+M2 discs use `ExtVolumeLabel`, which appends fields after the Opera label body:
+
+| Field | Description |
+|-------|-------------|
+| `dl_NumRomTags` | Number of ROMTag entries in the table |
+| `dl_ApplicationID` | Application identifier |
+| `dl_Reserved[9]` | Reserved; must be zero |
+
+The extended label totals 176 bytes (132 base + 44 extended).
+
+The standard M2 layout tool creates labels with:
+- `VF_M2 | VF_BLESSED` by default
+- `VF_M2ONLY` set for M2-only media when requested
+- `dl_NumRomTags` set explicitly by `setromtags`
+
+Relevant source:
+- `tools/layout/layout.c:336-356`
+- `tools/layout/layout.c:424-452`
+- `tools/layout/layout.tcl:1978-1987`
+- `tools/layout/cdrom.tcl:37-50`
+
+## ROMTag Table
+
+For M2, the ROMTag table is an array of exactly `dl_NumRomTags` entries. It is not terminated by a null ROMTag when read as an M2 table.
+
+The table starts at the block immediately after the extended label, rounded up to the next device block:
+
+```c
+romtag_block = ceil((label_block * block_size + sizeof(ExtVolumeLabel)) / block_size)
+```
+
+For normal 2048-byte CD images this is block `1`.
+
+The M2 dipir rejects labels where `dl_NumRomTags` exceeds `MAX_ROMTAG_BLOCK_SIZE / sizeof(RomTag)`, with `MAX_ROMTAG_BLOCK_SIZE` set to 8192 bytes.
+
+Relevant source:
+- `includes/dipir/rom.h:37-45`
+- `others/dipir/romtag.c:289-323`
+- `others/dipir/dipir.h:92`
+
+## M2 RSA Key
+
+M2 signature checks use `KEY_128`, whose signature length is 128 bytes. `ReadSigned()` treats the last `KeyLen(key)` bytes as the signature and digests all preceding bytes.
+
+Relevant source:
+- `others/dipir/dipir.h:76-90`
+- `others/dipir/dbuffer.c:164-200`
+- `others/dipir/rsadipir.c:261-270`
+
+The M2 source includes an `rsasign` tool with key names `opera` and `m2`. The tool defaults to `m2`. The key material in `tools/rsasign/keys.c` matches the demo key path accepted by dipir only when `DC_DEMOKEY` is enabled; do not assume it is a retail signing key.
+
+Relevant source:
+- `tools/rsasign/rsasign.c:16-19`
+- `tools/rsasign/rsasign.c:421-461`
+- `tools/rsasign/keys.c:129-137`
+- `others/dipir/rsadipir.c:261-270`
+
+## ROMTag Table Signature
+
+The M2 ROMTag table signature verifies this byte stream:
+
+```text
+ExtVolumeLabel || RomTag[dl_NumRomTags]
+```
+
+The signature is checked with `KEY_128`.
+
+Signature location depends on `VF_M2ONLY`:
+
+| Volume flags | Signature location |
+|--------------|--------------------|
+| `VF_M2ONLY` set | Immediately after `RomTag[dl_NumRomTags]` |
+| `VF_M2ONLY` clear | After `RomTag[dl_NumRomTags]`, then one null Opera ROMTag, then one 64-byte Opera signature |
+
+In other words, hybrid M2/Opera media stores:
+
+```text
+RomTag[dl_NumRomTags]
+Opera null RomTag
+Opera 64-byte RTT signature
+M2 128-byte RTT signature
+```
+
+The M2 signature does not include the Opera null ROMTag or Opera 64-byte signature in its digest. It covers only `ExtVolumeLabel` and the counted M2 ROMTags.
+
+Relevant source:
+- `others/dipir/romtag.c:309-319`
+- `others/dipir/m2dipir.c:581-604`
+
+## Signed M2 Assets
+
+M2 assets referenced by ROMTags are signed as whole files where the final 128 bytes are the RSA signature. The `rt_Size` includes those 128 signature bytes.
+
+Digest input:
+
+```text
+asset_bytes[0 : rt_Size - 128]
+```
+
+Signature bytes:
+
+```text
+asset_bytes[rt_Size - 128 : rt_Size]
+```
+
+The block address used by dipir is:
+
+```c
+start_block = fd_RomTagBlock + rt_Offset
+```
+
+This is different from the common 3dt/Opera convention that displays an asset block as `romtag.offset + 1` when the table is at block `1`.
+
+Relevant source:
+- `others/dipir/dbuffer.c:164-200`
+- `others/dipir/diplib.verify.c:18-28`
+- `others/dipir/diplib.banner.c:19-41`
+- `others/dipir/dipir.cd.c:138-164`
+
+## Device Dipir Signature
+
+`RSA_M2_DEVDIPIR` has special coverage when loaded from a device. The signature at the end of the device dipir covers:
+
+```text
+ExtVolumeLabel || RomTag[dl_NumRomTags] || device_dipir_body_without_signature
+```
+
+The trailing signature is still 128 bytes and is checked with `KEY_128`.
+
+Relevant source:
+- `others/dipir/m2dipir.c:475-491`
+
+## Assets Checked During CD Validation
+
+The CD device dipir checks M2 assets with `KEY_128`:
+
+| ROMTag | Purpose |
+|--------|---------|
+| `RSA_M2_APPBANNER` | Banner read/display and validation |
+| `RSA_M2_OS` | OS read, validation, relocation, and boot |
+
+When the current OS remains running, the dipir still verifies the banner, media, and on-disc M2 OS.
+
+Relevant source:
+- `others/dipir/dipir.cd.c:116-133`
+- `others/dipir/dipir.cd.c:138-176`
+
+Other M2 ROMTag types include `RSA_M2_MISCCODE`, `RSA_M2_DRIVER`, `RSA_M2_DEVDIPIR`, `RSA_M2_APP_KEYS`, and `RSA_M2_ICON`. The source comments describe `RSA_M2_APP_KEYS` as `65 followed by 129 byte APP key`, but the searched source does not show it being used by the CD validation path.
+
+Relevant source:
+- `includes/dipir/rom.h:90-120`
+
+## Loader File Signatures
+
+The M2 loader also verifies ordinary loader files using the public dipir RSA interface. It reads all file bytes except the final `RSA_KEY_SIZE` bytes into the digest, then verifies the final signature. `RSA_KEY_SIZE` is 128.
+
+Relevant source:
+- `includes/dipir/dipirpub.h:35`
+- `libs/loader/fileio.c:25-57`
+- `libs/loader/fileio.c:103-107`
+- `libs/loader/fileio.c:205-234`
+
+## Implementation Notes For 3dt
+
+M2 signing should be implemented separately from the current Opera signing path.
+
+Required behavior:
+- Write `ExtVolumeLabel`, not `DiscLabel`, when `VF_M2` is set.
+- Set `dl_NumRomTags` to the exact M2 ROMTag count.
+- Generate counted M2 ROMTags without relying on a null terminator.
+- Append 128-byte signatures to signed M2 assets and include those bytes in `rt_Size`.
+- Sign M2 assets with the 128-byte M2 key path, not the 64-byte 3DO/App keys.
+- Sign the M2 RTT digest over `ExtVolumeLabel || counted ROMTags`.
+- Place the M2 RTT signature immediately after the counted table for `VF_M2ONLY` media.
+- For hybrid media, reserve space for `null Opera ROMTag || Opera 64-byte RTT signature || M2 128-byte RTT signature` after the counted table.
+- Validate `RSA_M2_DEVDIPIR` with its special `label + table + body` coverage if supporting device dipirs.
+
+Open questions before implementing retail M2 signing:
+- Which private 128-byte key should be used for target hardware.
+- Whether hybrid M2/Opera discs produced by 3dt should also generate a meaningful Opera 64-byte RTT signature.
+- Whether `RSA_M2_APP_KEYS` needs support for any target samples or hardware configuration.

--- a/docs/romtags.md
+++ b/docs/romtags.md
@@ -1,0 +1,256 @@
+# 3DO ROM Tags
+
+## Overview
+
+ROM Tags are metadata structures on 3DO discs that identify special components like boot code, operating system files, signatures, and splash screens. They provide a boot-time lookup mechanism for the system to locate critical files without traversing the filesystem.
+The definitions below match the Portfolio OS source tree mappings, especially
+`portfolio_os/src/includes/rom.h` and `portfolio_os/src/dipir/cdipir.c`.
+
+## ROM Tag Structure
+
+### Memory Layout (24 bytes)
+
+| Offset | Size | Field | Type | Description |
+|--------|------|-------|------|-------------|
+| 0x00 | 1 | `sub_systype` | `uint8_t` | Subsystem type |
+| 0x01 | 1 | `type` | `uint8_t` | Component type |
+| 0x02 | 1 | `version` | `uint8_t` | Component version |
+| 0x03 | 1 | `revision` | `uint8_t` | Component revision |
+| 0x04 | 1 | `flags` | `uint8_t` | ROM tag flags |
+| 0x05 | 1 | `type_specific` | `uint8_t` | Type-specific data |
+| 0x06 | 1 | `reserved1` | `uint8_t` | Reserved |
+| 0x07 | 1 | `reserved2` | `uint8_t` | Reserved |
+| 0x08 | 4 | `offset` | `uint32_t` | Block offset (0-indexed) |
+| 0x0C | 4 | `size` | `uint32_t` | Size in bytes |
+| 0x10 | 16 | `reserved3` | `uint32_t[4]` | Reserved / type-specific |
+
+**Total size: 24 bytes**
+
+## Subsystem Types
+
+The `sub_systype` field identifies the subsystem category:
+
+| Value | Name | Description |
+|-------|------|-------------|
+| `0x0F` | `RSANODE` | RSA-signable components on CD |
+| `0x10` | `RT_SUBSYS_ROM` | Components in system ROM |
+
+## Component Types (RSANODE Subsystem)
+
+The `type` field when `sub_systype == RSANODE`:
+
+### Boot and OS Components
+
+| Value | Name | Description |
+|-------|------|-------------|
+| `0x01` | `RSA_MUST_RSA` | Must be RSA verified |
+| `0x02` | `RSA_BLOCKS_ALWAYS` | Blocks always present |
+| `0x03` | `RSA_BLOCKS_SOMETIMES` | Blocks sometimes present |
+| `0x04` | `RSA_BLOCKS_RANDOM` | Random blocks |
+| `0x05` | `RSA_SIGNATURE_BLOCK` | Block of MD5 digest signatures |
+| `0x06` | `RSA_BOOT` | Old CD dipir tag (legacy) |
+| `0x07` | `RSA_OS` | Operating system (sherry, operator, fs) |
+| `0x08` | `RSA_CDINFO` | Optional mastering information |
+| `0x09` | `RSA_NEWBOOT` | Old CD dipir, double key scheme |
+| `0x0A` | `RSA_NEWNEWBOOT` | Old CD dipir, cheezo-encrypted |
+| `0x0B` | `RSA_NEWNEWGNUBOOT` | Old CD dipir, doubly encrypted |
+| `0x0C` | `RSA_BILLSTUFF` | Bill Duvall special request |
+| `0x0D` | `RSA_NEWKNEWNEWGNUBOOT` | **Current boot code** (quadruple secure) |
+| `0x0F` | `RSA_OLD_MISCCODE` | Old misc_code (C&B and Sampler) |
+| `0x10` | `RSA_MISCCODE` | Current misc_code |
+| `0x11` | `RSA_APP` | Start of application area |
+| `0x12` | `RSA_DRIVER` | Downloadable device drivers |
+| `0x13` | `RSA_DEVDIPIR` | Dipir driver for non-CD device |
+| `0x14` | `RSA_APPSPLASH` | Application splash screen image |
+| `0x15` | `RSA_DEPOTCONFIG` | Depot configuration file |
+| `0x16` | `RSA_DEVICE_INFO` | Device ID & related info |
+| `0x17` | `RSA_DEV_PERMS` | List of usable devices |
+| `0x18` | `RSA_BOOT_OVERLAY` | Overlay module for RSA_NEW*BOOT |
+
+### M2 Component Types
+
+| Value | Name | Description |
+|-------|------|-------------|
+| `0x87` | `RSA_M2_OS` | M2 operating system |
+| `0x90` | `RSA_M2_MISCCODE` | M2 misc code |
+| `0x92` | `RSA_M2_DRIVER` | M2 dipir device driver |
+| `0x93` | `RSA_M2_DEVDIPIR` | M2 device dipir |
+| `0x94` | `RSA_M2_APPBANNER` | M2 application banner image |
+| `0x95` | `RSA_M2_APP_KEYS` | 65-byte followed by 129-byte APP key |
+| `0x96` | `RSA_OPERA_CD_IMAGE` | Opera CD image (Bridgit) |
+| `0x97` | `RSA_M2_ICON` | Device icon image |
+
+## Component Types (ROM Subsystem)
+
+The `type` field when `sub_systype == RT_SUBSYS_ROM`:
+
+### Boot Code Related
+
+| Value | Name | Description |
+|-------|------|-------------|
+| `0x10` | `ROM_DIAGNOSTICS` | In-ROM diagnostics code |
+| `0x11` | `ROM_DIAG_LOADER` | Loader for downloadable diagnostics |
+| `0x12` | `ROM_VER_STRING` | Version string for static screen |
+
+### Dipir Related
+
+| Value | Name | Description |
+|-------|------|-------------|
+| `0x20` | `ROM_DIPIR` | System ROM dipir code |
+| `0x21` | `ROM_DIPIR_DRIVERS` | Various dipir device drivers |
+
+### OS Related
+
+| Value | Name | Description |
+|-------|------|-------------|
+| `0x30` | `ROM_KERNEL_ROM` | Reduced kernel for ROM apps |
+| `0x31` | `ROM_KERNEL_CD` | Full kernel for titles (no misc) |
+| `0x32` | `ROM_OPERATOR` | Operator for ROM apps/titles |
+| `0x33` | `ROM_FS` | Filesystem for ROM apps/titles |
+
+### Configuration Related
+
+| Value | Name | Description |
+|-------|------|-------------|
+| `0x40` | `ROM_SYSINFO` | System information code |
+| `0x41` | `ROM_FS_IMAGE` | Mountable ROM filesystem |
+| `0x42` | `ROM_PLATFORM_ID` | ROM release ID |
+| `0x43` | `ROM_ROM2_BASE` | Base address of 2nd ROM bank |
+
+## ROM Tag Location
+
+ROM tags are stored immediately after the disc label:
+```
+romtags_block = disc_label_block + 1
+```
+
+## ROM Tag Termination
+
+ROM tags are read sequentially until a terminator is found:
+```c
+while (true) {
+    ROMTag tag;
+    read(&tag, sizeof(tag));
+    
+    // Terminator condition
+    if (tag.sub_systype == 0)
+        break;
+    
+    // Process tag...
+}
+```
+
+## Type-Specific Field Usage
+
+### RSA_CDINFO (0x08)
+| Field | Usage |
+|-------|-------|
+| `offset` | Zeros |
+| `size` | Zeros |
+| `reserved3[0]` | Copy of `VolumeUniqueId` |
+| `reserved3[1]` | Random number (backup unique ID) |
+| `reserved3[2]` | Date & time stamp |
+| `reserved3[3]` | Reserved |
+
+### RSA_SIGNATURE_BLOCK (0x05)
+| Field | Usage |
+|-------|-------|
+| `type_specific` | Number of block digests to check (default: 15) |
+
+### RSA_OS (0x07)
+| Field | Usage |
+|-------|-------|
+| `version` | OS version (typically 24) |
+| `revision` | OS revision (typically 225) |
+
+### RSA_NEWKNEWNEWGNUBOOT (0x0D)
+| Field | Usage |
+|-------|-------|
+| `version` | Boot code version (typically 2) |
+| `revision` | Boot code revision (typically 5) |
+
+### RSA_DRIVER / RSA_M2_DRIVER
+| Field | Usage |
+|-------|-------|
+| `reserved1` | Component ID |
+
+#### Component IDs
+| Value | Name | Description |
+|-------|------|-------------|
+| 1 | `DDDID_LCCD` | LCCD driver |
+| 2 | `DDDID_MICROCARD_MEM` | Microcard memory driver |
+| 3 | `DDDID_PCMCIA_MEM` | 3DO card memory driver |
+| 4 | `DDDID_HOST` | Debugger host FS driver |
+| 5 | `DDDID_HOSTCD` | Host CD-ROM emulator driver |
+| 6 | `DDDID_PCHOST` | PC debugger host FS driver |
+
+### RSA_DEVDIPIR / RSA_M2_DEVDIPIR
+| Field | Usage |
+|-------|-------|
+| `reserved1` | Dipir ID |
+
+#### Dipir IDs
+| Value | Name | Description |
+|-------|------|-------------|
+| 2 | `DIPIRID_CD` | CD-ROM media validation |
+| 3 | `DIPIRID_ROMAPP` | Non-bootable RomApp device |
+| 4 | `DIPIRID_SYSROMAPP` | Load RomApp OS from system ROM |
+| 5 | `DIPIRID_HOST` | Load OS from debugger host |
+| 6 | `DIPIRID_CART` | Load OS from bootable cartridge |
+| 7 | `DIPIRID_BOOTROMAPP` | Load RomApp OS from device |
+| 8 | `DIPIRID_MICROCARD` | Generic Microcard validation |
+| 9 | `DIPIRID_VISA` | Generic VISA card validation |
+| 10 | `DIPIRID_PC16550` | Proto PC16550 card validation |
+| 11 | `DIPIRID_MEDIA_DEBUG` | Debug testing of RomApp media |
+| 12 | `DIPIRID_PCDEVCARD` | PC developer card validation |
+
+## Reading ROM Tags
+
+```c
+void read_romtags(DevStream &stream) {
+    stream.data_block_seek(stream.romtags_block());
+    
+    while (true) {
+        ROMTag tag;
+        stream.read(tag);
+        
+        if (tag.sub_systype == 0)
+            break;
+        
+        // Access the component
+        uint32_t actual_block = tag.offset + 1;
+        uint32_t size = tag.size;
+        
+        printf("Found %s at block %u, size %u bytes\n",
+               tag.type_str(), actual_block, size);
+    }
+}
+```
+
+## File-to-ROMTag Mapping
+
+The 3DO signing process maps specific filesystem paths to ROM tag types:
+
+| File Path | ROM Tag Type |
+|-----------|--------------|
+| `signatures` | `RSA_SIGNATURE_BLOCK` |
+| `system/kernel/boot_code` | `RSA_NEWKNEWNEWGNUBOOT` |
+| `system/kernel/misc_code` | `RSA_MISCCODE` |
+| `system/kernel/os_code` | `RSA_OS` |
+| `bannerscreen` | `RSA_APPSPLASH` |
+
+This table reflects the same file-to-ROMTag associations used during CD-DIPIR
+load-time discovery in `portfolio_os/src/dipir/cdipir.c`.
+
+## ROM Tags for Signatures
+
+After signing, an additional RSA signature is appended after the ROM tags:
+
+```
+[DiscLabel][ROMTag][ROMTag]...[Terminator][RSA Signature (64 bytes)]
+```
+
+This signature covers: DiscLabel + ROMTags + boot_code data.
+The same coverage is checked by the Portfolio OS boot path in
+`portfolio_os/src/dipir/cdipir.c` (after the boot payload has been passed through
+`DecryptBlock()`).

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -1,0 +1,390 @@
+# 3DO RSA Signing
+
+## Overview
+
+3DO discs use RSA-512 digital signatures to verify the authenticity and integrity of disc contents. This document describes the signing algorithm, key structure, and verification process.
+The implementation here is aligned with Portfolio OS sources, primarily
+`portfolio_os/src/dipir/cdipir.c` for boot/verification flow and
+`portfolio_os/src/dipir/rsadipir.c` for CD boot payload obfuscation handling.
+
+## RSA Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Algorithm | RSA |
+| Key Size | 512 bits |
+| Signature Size | 64 bytes |
+| Hash Algorithm | MD5 |
+| Public Exponent (e) | 65537 (0x10001) |
+
+## Signature Types
+
+### rsa512_sig_t
+```c
+typedef unsigned char rsa512_sig_t[64];  // 512 bits = 64 bytes
+```
+
+## Keys
+
+### Key Names
+
+| Name | Constant | Description |
+|------|----------|-------------|
+| `"3do"` | `TDO_KEY_3DO` | 3DO system key |
+| `"app"` | `TDO_KEY_APP` | Application/publisher key |
+
+### RSA Key Components
+
+Each key has three components:
+- **n**: Modulus (public, 512 bits)
+- **d**: Private exponent (secret, 512 bits)
+- **e**: Public exponent (65537)
+
+### 3DO Key (System Key)
+
+**Modulus (n):**
+```
+B19462B00D8D6E1EC909AB385E06FE034BFD282E9FFDC584838C15F12593DD1E
+3A8B5626F1B9D0ED0C384EF6C5D14512BD72DDB85B44080E0472C03D0AFC4C97
+```
+
+**Private Exponent (d):**
+```
+42F7CD9BCD109805BE150A60107D9C8F8BB9A5CCA78361588EEF665AF1ABE887
+DBC2593D0868F364A93C8CB8CC6F4BCC6A3DE57E04B17AC52F2649939C453F61
+```
+
+### APP Key (Application Key)
+
+**Modulus (n):**
+```
+BC0B199086C7F26CBC9D50F404944DB4789FCBFCF7AD8DBC2120898ABEAAF311
+EEA20229035608841FA41073ABBD5D37500C60B53BFB46605740381B72C9DB71
+```
+
+**Private Exponent (d):**
+```
+18B2207E61A51ACA7B0EF215CA102C105A9329F824130FFD38208CCFC2F0B291
+5B8AD1E7772334381737D232B183C869C34940BC8769C97E18D7B0E78C492991
+```
+
+## Message Formatting
+
+Before signing, the MD5 digest is formatted into a PKCS#1 v1.5 compatible message.
+
+### Message Prefix
+```
+1ffffffffffffffffffffffffffffffffffffffffffffffffffffff003020300c06082a864886f70d020505000410
+```
+
+This 70-character hex string (35 bytes) is prepended to the MD5 digest.
+
+### Full Message Construction
+```
+message = prefix || MD5_digest_hex
+```
+
+**Example:**
+```
+Prefix:  1ffffffffffffffffffffffffffffffffffffffffffffffffffffff003020300c06082a864886f70d020505000410
+MD5:     93A6D77F3DC4DF73D7F819598DE97DDB
+Message: 1ffffffffffffffffffffffffffffffffffffffffffffffffffffff003020300c06082a864886f70d02050500041093A6D77F3DC4DF73D7F819598DE97DDB
+```
+
+### Prefix Breakdown
+
+| Bytes | Value | Meaning |
+|-------|-------|---------|
+| 1 | `0x1F` | PKCS#1 block type 1 (signature) |
+| 15 | `FF...FF` | Padding bytes |
+| 1 | `0x00` | Separator |
+| 2 | `0x30 0x20` | SEQUENCE (32 bytes) |
+| 2 | `0x30 0x0C` | Nested SEQUENCE (12 bytes) |
+| 2 | `0x06 0x08` | OID tag (8 bytes) |
+| 8 | `2A864886F70D0205` | MD5 OID (1.2.840.113549.2.5) |
+| 2 | `0x05 0x00` | NULL |
+| 2 | `0x04 0x10` | OCTET STRING (16 bytes) |
+| 16 | MD5 digest | The actual hash |
+
+## Signing Algorithm
+
+### RSA Signature Generation
+
+```
+signature = m^d mod n
+```
+
+Where:
+- `m` = formatted message (as big integer)
+- `d` = private exponent
+- `n` = modulus
+
+### Implementation
+
+```c
+void tdo_rsa_sign(const char *key_name, 
+                  const md5_digest_t digest, 
+                  rsa512_sig_t signature) {
+    // Get key components
+    BIGD n = get_modulus(key_name);      // n
+    BIGD d = get_private_exponent(key_name);  // d
+    BIGD m = format_message(digest);     // m = prefix || digest
+    
+    // Compute signature: s = m^d mod n
+    BIGD s = bdNew();
+    bdModExp(s, m, d, n);  // s = m^d mod n
+    
+    // Convert to bytes
+    bdConvToOctets(s, signature, 64);
+    
+    // Cleanup
+    bdFree(&s);
+    bdFree(&m);
+    bdFree(&d);
+    bdFree(&n);
+}
+```
+
+## Signed Components
+
+### Components Signed with APP Key
+
+| Component | Data Signed | Signature Location |
+|-----------|-------------|-------------------|
+| DiscLabel + ROMTags + BootCode | Concatenated data | After ROM tags |
+| Signatures File | All MD5 digests | End of file |
+| BannerScreen | Image data | End of file |
+
+### Components Signed with 3DO Key
+
+| Component | Data Signed | Signature Location |
+|-----------|-------------|-------------------|
+| OS Code | `system/kernel/os_code` | End of file |
+| Misc Code | `system/kernel/misc_code` | End of file |
+| Boot Code (inner decrypted payload) | Post-decryption inner boot code | End of encrypted `boot_code` file |
+
+## Signature Verification
+
+### Verification Algorithm
+
+```
+m' = s^e mod n
+```
+
+Where:
+- `s` = signature (as big integer)
+- `e` = public exponent (65537)
+- `n` = modulus
+
+The result `m'` should match the formatted message.
+
+### Implementation
+
+```c
+bool verify_signature(const char *key_name,
+                      const md5_digest_t digest,
+                      const rsa512_sig_t signature) {
+    // Get public key components
+    BIGD n = get_modulus(key_name);
+    BIGD e = bdNew(); bdConvFromHex(e, "10001");
+    
+    // Convert signature to big integer
+    BIGD s = bdNew(); bdConvFromOctets(s, signature, 64);
+    
+    // Compute: m' = s^e mod n
+    BIGD m_prime = bdNew();
+    bdModExp(m_prime, s, e, n);
+    
+    // Compute expected message
+    BIGD m_expected = format_message(digest);
+    
+    // Compare
+    bool valid = (bdCompare(m_prime, m_expected) == 0);
+    
+    // Cleanup
+    bdFree(&m_expected);
+    bdFree(&m_prime);
+    bdFree(&s);
+    bdFree(&e);
+    bdFree(&n);
+    
+    return valid;
+}
+```
+
+## Signing a Disc
+
+### Process Overview
+
+1. **Pad image to 32KB boundary**
+   - Image size must be multiple of 32768 bytes
+
+2. **Update disc label**
+   - Set `volume_block_count` to new total blocks
+
+3. **Add 3dt mark** (optional)
+   - Write signature marker at offset 0x100
+
+4. **Generate and write ROM tags**
+   - Create ROMTag for each special file
+   - Write terminator
+   - Validate all required files exist
+
+5. **Sign BannerScreen**
+   - Read bannerscreen data
+   - Compute MD5
+   - Sign with APP key
+   - Append signature
+
+6. **Generate `RSA_BILLSTUFF` ROM tag**
+   - Create ROM tag for Bill Duvall component
+
+7. **Generate signatures file**
+   - Compute MD5 for each 32KB block
+   - Build signatures file
+   - Sign digest list with APP key
+   - Append signature
+
+8. **Sign DiscLabel + ROMTags + BootCode**
+   - Concatenate: DiscLabel + ROMTags + boot_code (encrypted outer payload)
+   - Compute MD5
+   - Sign with APP key
+   - Write signature after ROM tags
+
+9. **Sign boot code inner payload with 3DO key**
+   - Decrypt boot_code (remove XOR obfuscation)
+   - Compute MD5 of decrypted inner payload
+   - Sign with 3DO key
+   - Append signature to encrypted boot_code file
+
+### Signatures File Format
+
+```
++------------------+
+| MD5 Digest 1     | 16 bytes
+| MD5 Digest 2     | 16 bytes
+| ...              |
+| MD5 Digest N     | 16 bytes
++------------------+
+| RSA Signature    | 64 bytes
++------------------+
+```
+
+### Digest Count Calculation
+
+```c
+uint64_t num_digests = (volume_block_count * volume_block_size) / 32768;
+```
+
+Each digest covers 32KB (16 blocks of 2048 bytes):
+- Physical block size: 2048 bytes
+- Logical block size: 32768 bytes (16 physical blocks)
+- Each MD5 covers one 32KB logical block
+
+### BannerScreen Sizes
+
+| Type | Size (bytes) | With Signature |
+|------|--------------|----------------|
+| NTSC | 153,624 | 153,688 |
+| PAL | 202,752 | 202,816 |
+
+Calculation:
+- NTSC: (320 × 240 × 2) + 24 = 153,624
+- PAL: (352 × 288 × 2) + 24 = 202,752
+
+## MD5 Implementation
+
+### MD5 Digest Structure
+
+```c
+typedef uint8_t md5_digest_t[16];
+```
+
+### MD5 API
+
+```c
+void md5_init(md5_ctx_t *ctx);
+void md5_update(md5_ctx_t *ctx, const void *data, size_t size);
+void md5_finalize(md5_ctx_t *ctx, md5_digest_t digest);
+void md5_calc(const void *data, size_t size, md5_digest_t digest);
+```
+
+### Example: Computing File MD5
+
+```c
+void compute_file_md5(DevStream &stream, uint64_t block, 
+                      uint64_t size, md5_digest_t digest) {
+    std::vector<char> data;
+    stream.read_data_bytes_from_block(data, block, size);
+    md5_calc(data.data(), data.size(), digest);
+}
+```
+
+## Cross-Application Signature
+
+The "cross-app" signature is stored immediately after the ROM tags:
+
+```c
+void get_cross_app_sig(DevStream &stream, rsa512_sig_t sig) {
+    stream.data_block_seek(stream.romtags_block());
+    stream.data_byte_skip(stream.romtags_size_in_bytes());
+    stream.read((char*)sig, 64);
+}
+```
+
+This signature covers:
+1. DiscLabel (132 bytes)
+2. All ROM tags (24 bytes each + terminator)
+3. Boot code (from RSA_NEWKNEWNEWGNUBOOT)
+
+## Signature Validation During Boot
+
+The 3DO boot process:
+
+1. **Read DiscLabel** - Find and validate disc label
+2. **Read ROM Tags** - Locate special components
+3. **Verify cross-app signature** - Validates DiscLabel + ROMTags + boot_code
+4. **Load boot_code** - Verify with 3DO key signature
+5. **Load OS** - Verify with 3DO key signature
+6. **Validate signatures file** - Spot-check block digests
+7. **Boot application**
+
+This sequence follows the Portfolio OS `cdipir` flow in
+`portfolio_os/src/dipir/cdipir.c`.
+
+### Signature File Checking
+
+The `type_specific` field in RSA_SIGNATURE_BLOCK controls how many block digests are checked:
+
+- `MAX_DIGEST_CHECKS` = 128 (maximum)
+- Default: 15 digests checked
+- Setting to 0: disables checking
+- Setting to 1: uses default (15)
+- Setting ≥ 128: uses 127
+
+## Security Notes
+
+### Key Security
+
+- The **private exponent (d)** must be kept secret
+- The **modulus (n)** and **public exponent (e)** can be public
+- Keys are 512-bit RSA, which is considered weak by modern standards
+- 3DO uses fixed, known keys for retail discs
+
+### Signature Storage
+
+- Signatures are appended to the end of signed data
+- File signatures replace any existing signature
+- The cross-app signature is stored at a fixed location
+
+### Known Boot Code MD5
+
+The standard 3DO boot code has a known MD5:
+```c
+md5_digest_t MD5_DIGEST_BOOT_CODE = {
+    0x93, 0xA6, 0xD7, 0x7F, 0x3D, 0xC4, 0xDF, 0x73,
+    0xD7, 0xF8, 0x19, 0x59, 0x8D, 0xE9, 0x7D, 0xDB
+};
+```
+
+Size: 5996 bytes (some tools incorrectly pad to 8192 bytes).

--- a/src/bigd.c
+++ b/src/bigd.c
@@ -1,0 +1,1563 @@
+/* $Id: bigd.c $ */
+
+/***** BEGIN LICENSE BLOCK *****
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2001-16 David Ireland, D.I. Management Services Pty Limited
+ * <http://www.di-mgt.com.au/bigdigits.html>. All rights reserved.
+ *
+ ***** END LICENSE BLOCK *****/
+/*
+ * Last updated:
+ * $Date: 2016-03-31 09:51:00 $
+ * $Revision: 2.6.1 $
+ * $Author: dai $
+ */
+
+/* BIGD "bd" wrapper functions around BigDigits "mp" functions */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <assert.h>
+#include "bigd.h"
+#include "bigdigits.h"
+
+/* Required for opaque pointers */
+#define T BIGD
+struct T
+{
+	DIGIT_T *digits;	/* Ptr to array of digits, least sig. first */
+	size_t ndigits;		/* No of non-zero significant digits */
+	size_t maxdigits;	/* Max size allocated */
+	/*int is_signed;*/	/* (for future use) */
+};
+
+#define OCTETS_PER_DIGIT (sizeof(bdigit_t))
+
+/* 
+All these functions MUST make sure that there are always
+enough digits before doing anything, and SHOULD reset <ndigits>
+afterwards to reflect the final significant size.
+-- <maxdigits> is the size allocated (at least one).
+-- <ndigits> may be zero.
+-- <ndigits> may be too long if MS digits compute to zero so
+   consider it an upper bound on significant digits, not gospel.
+
+It is an error to pass a NULL BIGD parameter except to bdFree.
+*/
+
+#ifdef _DEBUG
+static int debug = 0; /* <= change this to > 0 for console debugging */
+#else
+static int debug = 0; /* <= ALWAYS ZERO */
+#endif
+
+/* Useful definitions */
+#ifndef FALSE
+#define FALSE               0
+#endif
+#ifndef TRUE
+#define TRUE                1
+#endif
+#ifndef max
+#define max(a,b)            (((a) > (b)) ? (a) : (b))
+#endif
+#ifndef min
+#define min(a,b)            (((a) < (b)) ? (a) : (b))
+#endif
+
+
+T bdNew(void)
+{
+	struct T *p;
+	p = calloc(1, (long)sizeof(*p));
+	if (!p)
+	{
+		mpFail("bdNew: Failed to calloc memory.");
+	}
+	copyright_notice();	
+	/* set up with single zero digit */
+	p->digits = mpAlloc(1);
+	p->digits[0] = 0;
+	p->ndigits = 0;
+	p->maxdigits = 1;
+	//p->sign = 0;
+	return p;
+}
+
+void bdFree(T *p)
+/* Zeroise and free memory. Set ptr to NULL. */
+{
+	T bd = *p;
+	if (*p)
+	{
+		/* Zeroise them all, just in case */
+		if (bd->digits)
+		{
+			mpSetZero(bd->digits, bd->maxdigits);
+			free(bd->digits);
+		}
+		bd->maxdigits = 0;
+		bd->ndigits = 0;
+		free(*p);
+	}
+	*p = NULL;
+}
+
+static int bd_resize(T b, size_t newsize)
+{
+/* 
+Internal fn to re-size a BIGD structure before a calc.
+Use carefully!
+1. If growing, it allocs more digits and increases maxdigits
+2. If shrinking, it decreases ndigits and zeroises the excess.
+3. It does not increase b->ndigits; that's up to you later.
+4. It does not release excess digits; use bdFree.
+
+In other words, it's like middle-aged spread: 
+you go from a 32" waist to a 38 but can never go backwards.
+
+Be careful doing the following:-
+	n = new_size_we_expect;
+	bd_resize(b, n);
+	mpFunctionOfSorts(b->digits, n);
+	b->ndigits = mpSizeof(b->digits, b->ndigits); // NO!
+
+b->ndigits may be set too short
+
+Better:
+	n = new_size_we_expect;
+	bd_resize(b, n);
+	mpFunctionOfSorts(b->digits, n);
+	b->ndigits = mpSizeof(b->digits, n);  // Yes.
+
+*/
+
+	size_t i;
+
+	/* Check just in case NULL */
+	assert(b);
+	assert(b->digits);
+
+	/* If we are shrinking, clear high digits */
+	if (newsize < b->ndigits)
+	{
+		for (i = newsize; i < b->ndigits; i++)
+			b->digits[i] = 0;
+		b->ndigits = newsize;
+		return 0;
+	}
+
+	/* We need more room */
+	if (b->maxdigits < newsize)
+	{
+		DIGIT_T *newp, *oldp;
+		size_t oldsize = b->maxdigits;
+		/* Increase size of digit array */
+		//b->digits = (DIGIT_T *)realloc(b->digits, newsize * sizeof(DIGIT_T));
+		/* -- [v2.2] changed [2008-03-30] to avoid realloc */
+		newp = (DIGIT_T *)malloc(newsize * sizeof(DIGIT_T));
+		oldp = b->digits;
+		
+		/* Check for failure */
+		if (!newp)
+		{
+			mpSetZero(oldp, oldsize);
+			free(oldp);
+			mpFail("bd_resize: Failed to realloc memory.");
+		}
+
+		memcpy(newp, oldp, oldsize * sizeof(DIGIT_T));
+		mpSetZero(oldp, oldsize);
+		free(oldp);
+		b->digits = newp;
+
+		b->maxdigits = newsize;	/* Remember new allocated size */
+	}
+
+	/* Make sure new digits are zero */
+	for (i = b->ndigits; i < newsize; i++)
+		b->digits[i] = 0;
+
+	return 0;
+}
+
+/* New in [v2.6]: A more compact way to allocate and free BIGD variables */
+
+void bdNewVars(BIGD *pb1, ...)
+{
+	BIGD *pbd;
+	va_list ap;
+
+	va_start(ap, pb1);
+	while ((pbd = va_arg(ap, BIGD*))) {
+		*pbd = bdNew();
+	}
+	va_end(ap);
+	/* Deal with the first argument */
+	*pb1 = bdNew();
+}
+
+void bdFreeVars(BIGD *pb1, ...)
+{
+	BIGD *pbd;
+	va_list ap;
+
+	/* NB the stdarg macros do not permit programmers to code a function with no fixed arguments
+	* So this skips the first argument */
+	va_start(ap, pb1);
+	while ((pbd = va_arg(ap, BIGD*))) {
+		bdFree(pbd);
+	}
+	va_end(ap);
+	/* Deal with the first argument */
+	bdFree(pb1);
+}
+
+size_t bdConvFromOctets(T b, const unsigned char *c, size_t nbytes)
+/* Converts nbytes octets into big digit b, resizing if necessary */
+{
+	size_t ndigits, n;
+
+	assert(b);
+	ndigits = (nbytes + OCTETS_PER_DIGIT - 1) / OCTETS_PER_DIGIT;
+
+	bd_resize(b, ndigits);
+	
+	n = mpConvFromOctets(b->digits, ndigits, c, nbytes);
+	b->ndigits = mpSizeof(b->digits, n);
+
+	return n;
+}
+
+size_t bdConvToOctets(T b, unsigned char *c, size_t nbytes)
+/* Convert big digit b into string of octets, in big-endian order,
+   padding to nbytes or truncating if necessary.
+   Returns # significant bytes. 
+   If c is NULL or nbytes == 0 then just return required size.
+*/
+{
+	size_t noctets, nbits, n;
+
+	assert(b);
+
+	nbits = mpBitLength(b->digits, b->ndigits);
+	noctets = (nbits + 7) / 8;
+	/* [2008-05-23] always return at least 1 */
+	if (0 == noctets) noctets = 1;
+
+	if (!c || 0 == nbytes)
+	{
+		return noctets;
+	}
+
+	n = mpConvToOctets(b->digits, b->ndigits, c, nbytes);
+
+	return n;
+}
+
+size_t bdConvFromHex(T b, const char *s)
+/* Converts a hex string into big digit b */
+{
+	size_t ndigits, n;
+
+	assert(b);
+
+	/* Revision [2006-02-21] */
+	/* EDIT: ndigits = (strlen(s) / 2 + OCTETS_PER_DIGIT - 1) / OCTETS_PER_DIGIT; */
+	ndigits = ((strlen(s) + 1) / 2 + OCTETS_PER_DIGIT - 1) / OCTETS_PER_DIGIT;
+	bd_resize(b, ndigits);
+
+	n = mpConvFromHex(b->digits, ndigits, s);
+	b->ndigits = mpSizeof(b->digits, n);
+
+	return n;
+}
+
+size_t bdConvToHex(T b, char *s, size_t smax)
+{
+	assert(b);
+	return mpConvToHex(b->digits, b->ndigits, s, smax);
+}
+
+size_t bdConvFromDecimal(BIGD b, const char *s)
+{
+	size_t ndigits, n;
+
+	assert(b);
+	/* approx size but never too small */
+	ndigits = (strlen(s) / 2 + OCTETS_PER_DIGIT) / OCTETS_PER_DIGIT;
+	bd_resize(b, ndigits);
+
+	n = mpConvFromDecimal(b->digits, ndigits, s);
+	b->ndigits = n;
+
+	return n;
+}
+
+size_t bdConvToDecimal(BIGD b, char *s, size_t smax)
+{
+	assert(b);
+	return mpConvToDecimal(b->digits, b->ndigits, s, smax);
+}
+
+int bdSetShort(T b, bdigit_t value)
+	/* Converts value into a (single-digit) big digit b */
+{
+	assert(b);
+	bd_resize(b, 1);
+	b->digits[0] = (DIGIT_T)value;
+	b->ndigits = (value ? 1 : 0);
+	return 0;
+}
+
+/** Returns the least significant digit in b */
+bdigit_t bdToShort(T b)
+{
+	assert(b);
+	return mpToShort(b->digits, b->ndigits);
+}
+
+
+size_t bdBitLength(T b)
+	/* Returns base-1 index to most significant bit in b */
+{
+	assert(b);
+	return mpBitLength(b->digits, b->ndigits);
+}
+
+size_t bdSizeof(T b)
+	/* Returns number of significant non-zero bytes in b */
+{
+	assert(b);
+	return mpSizeof(b->digits, b->ndigits);
+}
+
+
+/* Print function for bigdigit_t structures [OBSOLETE] */
+void bdPrint(T p, size_t flags)
+{
+	size_t n;
+
+	assert(p);
+	n = p->ndigits;
+	if (n == 0) {
+		bdSetZero(p);	// Added [v2.6]
+		n = 1;
+	}
+
+	if (flags & BD_PRINT_TRIM)	/* Trim leading zeroes */
+	{
+		if (flags & BD_PRINT_NL)	/* add newlines */
+			mpPrintTrimNL(p->digits, n);
+		else
+			mpPrintTrim(p->digits, n);
+	}
+	else
+	{
+		if (flags & BD_PRINT_NL)	/* add newlines */
+			mpPrintNL(p->digits, n);
+		else
+			mpPrint(p->digits, n);
+	}
+}
+
+void bdPrintHex(const char *prefix, T p, const char *suffix)
+{
+	size_t n;
+
+	assert(p);
+	n = p->ndigits;
+	if (n == 0) {
+		bdSetZero(p);	// Added [v2.6]
+		n = 1;
+	}
+	mpPrintHex(prefix, p->digits, n, suffix);
+}
+
+void bdPrintDecimal(const char *prefix, T p, const char *suffix)
+{
+	size_t n;
+
+	assert(p);
+	n = p->ndigits;
+	if (n == 0) {
+		bdSetZero(p);	// Added [v2.6]
+		n = 1;
+	}
+	mpPrintDecimal(prefix, p->digits, n, suffix);
+}
+
+void bdPrintBits(const char *prefix, T p, const char *suffix)
+{
+	size_t n;
+
+	assert(p);
+	n = p->ndigits;
+	if (n == 0) {
+		bdSetZero(p);	// Added [v2.6]
+		n = 1;
+	}
+	mpPrintBits(prefix, p->digits, n, suffix);
+}
+
+/** Returns true if a == 0, else false */
+int bdIsZero(T a)
+{
+	assert(a);
+	return mpIsZero(a->digits, a->ndigits);
+}
+
+int bdIsZero_ct(T a)
+{
+	assert(a);
+	/* [v2.6] Use constant-time fn */
+	return mpIsZero_ct(a->digits, a->ndigits);
+}
+
+/**	Returns true if a == b, else false */
+static int isequal_local(T a, T b, int ct)
+{
+	size_t n, na, nb;
+
+	assert(a && b);
+	if (a->ndigits != b->ndigits) {
+		na = mpSizeof(a->digits, a->ndigits);
+		nb = mpSizeof(b->digits, b->ndigits);
+	
+		if (na != nb)
+			return FALSE;
+		if (na == 0 && nb == 0)
+			return TRUE;
+		n = na;
+	} else {
+		n = a->ndigits;
+	}
+
+	/* [v2.5] Use constant-time fn if equal length */
+	/* [v2.6] ... only if _ct function is called */
+	if (ct)
+		return mpEqual_ct(a->digits, b->digits, n);
+	else
+		return mpEqual(a->digits, b->digits, n);
+}
+
+/**	Returns true if a == b, else false */
+int bdIsEqual(T a, T b)
+{
+	return isequal_local(a, b, 0);
+}
+int bdIsEqual_ct(T a, T b)
+{
+	return isequal_local(a, b, 1);
+}
+
+/**	Returns sign of (a-b) */
+static int compare_local(T a, T b, int ct)
+{
+	size_t n, na, nb;
+
+	assert(a && b);
+	if (a->ndigits != b->ndigits) {
+		na = mpSizeof(a->digits, a->ndigits);
+		nb = mpSizeof(b->digits, b->ndigits);
+		if (na > nb) return 1;
+		if (na < nb) return -1;
+		n = na;
+	} else {
+		n = a->ndigits;
+	}
+
+	/* [v2.5] Use constant-time fn if equal length */
+	/* [v2.6] ... only if _ct function is called */
+	if (ct)
+		return mpCompare_ct(a->digits, b->digits, n);
+	else
+		return mpCompare(a->digits, b->digits, n);
+
+}
+
+/**	Returns sign of (a-b) */
+int bdCompare(T a, T b)
+{
+	return compare_local(a, b, 0);
+}
+int bdCompare_ct(T a, T b)
+{
+	return compare_local(a, b, 0);
+}
+
+/** Returns sign of (a-d) */
+int bdShortCmp(T a, bdigit_t d)
+{
+	assert(a);
+	return mpShortCmp(a->digits, d, a->ndigits);
+}
+
+/** Returns true if a == d, else false, where d is a single digit */
+int bdShortIsEqual(BIGD a, bdigit_t d)
+{
+	assert(a);
+	return mpShortIsEqual(a->digits, d, a->ndigits);
+}
+
+int bdIsEven(T a)
+{
+	assert(a);
+	return ISEVEN(a->digits[0]);
+}
+
+int bdIsOdd(T a)
+{
+	assert(a);
+	return ISODD(a->digits[0]);
+}
+
+
+int bdSetEqual(T a, T b)
+	/*	Sets a = b */
+{
+	assert(a && b);
+	bd_resize(a, b->ndigits);
+	mpSetEqual(a->digits, b->digits, b->ndigits);
+	a->ndigits = b->ndigits;
+	return 0;
+}
+
+int bdSetZero(T a)
+	/* Sets a = 0 */
+{
+	assert(a);
+	/* [v2.6] changed a->ndigits to a->maxdigits to make sure we clear any residual */
+	mpSetZero(a->digits, a->maxdigits);
+	a->ndigits = 0;
+	return 0;
+}
+
+int bdShortAdd(T w, T u, bdigit_t d)
+	/* Compute w = u + d, 
+	returns 1 if we had a carry */
+{
+	DIGIT_T carry;
+	size_t dig_size = max(u->ndigits, 1);
+
+	assert(w && u);
+	bd_resize(w, dig_size + 1);
+
+	carry = mpShortAdd(w->digits, u->digits, d, dig_size);
+
+	/* Cope with overflow */
+	if (carry)
+	{
+		w->digits[dig_size] = carry;
+		w->ndigits = dig_size + 1;
+	}
+	else
+		w->ndigits = dig_size;	
+
+	return carry;
+}
+
+int bdAdd(T w, T u, T v)
+	/* Compute w = u + v, w#v */
+{
+	size_t dig_size;
+	DIGIT_T carry;
+
+	assert(w && u && v);
+	/* Check for cheaper option */
+	if (v->ndigits == 1)
+		return bdShortAdd(w, u, v->digits[0]);
+
+	/* Make sure u and v are the same size */
+	dig_size = max(u->ndigits, v->ndigits);
+	bd_resize(v, dig_size);
+	bd_resize(u, dig_size);
+	/* Now make sure w is big enough for sum (incl carry) */
+	bd_resize(w, dig_size + 1);
+
+	/* Finally, do the business */
+	carry = mpAdd(w->digits, u->digits, v->digits, dig_size);
+
+	/* Make sure we've set the right size for w */
+	if (carry)
+	{
+		w->digits[dig_size] = carry;
+		w->ndigits = dig_size + 1;
+	}
+	else
+		w->ndigits = mpSizeof(w->digits, dig_size);	
+
+	return carry;
+}
+
+int bdAdd_s(T w, T u, T v)
+	/* Compute w = u + v (safe) */
+{
+	DIGIT_T carry;
+	T ww;
+
+	assert(w && u && v);
+	/* Use temp */
+	ww = bdNew();
+	bdSetEqual(ww, w);
+
+	carry = bdAdd(ww, u, v);
+
+	bdSetEqual(w, ww);
+	bdFree(&ww);
+
+	return carry;
+}
+
+int bdShortSub(T w, T u, bdigit_t d)
+	/* Compute w = u - d, return borrow */
+{
+	DIGIT_T borrow;
+	size_t dig_size = max(u->ndigits, 1);
+
+	assert(w && u);
+	bd_resize(w, dig_size);
+
+	borrow = mpShortSub(w->digits, u->digits, d, dig_size);
+
+	w->ndigits = dig_size;	
+
+	return borrow;
+}
+
+int bdSubtract(T w, T u, T v)
+	/* Compute w = u - v, return borrow, w#v */
+{
+	size_t dig_size;
+	DIGIT_T borrow;
+
+	assert(w && u && v);
+	/* Check for cheaper option */
+	if (v->ndigits == 1)
+		return bdShortSub(w, u, v->digits[0]);
+
+	/* Make sure u and v are the same size */
+	dig_size = max(u->ndigits, v->ndigits);
+	bd_resize(v, dig_size);
+	bd_resize(u, dig_size);
+	bd_resize(w, dig_size);
+
+	/* Finally, do the business */
+	borrow = mpSubtract(w->digits, u->digits, v->digits, dig_size);
+
+	/* Make sure we've set the right size for w */
+	w->ndigits = mpSizeof(w->digits, dig_size);	
+
+	return borrow;
+}
+
+int bdSubtract_s(T w, T u, T v)
+	/* Compute w = u - v (safe) */
+{
+	DIGIT_T carry;
+	T ww;
+
+	assert(w && u && v);
+	/* Use temp */
+	ww = bdNew();
+	bdSetEqual(ww, w);
+
+	carry = bdSubtract(ww, u, v);
+
+	bdSetEqual(w, ww);
+	bdFree(&ww);
+
+	return carry;
+}
+
+int bdIncrement(T a)
+	/* Sets a = a + 1, returns carry */
+{
+	assert(a);
+	return bdShortAdd(a, a, 1);
+}
+
+int bdDecrement(T a)
+	/* Sets a = a - 1, returns borrow */
+{
+	assert(a);
+	return bdShortSub(a, a, 1);
+}
+
+int bdShortMult(T w, T u, bdigit_t d)
+	/* Compute w = u * d */
+{
+	DIGIT_T overflow;
+	size_t dig_size = u->ndigits;
+
+	assert(w && u);
+	/***************************************************/
+	// [2013-06-05]: catch empty u; make sure w is empty
+	if (dig_size == 0 || d == 0)
+	{	/* u == 0 */
+		bd_resize(w, 0);
+		return 0;
+	}
+	/***************************************************/
+	bd_resize(w, dig_size+1);
+
+	overflow = mpShortMult(w->digits, u->digits, d, dig_size);
+
+	/* Cope with overflow */
+	if (overflow)
+	{
+		w->digits[dig_size] = overflow;
+		w->ndigits = dig_size + 1;
+	}
+	else
+		w->ndigits = mpSizeof(w->digits, dig_size);	
+
+	return 0;
+}
+
+int bdMultiply(T w, T u, T v)
+	/* Compute w = u * v 
+	   -- no overlap permitted
+	*/
+{
+	size_t dig_size;
+
+	assert(w && u && v);
+	/* Check for cheaper option */
+	if (v->ndigits == 1)
+		return bdShortMult(w, u, v->digits[0]);
+
+	/* Make sure u and v are the same size */
+	dig_size = max(u->ndigits, v->ndigits);
+	bd_resize(v, dig_size);
+	bd_resize(u, dig_size);
+	/* Now make sure w is big enough for product */
+	bd_resize(w, 2 * dig_size);
+
+	/* Finally, do the business */
+	mpMultiply(w->digits, u->digits, v->digits, dig_size);
+
+	/* Make sure we've set the right size for w */
+	w->ndigits = mpSizeof(w->digits, 2 * dig_size);	
+
+	return 0;
+}
+
+int bdMultiply_s(T w, T u, T v)
+	/* Compute w = u * v (safe) */
+{
+	T ww;
+
+	assert(w && u && v);
+	/* Use temp */
+	ww = bdNew();
+	bdSetEqual(ww, w);
+
+	bdMultiply(ww, u, v);
+
+	bdSetEqual(w, ww);
+	bdFree(&ww);
+
+	return 0;
+}
+
+int bdSquare(T w, T x)
+	/* Computes w = x^2, w#x */
+{
+	size_t dig_size;
+
+	assert(w && x);
+
+	dig_size = max(x->ndigits, 1);
+	/* Make sure w is big enough for product */
+	bd_resize(w, 2 * dig_size);
+
+	/* Finally, do the business */
+	mpSquare(w->digits, x->digits, dig_size);
+
+	/* Make sure we've set the right size for w */
+	w->ndigits = mpSizeof(w->digits, 2 * dig_size);	
+
+	return 0;
+}
+
+int bdSquare_s(T w, T x)
+	/* Compute w = x^2 (safe) */
+{
+	T ww;
+
+	assert(w && x);
+	/* Use temp */
+	ww = bdNew();
+	bdSetEqual(ww, w);
+
+	bdSquare(ww, x);
+
+	bdSetEqual(w, ww);
+	bdFree(&ww);
+
+	return 0;
+}
+
+int bdPower(BIGD y, BIGD g, unsigned short int n)
+/* Computes y = g^n (up to available memory!) */
+{
+	BIGD z;
+	z = bdNew();
+	/* Use Right-Left Binary */
+	/* 1. Set y <-- 1, z <-- g */
+	bdSetShort(y, 1);
+	bdSetEqual(z, g);
+	/* If n = 0, output y and stop */
+	while (n > 0)
+	{
+		/* 2. If n is odd, set y <-- z.y */
+		if (n & 0x1)
+			bdMultiply_s(y, z, y);
+		/* 3. Set n <-- [n/2]. If n = 0, output y and stop */
+		n >>= 1;
+		if (n > 0)
+			/* 3b. Otherwise set z <-- z.z and go to step 2 */
+			bdSquare_s(z, z);
+	}
+	bdFree(&z);
+	/* Result is in y */
+	return 0;
+}
+
+int bdSqrt(BIGD s, BIGD x)
+	/* Computes integer square root s = floor(sqrt(x)) */
+{
+	size_t dig_size;
+	int r;
+
+	assert(s && x);
+	dig_size = x->ndigits;
+	bd_resize(s, dig_size);
+	r = mpSqrt(s->digits, x->digits, dig_size);
+	s->ndigits = mpSizeof(s->digits, dig_size);
+
+	return r;
+}
+
+int bdCubeRoot(BIGD s, BIGD x)
+	/* Computes integer cube root s = floor(cuberoot(x)) */
+{
+	size_t dig_size;
+	int r;
+
+	assert(s && x);
+	dig_size = x->ndigits;
+	bd_resize(s, dig_size);
+	r = mpCubeRoot(s->digits, x->digits, dig_size);
+	s->ndigits = mpSizeof(s->digits, dig_size);
+
+	return r;
+}
+
+int bdShortDiv(T q, T r, T u, bdigit_t d)
+	/* Computes quotient q = u / d and remainder r = u mod d */
+{
+	DIGIT_T rem;
+	size_t dig_size;
+
+	assert(q && r && u);
+	dig_size = u->ndigits;
+	bd_resize(q, dig_size);
+
+	rem = mpShortDiv(q->digits, u->digits, d, dig_size);
+	bdSetShort(r, rem);
+
+	q->ndigits = mpSizeof(q->digits, dig_size);
+
+	return 0;
+}
+
+int bdDivide(T q, T r, T u, T v)
+	/* Computes quotient q = u / v and remainder r = u mod v 
+	   trashes q and r first
+	*/
+{
+	size_t dig_size;
+
+	assert(q && r && u && v);
+	dig_size = u->ndigits;
+	bd_resize(q, dig_size);
+	bd_resize(r, dig_size);
+
+	/* Do the business */
+	mpDivide(q->digits, r->digits, u->digits, dig_size, v->digits, v->ndigits);
+
+	/* Set final sizes */
+	q->ndigits = mpSizeof(q->digits, dig_size);
+	r->ndigits = mpSizeof(r->digits, dig_size);
+
+	return 0;
+}
+
+int bdDivide_s(T q, T r, T u, T v)
+	/* Computes quotient q = u / v and remainder r = u mod v (safe) */
+{
+	size_t dig_size;
+	BIGD qq, rr;
+
+	assert(q && r && u && v);
+	/* Use temps because mpDivide trashes q and r */
+	qq = bdNew();
+	rr = bdNew();
+
+	dig_size = u->ndigits;
+	bd_resize(qq, dig_size);
+	bd_resize(rr, dig_size);
+
+	/* Do the business */
+	mpDivide(qq->digits, rr->digits, u->digits, dig_size, v->digits, v->ndigits);
+
+	/* Copy temps */
+	qq->ndigits = dig_size;
+	rr->ndigits = dig_size;
+	bdSetEqual(q, qq);
+	bdSetEqual(r, rr);
+
+	/* Set final sizes */
+	q->ndigits = mpSizeof(q->digits, dig_size);
+	r->ndigits = mpSizeof(r->digits, dig_size);
+
+	/* Free temps */
+	bdFree(&qq);
+	bdFree(&rr);
+
+	return 0;
+}
+
+bdigit_t bdShortMod(T r, T u, bdigit_t d)
+	/* Returns r = u mod d */
+{
+	DIGIT_T rr;
+
+	assert(r && u);
+	rr = mpShortMod(u->digits, d, u->ndigits);
+	bdSetShort(r, rr);
+
+	return rr;
+}
+
+int bdModulo(T r, T u, T v)
+	/* Computes r = u mod v, r#u */
+{
+	size_t nr;
+
+	assert(r && u && v);
+
+	/* NB r is only vdigits long at most */
+	nr = v->ndigits;
+	bd_resize(r, nr);
+
+	/* Do the business */
+	mpModulo(r->digits, u->digits, u->ndigits, v->digits, v->ndigits);
+
+	/* Set final size */
+	r->ndigits = mpSizeof(r->digits, nr);
+
+	return 0;
+}
+
+int bdModulo_s(T r, T u, T v)
+	/* Computes r = u mod v (safe) */
+{
+	T rr;
+
+	assert(r && u && v);
+	/* Use temp */
+	rr = bdNew();
+	bdSetEqual(rr, r);
+
+	bdModulo(rr, u, v);
+
+	bdSetEqual(r, rr);
+	bdFree(&rr);
+
+	return 0;
+}
+
+int bdSetBit(T a, size_t ibit, int value)
+/* Set bit ibit (0..nbits-1) with value 1 or 0 
+   -- increases size if a too small but does not shrink */
+{
+	size_t idigit;
+
+	assert(a);
+	/* Which digit? (0-based) */
+	idigit = ibit / BITS_PER_DIGIT;
+	/* Check size */
+	/* [EDIT v2.1:] change a->maxdigits to a->ndigits */
+	if (idigit >= a->ndigits)
+	{
+		bd_resize(a, idigit+1);
+		a->ndigits = idigit+1;
+	}
+
+	/* [v2.2] use mp function */
+	mpSetBit(a->digits, a->ndigits, ibit, value);
+
+	/* Set the right size */
+	a->ndigits = mpSizeof(a->digits, a->ndigits);
+
+	return 0;
+}
+
+int bdGetBit(T a, size_t ibit)
+/* Returns value 1 or 0 of bit ibit (0..nbits-1) */
+{
+	size_t idigit;
+
+	assert(a);
+	/* Which digit? (0-based) */
+	idigit = ibit / BITS_PER_DIGIT;
+	/* Check size */
+	if (idigit >= a->maxdigits)
+		return 0;
+
+	/* [v2.2] use mp function */
+	return mpGetBit(a->digits, a->ndigits, ibit);
+}
+
+void bdShiftLeft(T a, T b, size_t s)
+	/* Computes a = b << s */
+{ 
+	/* Increases the size of a if necessary. */
+	/* [v2.1.0] modified to allow any size of shift */
+
+	size_t dig_size = b->ndigits;
+	
+	assert(a && b);
+
+	if (s >= BITS_PER_DIGIT)
+		dig_size += (s / BITS_PER_DIGIT);
+	
+	/* Assume overflow */
+	dig_size++;
+	/* Make sure both big enough */
+	bd_resize(a, dig_size);
+	bd_resize(b, dig_size);
+
+	/* Set the final size */
+	mpShiftLeft(a->digits, b->digits, s, dig_size);
+
+	a->ndigits = mpSizeof(a->digits, dig_size);
+
+}
+
+void bdShiftRight(T a, T b, size_t n)
+	/* Computes a = b >> n */
+{ 
+	/* Throws away shifted bits */
+	/* [v2.1.0] modified to allow any size of shift */
+
+	size_t dig_size = b->ndigits;
+	
+	assert(a && b);
+
+	bd_resize(a, dig_size);
+	mpShiftRight(a->digits, b->digits, n, dig_size);
+
+	/* Set the final size */
+	a->ndigits = mpSizeof(a->digits, dig_size);
+
+}
+
+void bdXorBits(T a, T b, T c)
+	/* Computes bitwise operation a = b XOR c */
+{ 
+	size_t n;
+
+	assert(a && b && c);
+	/* Make sure all variables are the same size */
+	n = max(b->ndigits, c->ndigits);
+
+	bd_resize(a, n);
+	bd_resize(b, n);
+	bd_resize(c, n);
+
+	/* Do the business */
+	mpXorBits(a->digits, b->digits, c->digits, n);
+
+	/* Set the final size */
+	a->ndigits = mpSizeof(a->digits, n);
+
+}
+
+void bdOrBits(T a, T b, T c)
+	/* Computes bitwise operation a = b OR c */
+{ 
+	size_t n;
+
+	assert(a && b && c);
+	/* Make sure all variables are the same size */
+	n = max(b->ndigits, c->ndigits);
+
+	bd_resize(a, n);
+	bd_resize(b, n);
+	bd_resize(c, n);
+
+	/* Do the business */
+	mpOrBits(a->digits, b->digits, c->digits, n);
+
+	/* Set the final size */
+	a->ndigits = mpSizeof(a->digits, n);
+
+}
+
+void bdAndBits(T a, T b, T c)
+	/* Computes bitwise operation a = b AND c */
+{ 
+	size_t n;
+
+	assert(a && b && c);
+	/* Make sure all variables are the same size */
+	n = max(b->ndigits, c->ndigits);
+
+	bd_resize(a, n);
+	bd_resize(b, n);
+	bd_resize(c, n);
+
+	/* Do the business */
+	mpAndBits(a->digits, b->digits, c->digits, n);
+
+	/* Set the final size */
+	a->ndigits = mpSizeof(a->digits, n);
+}
+
+void bdNotBits(BIGD a, BIGD b)
+	/* Computes bitwise a = NOT b */
+{
+	size_t n;
+
+	assert(a && b);
+	/* Make sure all variables are the same size */
+	n = b->ndigits;
+
+	bd_resize(a, n);
+
+	/* Do the business */
+	mpNotBits(a->digits, b->digits, n);
+
+	/* Set the final size */
+	a->ndigits = mpSizeof(a->digits, n);
+}
+
+void bdModPowerOf2(BIGD a, size_t L)
+	/* Computes a = a mod 2^L */
+{
+	size_t n;
+
+	assert(a);
+	n = a->ndigits;
+
+	/* Do the business */
+	mpModPowerOf2(a->digits, n, L);
+
+	/* Set the final size */
+	a->ndigits = mpSizeof(a->digits, n);
+}
+
+/** Compute y = x^e mod m, x,e < m */
+static int modexp_internal(T y, T x, T e, T m, int constant_time)
+{
+	size_t n;
+	int status;
+
+	assert(y && x && e && m);
+	/* Make sure all variables are the same size */
+	n = max(e->ndigits, m->ndigits);
+	n = max(x->ndigits, n);
+
+	bd_resize(y, n);
+	bd_resize(x, n);
+	bd_resize(e, n);
+	bd_resize(m, n);
+
+	/* Finally, do the business */
+	if (constant_time)
+		status = mpModExp_ct(y->digits, x->digits, e->digits, m->digits, n);
+	else
+		status = mpModExp(y->digits, x->digits, e->digits, m->digits, n);
+
+	y->ndigits = mpSizeof(y->digits, n);
+
+	return status;
+}
+
+/** Compute y = x^e mod m, x,e < m */
+int bdModExp(BIGD y, BIGD x, BIGD e, BIGD m)
+{
+	return modexp_internal(y, x, e, m, 0);
+}
+
+/** Compute y = x^e mod m in constant time */
+int bdModExp_ct(BIGD y, BIGD x, BIGD e, BIGD m)
+{
+	return modexp_internal(y, x, e, m, 1);
+}
+
+/** Compute a = (x * y) mod m */
+int bdModMult(T a, T x, T y, T m)
+{
+	size_t n;
+	int status;
+
+	assert(a && x && y && m);
+	/* Make sure all variables are the same size */
+	n = max(y->ndigits, m->ndigits);
+	n = max(x->ndigits, n);
+
+	bd_resize(a, n);
+	bd_resize(y, n);
+	bd_resize(x, n);
+	bd_resize(m, n);
+
+	/* Do the business */
+	status = mpModMult(a->digits, x->digits, y->digits, m->digits, n);
+
+	a->ndigits = mpSizeof(a->digits, n);
+
+	return status;
+}
+
+/** Computes a = x^2 mod m */
+int bdModSquare(BIGD a, BIGD x, BIGD m)
+{
+	size_t n;
+	int status;
+
+	assert(a && x && m);
+	/* Make sure all variables are the same size */
+	n = max(x->ndigits, m->ndigits);
+
+	bd_resize(a, n);
+	bd_resize(x, n);
+	bd_resize(m, n);
+
+	/* Do the business */
+	status = mpModSquare(a->digits, x->digits, m->digits, n);
+
+	a->ndigits = mpSizeof(a->digits, n);
+
+	return status;
+}
+
+/** Computes x = sqrt(a) mod p */
+int bdModSqrt(BIGD x, BIGD a, BIGD p)
+{
+	size_t n;
+	int status;
+
+	assert(x && a && p);
+	/* Make sure all variables are the same size */
+	n = max(a->ndigits, p->ndigits);
+
+	bd_resize(x, n);
+	bd_resize(a, n);
+	bd_resize(p, n);
+
+	/* Do the business */
+	status = mpModSqrt(x->digits, a->digits, p->digits, n);
+
+	x->ndigits = mpSizeof(x->digits, n);
+
+	return status;
+}
+
+/** Computes w = u/2 (mod p) for an odd prime p */
+void bdModHalve(BIGD w, const BIGD u, const BIGD p)
+{
+	size_t n;
+
+	assert(w && u && p);
+	/* Make sure all variables are the same size */
+	n = max(u->ndigits, p->ndigits);
+
+	bd_resize(w, n);
+	bd_resize(u, n);
+	bd_resize(p, n);
+
+	/* Do the business */
+	mpModHalve(w->digits, u->digits, p->digits, n);
+
+	w->ndigits = mpSizeof(w->digits, n);
+}
+
+
+/* Computes w = u + v (mod m) for 0 <= u,v < m*/
+void bdModAdd(BIGD w, BIGD u, BIGD v, BIGD m)
+{
+	size_t n;
+
+	assert(w && u && v && m);
+	/* Make sure all variables are the same size */
+	n = max(v->ndigits, m->ndigits);
+	n = max(u->ndigits, n);
+
+	bd_resize(w, n);
+	bd_resize(u, n);
+	bd_resize(v, n);
+	bd_resize(m, n);
+
+	/* Do the business */
+	mpModAdd(w->digits, u->digits, v->digits, m->digits, n);
+
+	w->ndigits = mpSizeof(w->digits, n);
+}
+
+/* Computes w = u - v (mod m) for 0 <= u,v < m*/
+void bdModSub(BIGD w, BIGD u, BIGD v, BIGD m)
+{
+	size_t n;
+
+	assert(w && u && v && m);
+	/* Make sure all variables are the same size */
+	n = max(v->ndigits, m->ndigits);
+	n = max(u->ndigits, n);
+
+	bd_resize(w, n);
+	bd_resize(u, n);
+	bd_resize(v, n);
+	bd_resize(m, n);
+
+	/* Do the business */
+	mpModSub(w->digits, u->digits, v->digits, m->digits, n);
+
+	w->ndigits = mpSizeof(w->digits, n);
+}
+
+/** Compute x = a^-1 mod m */
+int bdModInv(T x, T a, T m)
+{
+	size_t n;
+	int status;
+
+	assert(x && a && m);
+	/* Make sure all variables are the same size */
+	n = max(a->ndigits, m->ndigits);
+
+	bd_resize(x, n);
+	bd_resize(a, n);
+	bd_resize(m, n);
+
+	/* Do the business */
+	status = mpModInv(x->digits, a->digits, m->digits, n);
+
+	x->ndigits = mpSizeof(x->digits, n);
+
+	return status;
+}
+
+int bdGcd(T g, T x, T y)
+	/* Compute g = gcd(x, y) */
+{
+	size_t n;
+	int status;
+
+	assert(g && x && y);
+	n = max(x->ndigits, y->ndigits);
+
+	bd_resize(g, n);
+	bd_resize(y, n);
+	bd_resize(x, n);
+
+	/* Do the business */
+	status = mpGcd(g->digits, x->digits, y->digits, n);
+
+	g->ndigits = mpSizeof(g->digits, n);
+
+	return status;
+}
+
+int bdJacobi(T a, T m)
+	/* Returns Jacobi(a, m) = {0, +1, -1} */
+{
+	size_t n;	/* Careful with n and m here! */
+	int status;
+
+	assert(a && m);
+	n = max(a->ndigits, m->ndigits);
+
+	bd_resize(a, n);
+	bd_resize(m, n);
+
+	/* Do the business */
+	status = mpJacobi(a->digits, m->digits, n);
+
+	return status;
+}
+
+int bdIsPrime(T b, size_t ntests)
+/* Returns true if passes ntests x Miller-Rabin tests */
+{
+	assert(b);
+	return (mpIsPrime(b->digits, b->ndigits, ntests));
+}
+
+int bdRabinMiller(T b, size_t ntests)
+/* Returns true if passes ntests x Miller-Rabin tests without trial division */
+{
+	assert(b);
+	return (mpRabinMiller(b->digits, b->ndigits, ntests));
+}
+
+/* [Version 2.1: bdRandDigit moved to bdRand.c] */
+
+
+/* Make a random BIGD of up to `ndigits` digits
+	-- NB just for doing tests
+	Return # digits actually set
+*/
+size_t bdSetRandTest(T a, size_t ndigits)
+{
+	/* Re-written [v2.6] */
+	size_t n;
+	size_t nbitstarget = ndigits * BITS_PER_DIGIT;
+
+	/* Half the time, pick a shorter bitlength at random from [4,nbits] 
+	   so at least a >= 16 */
+	if (spSimpleRand(0, 1)) {
+		n = (size_t)spSimpleRand(4, (DIGIT_T)nbitstarget);
+	}
+	else {
+		n = nbitstarget;
+	}
+
+	bdQuickRandBits(a, n);
+	/* Make sure a > 1 */
+	if (bdShortCmp(a, 2) < 0)
+		bdQuickRandBits(a, nbitstarget);
+
+	return bdSizeof(a);
+
+}
+
+/** Generate a quick-and-dirty random number a <= 2^{nbits}-1 using plain-old-rand 
+ *  @return Number of digits actually set
+ *  @remark Not crypto secure
+ */	/* Added [v2.4] */
+size_t bdQuickRandBits(T a, size_t nbits)
+{
+	size_t n;
+
+	assert(a);
+	n = (nbits + BITS_PER_DIGIT - 1) / BITS_PER_DIGIT;
+	bd_resize(a, n);
+	n = mpQuickRandBits(a->digits, n, nbits);
+	a->ndigits = n;
+
+	return n;
+}
+
+int bdRandomSeeded(T a, size_t nbits, const unsigned char *seed, 
+	size_t seedlen, BD_RANDFUNC RandFunc)
+/* Create a random mp digit at most nbits long
+   -- high bit may or may not be set
+   -- Uses whatever RNG function the user specifies */
+{
+	size_t i, hibit, ndigits, nbytes;
+	DIGIT_T chop;
+
+	assert(a);
+	/* Make sure big enough */
+	ndigits = (nbits + BITS_PER_DIGIT - 1) / BITS_PER_DIGIT;
+	bd_resize(a, ndigits);
+	nbytes = ndigits * sizeof(DIGIT_T);
+
+	/* Generate random bytes using callback function */
+	RandFunc((unsigned char *)a->digits, nbytes, seed, seedlen);
+
+	/* Clear unwanted high bits */
+	hibit = (nbits-1) % BITS_PER_DIGIT;
+	for (chop = 0x01, i = 0; i < hibit; i++)
+		chop = (chop << 1) | chop;
+
+	a->digits[ndigits-1] &= chop;
+
+	a->ndigits = ndigits;
+
+	return 0;
+}
+
+
+int bdGeneratePrime(T b, size_t nbits, size_t ntests, 
+	const unsigned char *seed, size_t seedlen, BD_RANDFUNC RandFunc)
+{
+	size_t i, hibit, ndigits, nbytes;
+	DIGIT_T mask, chop;
+	DIGIT_T *p;
+	int done;
+	size_t iloop, maxloops, j, maxodd;
+
+	assert(b);
+	/* Make sure big enough */
+	ndigits = (nbits + BITS_PER_DIGIT - 1) / BITS_PER_DIGIT;
+	bd_resize(b, ndigits);
+	nbytes = ndigits * sizeof(DIGIT_T);
+
+	/* use a ptr */
+	p = b->digits;
+
+	maxloops = 5;
+	maxodd = 100 * nbits;
+	done = 0;
+	for (iloop = 0; !done && iloop < maxloops; iloop++)
+	{
+		/* Generate random digits using callback function */
+		RandFunc((unsigned char *)p, nbytes, seed, seedlen);
+
+		/* Set high and low bits */
+		hibit = (nbits-1) % BITS_PER_DIGIT;
+		mask = 0x01 << hibit;
+		for (chop = 0x01, i = 0; i < hibit; i++)
+			chop = (chop << 1) | chop;
+
+		p[ndigits-1] |= mask;
+		p[ndigits-1] &= chop;
+		p[0] |= 0x01;
+
+		/* Try each odd number until success or too many tries */
+		for (j = 0; !done && j < maxodd; j++, mpShortAdd(p, p, 2, ndigits))
+		{
+			if (!(p[ndigits-1] & mask))
+				break;	/* Catch overflow */
+
+			if (debug) mpPrintNL(p, ndigits);
+
+			if (mpIsPrime(p, ndigits, ntests))
+			{
+				done = 1;
+				break;
+			}
+		}
+	}
+
+	if (debug) mpPrintNL(p, ndigits);
+
+	b->ndigits = ndigits;
+
+	return (done ? 0 : 1);
+}
+
+/* Version Info - added in [v2.0.2] */
+int bdVersion(void)
+{
+	return mpVersion();
+}
+
+/* Added [v2.6] */
+const char *bdCompileTime(void)
+{
+	return __DATE__" "__TIME__;
+}
+

--- a/src/bigd.h
+++ b/src/bigd.h
@@ -1,0 +1,669 @@
+/* $Id: bigd.h $ */
+
+/***** BEGIN LICENSE BLOCK *****
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2001-16 David Ireland, D.I. Management Services Pty Limited
+ * <http://www.di-mgt.com.au/bigdigits.html>. All rights reserved.
+ *
+ ***** END LICENSE BLOCK *****/
+/*
+ * Last updated:
+ * $Date: 2016-03-31 09:51:00 $
+ * $Revision: 2.6.1 $
+ * $Author: dai $
+ */
+
+/* ANNOTATION FOR DOXYGEN... */
+
+/** @mainpage notitle
+
+@section intro_sec Introduction
+
+BigDigits is a free library of multiple-precision arithmetic routines written in ANSI C 
+to carry out calculations with the large natural numbers used in cryptography computations.
+
+You can download it from http://www.di-mgt.com.au/bigdigits.html.
+
+The BigDigits library is designed to work with the set of natural numbers \b N; 
+that is, the non-negative integers 0,1,2,... . 
+
+The library has two interfaces: the "bd" library and the underlying "mp" library.
+The "bd" functions use an opaque BIGD object and
+handle memory allocation automatically.
+The "mp" functions use fixed-length arrays and
+require a bit more care to use but the "mp" library is faster and
+has an option (`NO_ALLOCS`) to avoid all memory allocation calls completely.
+The "bd" library is an easier-to-use wrapper around the "mp" library.
+
+The "bd" functions are described in bigd.h and the more elementary "mp" functions are in bigdigits.h.
+
+There are some optional functions that generate random numbers using a "pretty-good" internal RNG 
+in bigdRand.h and bigdigitsRand.h for the "bd" and "mp" libraries, respectively.
+
+*/
+
+/** @file
+	Interface to the BigDigits "bd" functions using BIGD objects with automatic memory allocation
+
+@par PROGRAMMER'S NOTES
+Where the function computes a new BIGD value,
+the result is returned in the first argument.
+Some functions do not allow variables to overlap.
+Functions of type `int` generally return 0 to denote success 
+but some return True/False (1/0) or borrow (+1) or error (-1).
+Functions of type `size_t` (an unsigned int) return a length.
+
+@par Memory allocation
+Memory for each variable is allocated as required and is increased automatically if needed.
+However, memory for a variable is only released when freed with bdFree(). 
+The standard code for a variable `b` should be as follows:
+@code
+	BIGD b;
+	b = bdNew();
+	// operations using b...
+	bdFree(&b);
+@endcode*/
+
+
+#ifndef BIGD_H_
+#define BIGD_H_ 1
+
+#include "bigdtypes.h"
+
+/**** USER CONFIGURABLE SECTION ****/
+
+/* [v2.1] Changed to use exact width integer types.
+   [v2.2] Moved macros for exact-width types to "bigdtypes.h"
+*/
+
+/** A synonym for a single digit (DIGIT_T is not exposed) */
+typedef uint32_t bdigit_t;
+
+/**** END OF USER CONFIGURABLE SECTION ****/
+/** @cond */
+/**** OPTIONAL PREPROCESSOR DEFINITIONS ****/
+/* 
+   Choose one of { USE_SPASM | USE_64WITH32 }
+   USE_SPASM: to use the faster x86 ASM routines (if __asm option is available with your compiler).
+   USE_64WITH32: to use the 64-bit integers if available (e.g. long long).
+   Default: use default internal routines spDivide and spMultiply.
+   The USE_SPASM option takes precedence over USE_64WITH32.
+*/
+
+#ifdef NO_ALLOCS 
+#error NO_ALLOCS is not permitted with bd functions
+#endif
+
+/*
+This interface uses opaque pointers of type BIGD using
+the conventions in "C Interfaces and Implementions" by
+David R. Hanson, Addison-Wesley, 1996, pp21-4.
+Thanks to Ian Tree for the C++ fudge.
+*/
+#define T BIGD
+#ifdef __cplusplus
+	typedef struct T2 *T;
+#else
+	typedef struct T *T;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/** @endcond */
+
+
+/******************************/
+/* CONSTRUCTOR AND DESTRUCTOR */
+/******************************/
+/** Create new BIGD object
+@returns Handle to new object
+*/
+BIGD bdNew(void);
+
+/** Destroy BIGD object: zeroise contents and free allocated memory.
+@remark Pass a *pointer* to the handle
+*/
+void bdFree(BIGD *bd);
+
+/** Create a set of BIGD objects
+@code
+BIGD a, b, c;
+bdNewVars(&a, &b, &c, NULL);
+// do stuff with variables a, b, c...
+bdFreeVars(&a, &b, &c, NULL);
+@endcode
+The `bdNewVars` function call above is equivalent to
+@code
+a = bdNew();
+b = bdNew();
+c = bdNew();
+@endcode
+
+@warning The list *must* finish with `NULL`
+ */
+void bdNewVars(BIGD *pb1, ...);
+
+
+/** Destroy a set of BIGD objects
+@code
+BIGD a, b, c;
+bdNewVars(&a, &b, &c, NULL);
+// do stuff with variables a, b, c...
+bdFreeVars(&a, &b, &c, NULL);
+@endcode
+The `bdFreeVars` function call above is equivalent to
+@code
+bdFree(&a);
+bdFree(&b);
+bdFree(&c);
+@endcode
+
+@warning The list *must* finish with `NULL`
+ */
+void bdFreeVars(BIGD *pb1, ...);
+
+
+/*************************/
+/* ARITHMETIC OPERATIONS */
+/*************************/
+
+/** Compute sum w = u + v
+@return carry
+@remark `w` and `v` must be separate variables. 
+Use bdAdd_s() to avoid overlap restriction.
+*/
+int bdAdd(BIGD w, BIGD u, BIGD v);
+
+/** Compute difference w = u - v
+@return borrow
+@remark `w` and `v` must be separate variables.
+Use bdSubtract_s() to avoid overlap restriction.
+@warning Behaviour is undefined for negative numbers.
+*/
+int bdSubtract(BIGD w, BIGD u, BIGD v);
+
+/** Compute product w = u * v
+@remark `w` and `u` must be separate variables.
+Use bdMultiply_s() to avoid overlap restriction.
+*/
+int bdMultiply(BIGD w, BIGD u, BIGD v);
+
+/** Compute integer division of u by v such that u=qv+r
+@param[out] q To receive quotient = u div v
+@param[out] r To receive remainder = u mod v
+@param[in] u Dividend
+@param[in] v Divisor
+@remark Trashes q and r first: `q` and `r` must be independent of `u` and `v`.
+Use bdDivide_s() to avoid overlap restriction.
+*/
+int bdDivide(BIGD q, BIGD r, BIGD u, BIGD v);
+
+/** Compute remainder r = u mod v
+@remark `r` and `u` must be separate variables.
+Use bdModulo_s() to avoid overlap restriction.
+*/
+int bdModulo(BIGD r, BIGD u, BIGD v);
+
+/** Compute square w = x^2
+@remark `w` and `x` must be separate variables.
+Use bdSquare_s() to avoid overlap restriction.
+*/
+int bdSquare(BIGD w, BIGD x);
+
+/** Computes y = g^n (up to available memory!) 
+@remark Be very careful that `n` is not too large
+*/
+int bdPower(BIGD y, BIGD g, unsigned short int n);
+
+/** Computes integer square root s = floor(sqrt(x)) */
+int bdSqrt(BIGD s, BIGD x);
+
+/** Computes integer cube root s = floor(cuberoot(x)) */
+int bdCubeRoot(BIGD s, BIGD x);
+
+/** Sets a = a + 1
+@return carry */
+int bdIncrement(BIGD a);
+
+/** Sets a = a - 1
+@return borrow 
+@warning Behaviour is undefined if a becomes negative.
+*/
+int bdDecrement(BIGD a);
+
+/* 'Safe' versions with no restrictions on overlap */
+/* [v2.2] Changed name from ~Ex to ~_s */
+
+/** Compute w = u + v without restrictions on overlap of bdAdd() */
+int bdAdd_s(BIGD w, BIGD u, BIGD v);
+/** Compute w = u - v without restrictions on overlap of bdSubtract() */
+int bdSubtract_s(BIGD w, BIGD u, BIGD v);
+/** Compute w = u * v without restrictions on overlap of bdMultiply() */
+int bdMultiply_s(BIGD w, BIGD u, BIGD v);
+/** Compute u div v without restrictions on overlap of bdDivide() */
+int bdDivide_s(BIGD q, BIGD r, BIGD u, BIGD v);
+/** Compute u mod v without restrictions on overlap of bdModulo() */
+int bdModulo_s(BIGD r, BIGD u, BIGD v);
+/** Compute s = x * x without restrictions on overlap of bdSquare() */
+int bdSquare_s(BIGD s, BIGD x);
+
+/* Keep the faith with the deprecated ~Ex version names */
+#define bdAddEx(w, u, v) bdAdd_s((w), (u), (v))
+#define bdSubtractEx(w, u, v) bdSubtract_s((w), (u), (v))
+#define bdMultiplyEx(w, u, v) bdMultiply_s((w), (u), (v))
+#define bdDivideEx(q, r, u, v) bdDivide_s((q), (r), (u), (v))
+#define bdModuloEx(r, u, v) bdModulo_s((r), (u), (v))
+#define bdSquareEx(s, x) bdSquare_s((s), (x))
+
+
+/*************************/
+/* COMPARISON OPERATIONS */
+/*************************/
+
+/** Returns true (1) if a == b, else false (0) 
+ *  @remark Not constant-time
+ */
+int bdIsEqual(BIGD a, BIGD b);
+
+/** Returns sign of `(a-b)` in `{0,1,-1}` 
+ *  @remark Not constant-time
+ */
+int bdCompare(BIGD a, BIGD b);
+
+/** Returns true (1) if a is zero, else false (0) 
+ *  @remark Not constant-time
+ */
+int bdIsZero(BIGD a);
+
+/** Returns true (1) if a is even, else false (0) */
+int bdIsEven(BIGD a);
+
+/** Returns true (1) if a is odd, else false (0) */
+int bdIsOdd(BIGD a);
+
+/***************************************/
+/* CONSTANT-TIME COMPARISON ALGORITHMS */
+/***************************************/
+/* -- added in [v2.6] */
+
+/** Returns true if a == b, else false, using constant-time algorithm */
+int bdIsEqual_ct(BIGD a, BIGD b);
+
+/** Returns sign of `(a-b)` as `{-1,0,+1}` using constant-time algorithm */
+int bdCompare_ct(BIGD a, BIGD b);
+
+/** Returns true if a is zero, else false, using constant-time algorithm */
+int bdIsZero_ct(BIGD a);
+
+/*************************/
+/* ASSIGNMENT OPERATIONS */
+/*************************/
+
+/** Sets a = b */
+int bdSetEqual(BIGD a, BIGD b);
+
+/** Sets a = 0 */
+int bdSetZero(BIGD a);
+
+
+/****************************/
+/* NUMBER THEORY OPERATIONS */
+/****************************/
+
+/** Computes y = x^e mod m */
+int bdModExp(BIGD y, BIGD x, BIGD e, BIGD m);
+
+/**	Computes y = x^e mod m in constant time 
+ *  @remark Resistant to simple power analysis attack on private exponent. 
+ *  Slower than bdModExp(). 
+ */
+int bdModExp_ct(BIGD y, BIGD x, BIGD e, BIGD m);
+
+/** Computes a = (x * y) mod m */
+int bdModMult(BIGD a, BIGD x, BIGD y, BIGD m);
+
+/** Computes a = x^2 mod m */
+int bdModSquare(BIGD a, BIGD x, BIGD m);
+
+/** Computes the inverse of `a` modulo `m`, `x = a^{-1} mod m` */
+int bdModInv(BIGD x, BIGD a, BIGD m);
+
+/** Computes g = gcd(x, y), the greatest common divisor of x and y */
+int bdGcd(BIGD g, BIGD x, BIGD y);
+
+/** Returns the Jacobi symbol (a/n) = {-1, 0, +1} 
+@remark If n is prime then the Jacobi symbol becomes the Legendre symbol (a/p) defined to be
+- (a/p) = +1 if a is a quadratic residue modulo p
+- (a/p) = -1 if a is a quadratic non-residue modulo p
+- (a/p) = 0 if a is divisible by p
+*/
+int bdJacobi(BIGD a, BIGD n);
+
+
+/** Computes x = one square root of an integer `a` modulo an odd prime `p`
+*  @param x To receive the result
+*  @param a An integer expected to be a quadratic residue modulo p
+*  @param p An odd prime
+*  @return 0 if successful, or -1 if square root does not exist
+*  @remark More precisely, find an integer x such that x^2 mod p = a.
+*  Uses the Tonelli-Shanks algorithm. The other square root is `p - x`.
+*  @warning Check the return value before using the result `x`.
+*/
+int bdModSqrt(BIGD x, BIGD a, BIGD p);
+
+
+/** Computes w = u/2 (mod p) for an odd prime p
+ *  @pre Require u to be in the range `[0,p-1]` 
+ */
+void bdModHalve(BIGD w, const BIGD u, const BIGD p);
+
+
+/** Computes w = u + v (mod m)
+*  @pre Require u and v to be in the range `[0, m-1]`.
+*  The variables `w` and `v` must not overlap.
+*  @remark Quicker than adding then using mpModulo()
+*/
+void bdModAdd(BIGD w, BIGD u, BIGD v, BIGD m);
+
+
+/** Computes w = u - v (mod m)
+*  @pre Require u and v to be in the range `[0, m-1]`.
+*  The variables `w` and `v` must not overlap.
+*  @remark Quicker than subtracting then using mpModulo()
+*/
+void bdModSub(BIGD w, BIGD u, BIGD v, BIGD m);
+
+
+/** Returns true (1) if `b` is probably prime 
+@param[in] b Number to test
+@param[in] ntests The count of Rabin-Miller primality tests to carry out (recommended at least 80)
+@returns true (1) if b is probably prime otherwise false (0)
+@remark Uses FIPS-186-2/Rabin-Miller with trial division by small primes, 
+which is faster in most cases than bdRabinMiller().
+@see bdRabinMiller().
+*/
+int bdIsPrime(BIGD b, size_t ntests);
+
+/** Returns true (1) if `b` is probably prime using just the Rabin-Miller test
+@param[in] b Number to test (b > 2)
+@param[in] ntests The count of Rabin-Miller primality tests to carry out (recommended at least 80)
+@returns true (1) if b is probably prime otherwise false (0)
+@remark bdIsPrime() is the recommended function to test for primality. 
+Use this variant if, for some reason, 
+you do not want to do the quicker trial division tests first.
+@see bdIsPrime()
+*/
+int bdRabinMiller(BIGD b, size_t ntests);
+
+
+/**********************************************/
+/* FUNCTIONS THAT OPERATE WITH A SINGLE DIGIT */
+/**********************************************/
+/* [v2.6] Added bdShortIsEqual() and bdToShort() */
+
+/** Converts a single digit into a BIGD
+@param[out] b To receive the result
+@param[in] d A single digit
+@remark Use this to set a BIGD variable to a small integer.
+*/
+int bdSetShort(BIGD b, bdigit_t d);
+
+/** Computes w = u + d where d is a single digit 
+@return carry
+*/
+int bdShortAdd(BIGD w, BIGD u, bdigit_t d);
+
+/** Computes w = u - d where d is a single digit 
+@return borrow
+*/
+int bdShortSub(BIGD w, BIGD u, bdigit_t d);
+
+/** Computes w = u * d where d is a single digit */
+int bdShortMult(BIGD w, BIGD u, bdigit_t d);
+
+/** Computes integer division of u by single digit d
+@param[out] q To receive quotient = u div d
+@param[out] r To receive remainder = u mod d
+@param[in] u Dividend, a BIGD object
+@param[in] d Divisor, a single digit
+@remark A separate BIGD object `r` must be provided to receive the remainder.
+*/
+int bdShortDiv(BIGD q, BIGD r, BIGD u, bdigit_t d);
+
+/** Computes r = u mod d where d is a single digit */
+bdigit_t bdShortMod(BIGD r, BIGD u, bdigit_t d);
+
+/** Returns sign of (a-d) where d is a single digit */
+int bdShortCmp(BIGD a, bdigit_t d);
+
+/** Returns true if a == d, else false, where d is a single digit */
+int bdShortIsEqual(BIGD a, bdigit_t d);
+
+/** Returns the least significant digit in b 
+ *  @return A single digit equal to the least significant digit in b
+ *  @remark Use this to convert (truncate) a BIGD object into a short integer
+ */
+bdigit_t bdToShort(BIGD b);
+
+
+/***********************/
+/* BIT-WISE OPERATIONS */
+/***********************/
+/* [v2.1.0] Added ModPowerOf2, Xor, Or and AndBits functions */
+/* [v2.2.0] Added NotBits, GetBit, SetBit functions */
+
+/** Returns number of significant bits in b */
+size_t bdBitLength(BIGD b);
+
+/** Set bit n of a (0..nbits-1) with value 1 or 0 */
+int bdSetBit(BIGD a, size_t n, int value);
+
+/** Returns value 1 or 0 of bit n of a (0..nbits-1) */
+int bdGetBit(BIGD a, size_t ibit);
+
+/** Computes a = b << n  */
+void bdShiftLeft(BIGD a, BIGD b, size_t n);
+
+/** Computes a = b >> n */
+void bdShiftRight(BIGD a, BIGD b, size_t n);
+
+/** Computes a = a mod 2^L, ie clears all bits greater than L */
+void bdModPowerOf2(BIGD a, size_t L);
+
+/** Computes bitwise operation a = b XOR c */
+void bdXorBits(BIGD a, BIGD b, BIGD c);
+
+/** Computes bitwise operation a = b OR c */
+void bdOrBits(BIGD a, BIGD b, BIGD c);
+
+/** Computes bitwise operation a = b AND c */
+void bdAndBits(BIGD a, BIGD b, BIGD c);
+
+/** Computes bitwise a = NOT b 
+@remark This flips all the bits up to the most significant digit, which may not be exactly what you want. */
+void bdNotBits(BIGD a, BIGD b);
+
+
+/*******************/
+/* MISC OPERATIONS */
+/*******************/
+
+/** Returns number of significant digits in b */
+size_t bdSizeof(BIGD b);
+
+/** Print b in hex format with optional prefix and suffix strings */
+void bdPrintHex(const char *prefix, BIGD b, const char *suffix);
+
+/** Print b in decimal format with optional prefix and suffix strings */
+void bdPrintDecimal(const char *prefix, BIGD b, const char *suffix);
+
+/** Print b in bit (0/1) format with optional prefix and suffix strings */
+void bdPrintBits(const char *prefix, BIGD b, const char *suffix);
+
+/* Options for bdPrint */
+#define BD_PRINT_NL   0x1	/* append a newline after printing */
+#define BD_PRINT_TRIM 0x2	/* trim leading zero digits */
+
+/** Print b in hex format to stdout
+@param[in] b Number to print
+@param[in] flags (see below)
+@remark Flags are
+- `0` default display leading zeros but no newline
+- `BD_PRINT_NL` `0x1` append a newline after printing
+- `BD_PRINT_TRIM` `0x2` trim leading zero digits
+@deprecated Use bdPrintHex() or bdPrintDecimal().
+*/
+void bdPrint(BIGD b, size_t flags);
+
+
+/***************/
+/* CONVERSIONS */
+/***************/
+/* All bdConv functions return 0 on error */
+/* "Octet" = an 8-bit byte */
+
+/** Converts a byte array into a BIGD object
+@param[out] b To receive the result
+@param[in] octets Pointer to array of bytes (octets)
+@param[in] nbytes Number of bytes in sequence
+@returns Number of digits actually set, which may be larger than bdSizeof(BIGD b).
+*/
+size_t bdConvFromOctets(BIGD b, const unsigned char *octets, size_t nbytes);
+
+/** Converts a BIGD into an array of bytes, in big-endian order
+@param[in] b BIGD object to be converted
+@param[out] octets Array of bytes (octets) to receive output
+@param[in] nbytes Length of array to receive output
+@returns Exact number of significant bytes in the result. 
+	If `octets` is NULL or `nbytes` is zero then just returns required size (nsig).
+@remark Will pad on the left with zeros if `nbytes` is larger than required,
+	or will truncate from the left if it is too short.
+- if nbytes = nsig, octets <--    mmmnnn;
+- if nbytes > nsig, octets <-- 000mmmnnn;
+- if nbytes < nsig, octets <--       nnn. 
+*/
+size_t bdConvToOctets(BIGD b, unsigned char *octets, size_t nbytes);
+
+
+/** Convert string of hexadecimal characters into a BIGD object
+@param[out] b To receive the result
+@param[in] s Null-terminated string of hex digits `[0-9A-Fa-f]`
+@returns Number of significant digits actually set, which could be 0.
+*/
+size_t bdConvFromHex(BIGD b, const char *s);
+
+/** Convert BIGD object into a string of hexadecimal characters
+@param[in] b BIGD object to be converted
+@param[out] s String buffer to receive output
+@param[in] smax Size of buffer *including* the terminating zero
+@returns Exact number of characters required *excluding* the terminating zero. 
+	If `s` is NULL or `smax` is zero then just returns required number.
+@code
+	char *s;
+	size_t nchars = bdConvToHex(b, NULL, 0);
+	s = malloc(nchars+1);  // NB add one extra
+	nchars = bdConvToHex(b, s, nchars+1);
+@endcode
+@remark Always returns the length of the string it tried to create, 
+	even if the actual output was truncated, so remember to check.
+*/
+size_t bdConvToHex(BIGD b, char *s, size_t smax);
+
+/** Convert string of decimal characters into a BIGD object
+@param[out] b To receive the result
+@param[in] s Null-terminated string of decimal digits `[0-9]`
+@returns Number of significant digits actually set, which could be 0.
+*/
+size_t bdConvFromDecimal(BIGD b, const char *s);
+
+/** Convert BIGD object into a string of decimal characters
+@param[in] b BIGD object to be converted
+@param[out] s String buffer to receive output
+@param[in] smax Size of buffer *including* the terminating zero
+@returns Exact number of characters required *excluding* the terminating zero. 
+	If `s` is NULL or `smax` is zero then just returns required number.
+@code
+	char *s;
+	size_t nchars = bdConvToDecimal(b, NULL, 0);
+	s = malloc(nchars+1);  // NB add one extra
+	nchars = bdConvToDecimal(b, s, nchars+1);
+@endcode
+@remark Always returns the length of the string it tried to create, 
+	even if the actual output was truncated, so remember to check.
+*/
+size_t bdConvToDecimal(BIGD b, char *s, size_t smax);
+
+/****************************/
+/* RANDOM NUMBER OPERATIONS */
+/****************************/
+
+/* [Version 2.1: bdRandDigit and bdRandomBits moved to bigdRand.h] */
+
+/** Set a with a "random" value of random length up to ndigits long suitable for quick tests 
+ *  @return Number of digits actually set
+ *  @remark For testing purposes only. Not crypto secure. Not thread safe.
+ */
+size_t bdSetRandTest(BIGD a, size_t ndigits);
+
+/** Generate a quick-and-dirty random number a of bit length at most `nbits` using plain-old-rand 
+ *  @return Number of digits actually set
+ *  @remark Not crypto secure. May give same value on repeated calls.  
+ *  @see bdRandomBits() or bdRandomSeeded().
+ */
+size_t bdQuickRandBits(BIGD a, size_t nbits);
+
+/** TYPEDEF for user-defined random byte generator function */
+typedef int (* BD_RANDFUNC)(unsigned char *buf, size_t nbytes, const unsigned char *seed, size_t seedlen);
+
+/** Generate a random number nbits long using RandFunc
+ *  @param[out] a To receive the result
+ *  @param [in] nbits Maximum number of bits in number
+ *  @param [in] seed Optional seed to add extra entropy
+ *  @param [in] seedlen Number of bytes in seed
+ *  @param [in] RandFunc User function to generate random bytes */
+int bdRandomSeeded(BIGD a, size_t nbits, const unsigned char *seed, 
+	size_t seedlen, BD_RANDFUNC RandFunc);
+
+/** Generate a prime number
+ *  @param[out] a To receive the result
+ *  @param [in] nbits Maximum number of bits in number
+ *  @param [in] ntests Number of primality tests to carry out (recommended at least 80)
+ *  @param [in] seed Optional seed to add extra entropy
+ *  @param [in] seedlen Number of bytes in seed
+ *  @param [in] RandFunc User function to generate random bytes */
+int bdGeneratePrime(BIGD a, size_t nbits, size_t ntests, const unsigned char *seed, 
+	size_t seedlen, BD_RANDFUNC RandFunc);
+
+/****************/
+/* VERSION INFO */
+/****************/
+/** Returns version number = major*1000+minor*100+release*10+PP_OPTIONS */
+int bdVersion(void);
+	/* Returns version number = major*1000+minor*100+release*10+uses_asm(0|1)+uses_64(0|2) 
+		 E.g. Version 2.3.0 will return 230x where x denotes the preprocessor options
+		 x | USE_SPASM | USE_64WITH32 | NO_ALLOCS
+		 --+-----------+--------------+----------
+		 0 |    No     |      No      |    N/A
+		 1 |    Yes    |      No      |    N/A
+		 2 |    No     |      Yes     |    N/A
+		 3 |    Yes    |      Yes*    |    N/A
+		 --+-----------+--------------+----------
+		 * USE_SPASM will take precedence over USE_64WITH32.
+	 */
+
+/** Returns a pointer to a static string containing the time of compilation */
+const char *bdCompileTime(void);
+
+
+#undef T /* (for opaque BIGD pointer) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BIGD_H_ */

--- a/src/bigdigits.c
+++ b/src/bigdigits.c
@@ -1,0 +1,3408 @@
+/* $Id: bigdigits.c $ */
+
+/***** BEGIN LICENSE BLOCK *****
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2001-16 David Ireland, D.I. Management Services Pty Limited
+ * <http://www.di-mgt.com.au/bigdigits.html>. All rights reserved.
+ *
+ ***** END LICENSE BLOCK *****/
+/*
+ * Last updated:
+ * $Date: 2016-03-31 09:51:00 $
+ * $Revision: 2.6.1 $
+ * $Author: dai $
+ */
+
+/* Core code for BigDigits library "mp" functions */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <time.h>
+#include "bigdigits.h"
+
+/* For debugging - these are NOOPs */
+#define DPRINTF0(s) 
+#define DPRINTF1(s, a1) 
+
+/***************************************/
+/* VERSION NUMBERS - USED IN MPVERSION */
+/***************************************/
+static const int kMajor = 2, kMinor = 6, kRelease = 1;
+
+/* Flags for preprocessor definitions used (=last digit of mpVersion) */
+#ifdef USE_SPASM
+static const int kUseSpasm = 1;
+#else
+static const int kUseSpasm = 0;
+#endif
+
+#ifdef USE_64WITH32
+static const int kUse64with32 = 2;
+#else
+static const int kUse64with32 = 0;
+#endif
+
+#ifdef NO_ALLOCS
+static const int kUseNoAllocs = 5;
+#else
+static const int kUseNoAllocs = 0;
+#endif
+
+/* Useful definitions */
+#ifndef max
+#define max(a,b)            (((a) > (b)) ? (a) : (b))
+#endif
+/* Internal macros */
+#define BITS_PER_HALF_DIGIT (BITS_PER_DIGIT / 2)
+#define BYTES_PER_DIGIT (BITS_PER_DIGIT / 8)
+#define LOHALF(x) ((DIGIT_T)((x) & MAX_HALF_DIGIT))
+#define HIHALF(x) ((DIGIT_T)((x) >> BITS_PER_HALF_DIGIT & MAX_HALF_DIGIT))
+#define TOHIGH(x) ((DIGIT_T)((x) << BITS_PER_HALF_DIGIT))
+#define mpNEXTBITMASK(mask, n) do{if(mask==1){mask=HIBITMASK;n--;}else{mask>>=1;}}while(0)
+
+/****************************/
+/* ERROR HANDLING FUNCTIONS */
+/****************************/
+/* Change these to suit your tastes and operating system. */
+#if defined(_WIN32) || defined(WIN32)
+/* Win32 GUI alternative */
+#ifndef STRICT
+#define STRICT
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+void mpFail(char *msg)
+{
+	MessageBox(NULL, msg, "BigDigits Error", MB_ICONERROR);
+	exit(EXIT_FAILURE);
+}
+#else	/* Ordinary console program */
+void mpFail(char *msg)
+{
+	perror(msg);
+	exit(EXIT_FAILURE);
+}
+#endif /* _WIN32 */
+
+/*******************************/
+/* MEMORY ALLOCATION FUNCTIONS */
+/*******************************/
+#ifndef NO_ALLOCS
+DIGIT_T *mpAlloc(size_t ndigits)
+{
+	DIGIT_T *ptr;
+
+	/* [v2.3] added check for zero digits. Thanks to "Radistao" */
+	if (ndigits < 1) ndigits = 1;
+
+	ptr = (DIGIT_T *)calloc(ndigits, sizeof(DIGIT_T));
+	if (!ptr)
+		mpFail("mpAlloc: Unable to allocate memory.");
+
+	return ptr;
+}
+
+void mpFree(DIGIT_T **p)
+{
+	if (*p)
+	{
+		free(*p);
+		*p = NULL;
+	}
+}
+#endif /* NO_ALLOCS */
+
+/* Added in [v2.4] for ALLOC_BYTES and FREE_BYTES */
+volatile uint8_t zeroise_bytes(volatile void *v, size_t n)
+{	/* Zeroise byte array b and make sure optimiser does not ignore this */
+	volatile uint8_t optdummy;
+	volatile uint8_t *b = (uint8_t*)v;
+	while(n--)
+		b[n] = 0;
+	optdummy = *b;
+	return optdummy;
+}
+/* [v2.4] Added explicit byte allocation functions with and without NO_ALLOCS */
+#ifndef NO_ALLOCS
+#define ALLOC_BYTES(b,n) do{(b)=calloc(n,1);if(!(b))mpFail("ALLOC_BYTES: Unable to allocate memory.");}while(0)
+#define FREE_BYTES(b,n) do{zeroise_bytes((b),(n));free((b));}while(0)
+#else
+#define MAX_ALLOC_SIZE (MAX_FIXED_DIGITS*BYTES_PER_DIGIT)
+#define ALLOC_BYTES(b,n) do{assert((n)<=sizeof((b)));zeroise_bytes((b),(n));}while(0)
+#define FREE_BYTES(b,n) zeroise_bytes((b),(n))
+#endif
+
+
+/* Force linker to include copyright notice in executable object image */
+volatile char *copyright_notice(void)
+{
+	return 
+"Contains multiple-precision arithmetic code originally written by David Ireland,"
+" copyright (c) 2001-16 by D.I. Management Services Pty Limited <www.di-mgt.com.au>.";
+}
+
+
+/* To use, include this statement somewhere in the final code:
+
+	copyright_notice();	
+	
+It has no real effect at run time. 
+Thanks to Phil Zimmerman for this idea.
+*/
+
+/****************/
+/* VERSION INFO */
+/****************/
+int mpVersion(void)
+{
+	return (kMajor * 1000 + kMinor * 100 + kRelease * 10 + kUseSpasm + kUse64with32 + kUseNoAllocs);
+}
+
+/* Added [v2.6] */
+const char *mpCompileTime(void)
+{
+	return __DATE__" "__TIME__;
+}
+
+/**************************************/
+/* CORE SINGLE PRECISION CALCULATIONS */
+/* (double where necessary)           */
+/**************************************/
+
+/* [v2.2] Moved these functions into main file
+	and added third option using 64-bit arithmetic if available.
+OPTIONS: 
+1. define USE_64WITH32 to use 64-bit types on a 32-bit machine; or
+2. define USE_SPASM to use Intel ASM (32-bit Intel compilers with __asm support); or
+3. use default "long" calculations (any platform)
+*/
+
+#ifdef USE_64WITH32
+/* 1. We are on a 32-bit machine with a 64-bit type available. */
+#pragma message("USE_64WITH32 is set")
+
+/* Make sure we have a uint64_t available */
+#if defined (_WIN32) || defined(WIN32)
+typedef unsigned __int64 uint64_t;
+#elif !defined(HAVE_C99INCLUDES) && !defined(HAVE_SYS_TYPES)
+typedef unsigned long long int uint64_t;
+#endif
+
+int spMultiply(uint32_t p[2], uint32_t x, uint32_t y)
+{
+	/* Use a 64-bit temp for product */
+	uint64_t t = (uint64_t)x * (uint64_t)y;
+	/* then split into two parts */
+	p[1] = (uint32_t)(t >> 32);
+	p[0] = (uint32_t)(t & 0xFFFFFFFF);
+
+	return 0;
+}
+
+uint32_t spDivide(uint32_t *pq, uint32_t *pr, const uint32_t u[2], uint32_t v)
+{
+	uint64_t uu, q;
+	uu = (uint64_t)u[1] << 32 | (uint64_t)u[0];
+	q = uu / (uint64_t)v;
+	//r = uu % (uint64_t)v;
+	*pr = (uint32_t)(uu - q * v);
+	*pq = (uint32_t)(q & 0xFFFFFFFF);
+	return (uint32_t)(q >> 32);
+}
+
+#elif defined(USE_SPASM)
+/* Use Intel MASM to compute sp products and divisions */
+#pragma message("Using MASM")
+
+int spMultiply(uint32_t p[2], uint32_t x, uint32_t y)
+/* ASM version explicitly for 32-bit integers */
+{
+/* Computes p = (p1p0) = x * y. No restrictions on input. */
+	__asm
+	{
+		mov eax, x
+		xor edx, edx
+		mul y
+		; Product in edx:eax
+		mov ebx, p
+		mov dword ptr [ebx], eax
+		mov dword ptr [ebx+4], edx
+	}
+	return 0;
+}
+
+uint32_t spDivide(uint32_t *pq, uint32_t *pr, const uint32_t u[2], uint32_t v)
+/* ASM version explicitly for 32-bit integers */
+{
+/* Computes quotient q = u / v, remainder r = u mod v.
+   Returns overflow (1) if q > word size (b) otherwise returns 0.
+   CAUTION: Requires v >= [b/2] i.e. v to have its high bit set.
+   (q1q0) = (u1u0)/v0
+   (r0)   = (u1u0) mod v0
+   Sets *pr = r0, *pq = q0 and returns "overflow" q1 (either 0 or 1).
+*/
+	uint32_t overflow = 0;
+	__asm
+	{
+		; Dividend u in EDX:EAX, divisor in v
+		mov ebx, u
+		mov eax, dword ptr [ebx]
+		mov edx, dword ptr [ebx+4]
+		; Catch overflow (edx >= divisor)
+		cmp edx, v
+		jb no_overflow
+		; If so, set edx = edx - divisor and flag it
+		sub edx, v
+		mov overflow, 1
+no_overflow:
+		div v
+		; Quotient in EAX, Remainder in EDX
+		mov ebx, pq
+		mov dword ptr [ebx], eax
+		mov ebx, pr
+		mov dword ptr [ebx], edx
+	}
+	return overflow;
+}
+
+#else
+/* Default routines the "long" way */
+
+int spMultiply(DIGIT_T p[2], DIGIT_T x, DIGIT_T y)
+{	/*	Computes p = x * y */
+	/*	Ref: Arbitrary Precision Computation
+	http://numbers.computation.free.fr/Constants/constants.html
+
+		 high    p1                p0     low
+		+--------+--------+--------+--------+
+		|      x1*y1      |      x0*y0      |
+		+--------+--------+--------+--------+
+			   +-+--------+--------+
+			   |1| (x0*y1 + x1*y1) |
+			   +-+--------+--------+
+				^carry from adding (x0*y1+x1*y1) together
+						+-+
+						|1|< carry from adding LOHALF t
+						+-+  to high half of p0
+	*/
+	DIGIT_T x0, y0, x1, y1;
+	DIGIT_T t, u, carry;
+
+	/*	Split each x,y into two halves
+		x = x0 + B*x1
+		y = y0 + B*y1
+		where B = 2^16, half the digit size
+		Product is
+		xy = x0y0 + B(x0y1 + x1y0) + B^2(x1y1)
+	*/
+
+	x0 = LOHALF(x);
+	x1 = HIHALF(x);
+	y0 = LOHALF(y);
+	y1 = HIHALF(y);
+
+	/* Calc low part - no carry */
+	p[0] = x0 * y0;
+
+	/* Calc middle part */
+	t = x0 * y1;
+	u = x1 * y0;
+	t += u;
+	if (t < u)
+		carry = 1;
+	else
+		carry = 0;
+
+	/*	This carry will go to high half of p[1]
+		+ high half of t into low half of p[1] */
+	carry = TOHIGH(carry) + HIHALF(t);
+
+	/* Add low half of t to high half of p[0] */
+	t = TOHIGH(t);
+	p[0] += t;
+	if (p[0] < t)
+		carry++;
+
+	p[1] = x1 * y1;
+	p[1] += carry;
+
+
+	return 0;
+}
+
+/* spDivide */
+
+#define B (MAX_HALF_DIGIT + 1)
+
+static void spMultSub(DIGIT_T uu[2], DIGIT_T qhat, DIGIT_T v1, DIGIT_T v0)
+{
+	/*	Compute uu = uu - q(v1v0) 
+		where uu = u3u2u1u0, u3 = 0
+		and u_n, v_n are all half-digits
+		even though v1, v2 are passed as full digits.
+	*/
+	DIGIT_T p0, p1, t;
+
+	p0 = qhat * v0;
+	p1 = qhat * v1;
+	t = p0 + TOHIGH(LOHALF(p1));
+	uu[0] -= t;
+	if (uu[0] > MAX_DIGIT - t)
+		uu[1]--;	/* Borrow */
+	uu[1] -= HIHALF(p1);
+}
+
+DIGIT_T spDivide(DIGIT_T *q, DIGIT_T *r, const DIGIT_T u[2], DIGIT_T v)
+{	/*	Computes quotient q = u / v, remainder r = u mod v
+		where u is a double digit
+		and q, v, r are single precision digits.
+		Returns high digit of quotient (max value is 1)
+		CAUTION: Assumes normalised such that v1 >= b/2
+		where b is size of HALF_DIGIT
+		i.e. the most significant bit of v should be one
+
+		In terms of half-digits in Knuth notation:
+		(q2q1q0) = (u4u3u2u1u0) / (v1v0)
+		(r1r0) = (u4u3u2u1u0) mod (v1v0)
+		for m = 2, n = 2 where u4 = 0
+		q2 is either 0 or 1.
+		We set q = (q1q0) and return q2 as "overflow"
+	*/
+	DIGIT_T qhat, rhat, t, v0, v1, u0, u1, u2, u3;
+	DIGIT_T uu[2], q2;
+
+	/* Check for normalisation */
+	if (!(v & HIBITMASK))
+	{	/* Stop if assert is working, else return error */
+		assert(v & HIBITMASK);
+		*q = *r = 0;
+		return MAX_DIGIT;
+	}
+	
+	/* Split up into half-digits */
+	v0 = LOHALF(v);
+	v1 = HIHALF(v);
+	u0 = LOHALF(u[0]);
+	u1 = HIHALF(u[0]);
+	u2 = LOHALF(u[1]);
+	u3 = HIHALF(u[1]);
+
+	/* Do three rounds of Knuth Algorithm D Vol 2 p272 */
+
+	/*	ROUND 1. Set j = 2 and calculate q2 */
+	/*	Estimate qhat = (u4u3)/v1  = 0 or 1 
+		then set (u4u3u2) -= qhat(v1v0)
+		where u4 = 0.
+	*/
+/* [Replaced in Version 2] -->
+	qhat = u3 / v1;
+	if (qhat > 0)
+	{
+		rhat = u3 - qhat * v1;
+		t = TOHIGH(rhat) | u2;
+		if (qhat * v0 > t)
+			qhat--;
+	}
+<-- */
+	qhat = (u3 < v1 ? 0 : 1);
+	if (qhat > 0)
+	{	/* qhat is one, so no need to mult */
+		rhat = u3 - v1;
+		/* t = r.b + u2 */
+		t = TOHIGH(rhat) | u2;
+		if (v0 > t)
+			qhat--;
+	}
+
+	uu[1] = 0;		/* (u4) */
+	uu[0] = u[1];	/* (u3u2) */
+	if (qhat > 0)
+	{
+		/* (u4u3u2) -= qhat(v1v0) where u4 = 0 */
+		spMultSub(uu, qhat, v1, v0);
+		if (HIHALF(uu[1]) != 0)
+		{	/* Add back */
+			qhat--;
+			uu[0] += v;
+			uu[1] = 0;
+		}
+	}
+	q2 = qhat;
+
+	/*	ROUND 2. Set j = 1 and calculate q1 */
+	/*	Estimate qhat = (u3u2) / v1 
+		then set (u3u2u1) -= qhat(v1v0)
+	*/
+	t = uu[0];
+	qhat = t / v1;
+	rhat = t - qhat * v1;
+	/* Test on v0 */
+	t = TOHIGH(rhat) | u1;
+	if ((qhat == B) || (qhat * v0 > t))
+	{
+		qhat--;
+		rhat += v1;
+		t = TOHIGH(rhat) | u1;
+		if ((rhat < B) && (qhat * v0 > t))
+			qhat--;
+	}
+
+	/*	Multiply and subtract 
+		(u3u2u1)' = (u3u2u1) - qhat(v1v0)	
+	*/
+	uu[1] = HIHALF(uu[0]);	/* (0u3) */
+	uu[0] = TOHIGH(LOHALF(uu[0])) | u1;	/* (u2u1) */
+	spMultSub(uu, qhat, v1, v0);
+	if (HIHALF(uu[1]) != 0)
+	{	/* Add back */
+		qhat--;
+		uu[0] += v;
+		uu[1] = 0;
+	}
+
+	/* q1 = qhat */
+	*q = TOHIGH(qhat);
+
+	/* ROUND 3. Set j = 0 and calculate q0 */
+	/*	Estimate qhat = (u2u1) / v1
+		then set (u2u1u0) -= qhat(v1v0)
+	*/
+	t = uu[0];
+	qhat = t / v1;
+	rhat = t - qhat * v1;
+	/* Test on v0 */
+	t = TOHIGH(rhat) | u0;
+	if ((qhat == B) || (qhat * v0 > t))
+	{
+		qhat--;
+		rhat += v1;
+		t = TOHIGH(rhat) | u0;
+		if ((rhat < B) && (qhat * v0 > t))
+			qhat--;
+	}
+
+	/*	Multiply and subtract 
+		(u2u1u0)" = (u2u1u0)' - qhat(v1v0)
+	*/
+	uu[1] = HIHALF(uu[0]);	/* (0u2) */
+	uu[0] = TOHIGH(LOHALF(uu[0])) | u0;	/* (u1u0) */
+	spMultSub(uu, qhat, v1, v0);
+	if (HIHALF(uu[1]) != 0)
+	{	/* Add back */
+		qhat--;
+		uu[0] += v;
+		uu[1] = 0;
+	}
+
+	/* q0 = qhat */
+	*q |= LOHALF(qhat);
+
+	/* Remainder is in (u1u0) i.e. uu[0] */
+	*r = uu[0];
+	return q2;
+}
+
+#endif /* Conditional single-digit mult & div routines */
+
+/************************/
+/* ARITHMETIC FUNCTIONS */
+/************************/
+DIGIT_T mpAdd(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T v[], size_t ndigits)
+{
+	/*	Calculates w = u + v
+		where w, u, v are multiprecision integers of ndigits each
+		Returns carry if overflow. Carry = 0 or 1.
+
+		Ref: Knuth Vol 2 Ch 4.3.1 p 266 Algorithm A.
+	*/
+
+	DIGIT_T k;
+	size_t j;
+
+	assert(w != v);
+
+	/* Step A1. Initialise */
+	k = 0;
+
+	for (j = 0; j < ndigits; j++)
+	{
+		/*	Step A2. Add digits w_j = (u_j + v_j + k)
+			Set k = 1 if carry (overflow) occurs
+		*/
+		w[j] = u[j] + k;
+		if (w[j] < k)
+			k = 1;
+		else
+			k = 0;
+		
+		w[j] += v[j];
+		if (w[j] < v[j])
+			k++;
+
+	}	/* Step A3. Loop on j */
+
+	return k;	/* w_n = k */
+}
+
+DIGIT_T mpSubtract(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T v[], size_t ndigits)
+{
+	/*	Calculates w = u - v where u >= v
+		w, u, v are multiprecision integers of ndigits each
+		Returns 0 if OK, or 1 if v > u.
+
+		Ref: Knuth Vol 2 Ch 4.3.1 p 267 Algorithm S.
+	*/
+
+	DIGIT_T k;
+	size_t j;
+
+	assert(w != v);
+
+	/* Step S1. Initialise */
+	k = 0;
+
+	for (j = 0; j < ndigits; j++)
+	{
+		/*	Step S2. Subtract digits w_j = (u_j - v_j - k)
+			Set k = 1 if borrow occurs.
+		*/
+		w[j] = u[j] - k;
+		if (w[j] > MAX_DIGIT - k)
+			k = 1;
+		else
+			k = 0;
+		
+		w[j] -= v[j];
+		if (w[j] > MAX_DIGIT - v[j])
+			k++;
+
+	}	/* Step S3. Loop on j */
+
+	return k;	/* Should be zero if u >= v */
+}
+
+int mpMultiply(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T v[], size_t ndigits)
+{
+	/*	Computes product w = u * v
+		where u, v are multiprecision integers of ndigits each
+		and w is a multiprecision integer of 2*ndigits
+
+		Ref: Knuth Vol 2 Ch 4.3.1 p 268 Algorithm M.
+	*/
+
+	DIGIT_T k, t[2];
+	size_t i, j, m, n;
+
+	assert(w != u && w != v);
+
+	m = n = ndigits;
+
+	/* Step M1. Initialise */
+	for (i = 0; i < 2 * m; i++)
+		w[i] = 0;
+
+	for (j = 0; j < n; j++)
+	{
+		/* Step M2. Zero multiplier? */
+		if (v[j] == 0)
+		{
+			w[j + m] = 0;
+		}
+		else
+		{
+			/* Step M3. Initialise i */
+			k = 0;
+			for (i = 0; i < m; i++)
+			{
+				/* Step M4. Multiply and add */
+				/* t = u_i * v_j + w_(i+j) + k */
+				spMultiply(t, u[i], v[j]);
+
+				t[0] += k;
+				if (t[0] < k)
+					t[1]++;
+				t[0] += w[i+j];
+				if (t[0] < w[i+j])
+					t[1]++;
+
+				w[i+j] = t[0];
+				k = t[1];
+			}	
+			/* Step M5. Loop on i, set w_(j+m) = k */
+			w[j+m] = k;
+		}
+	}	/* Step M6. Loop on j */
+
+	return 0;
+}
+
+/* mpDivide */
+
+static DIGIT_T mpMultSub(DIGIT_T wn, DIGIT_T w[], const DIGIT_T v[],
+					   DIGIT_T q, size_t n)
+{	/*	Compute w = w - qv
+		where w = (WnW[n-1]...W[0])
+		return modified Wn.
+	*/
+	DIGIT_T k, t[2];
+	size_t i;
+
+	if (q == 0)	/* No change */
+		return wn;
+
+	k = 0;
+
+	for (i = 0; i < n; i++)
+	{
+		spMultiply(t, q, v[i]);
+		w[i] -= k;
+		if (w[i] > MAX_DIGIT - k)
+			k = 1;
+		else
+			k = 0;
+		w[i] -= t[0];
+		if (w[i] > MAX_DIGIT - t[0])
+			k++;
+		k += t[1];
+	}
+
+	/* Cope with Wn not stored in array w[0..n-1] */
+	wn -= k;
+
+	return wn;
+}
+
+static int QhatTooBig(DIGIT_T qhat, DIGIT_T rhat,
+					  DIGIT_T vn2, DIGIT_T ujn2)
+{	/*	Returns true if Qhat is too big
+		i.e. if (Qhat * Vn-2) > (b.Rhat + Uj+n-2)
+	*/
+	DIGIT_T t[2];
+
+	spMultiply(t, qhat, vn2);
+	if (t[1] < rhat)
+		return 0;
+	else if (t[1] > rhat)
+		return 1;
+	else if (t[0] > ujn2)
+		return 1;
+
+	return 0;
+}
+
+int mpDivide(DIGIT_T q[], DIGIT_T r[], const DIGIT_T u[],
+	size_t udigits, DIGIT_T v[], size_t vdigits)
+{	/*	Computes quotient q = u / v and remainder r = u mod v
+		where q, r, u are multiple precision digits
+		all of udigits and the divisor v is vdigits.
+
+		Ref: Knuth Vol 2 Ch 4.3.1 p 272 Algorithm D.
+
+		Do without extra storage space, i.e. use r[] for
+		normalised u[], unnormalise v[] at end, and cope with
+		extra digit Uj+n added to u after normalisation.
+
+		WARNING: this trashes q and r first, so cannot do
+		u = u / v or v = u mod v.
+		It also changes v temporarily so cannot make it const.
+	*/
+	size_t shift;
+	int n, m, j;
+	DIGIT_T bitmask, overflow;
+	DIGIT_T qhat, rhat, t[2];
+	DIGIT_T *uu, *ww;
+	int qhatOK, cmp;
+
+	/* Clear q and r */
+	mpSetZero(q, udigits);
+	mpSetZero(r, udigits);
+
+	/* Work out exact sizes of u and v */
+	n = (int)mpSizeof(v, vdigits);
+	m = (int)mpSizeof(u, udigits);
+	m -= n;
+
+	/* Catch special cases */
+	if (n == 0)
+		return -1;	/* Error: divide by zero */
+
+	if (n == 1)
+	{	/* Use short division instead */
+		r[0] = mpShortDiv(q, u, v[0], udigits);
+		return 0;
+	}
+
+	if (m < 0)
+	{	/* v > u, so just set q = 0 and r = u */
+		mpSetEqual(r, u, udigits);
+		return 0;
+	}
+
+	if (m == 0)
+	{	/* u and v are the same length */
+		cmp = mpCompare(u, v, (size_t)n);
+		if (cmp < 0)
+		{	/* v > u, as above */
+			mpSetEqual(r, u, udigits);
+			return 0;
+		}
+		else if (cmp == 0)
+		{	/* v == u, so set q = 1 and r = 0 */
+			mpSetDigit(q, 1, udigits);
+			return 0;
+		}
+	}
+
+	/*	In Knuth notation, we have:
+		Given
+		u = (Um+n-1 ... U1U0)
+		v = (Vn-1 ... V1V0)
+		Compute
+		q = u/v = (QmQm-1 ... Q0)
+		r = u mod v = (Rn-1 ... R1R0)
+	*/
+
+	/*	Step D1. Normalise */
+	/*	Requires high bit of Vn-1
+		to be set, so find most signif. bit then shift left,
+		i.e. d = 2^shift, u' = u * d, v' = v * d.
+	*/
+	bitmask = HIBITMASK;
+	for (shift = 0; shift < BITS_PER_DIGIT; shift++)
+	{
+		if (v[n-1] & bitmask)
+			break;
+		bitmask >>= 1;
+	}
+
+	/* Normalise v in situ - NB only shift non-zero digits */
+	overflow = mpShiftLeft(v, v, shift, n);
+
+	/* Copy normalised dividend u*d into r */
+	overflow = mpShiftLeft(r, u, shift, n + m);
+	uu = r;	/* Use ptr to keep notation constant */
+
+	t[0] = overflow;	/* Extra digit Um+n */
+
+	/* Step D2. Initialise j. Set j = m */
+	for (j = m; j >= 0; j--)
+	{
+		/* Step D3. Set Qhat = [(b.Uj+n + Uj+n-1)/Vn-1] 
+		   and Rhat = remainder */
+		qhatOK = 0;
+		t[1] = t[0];	/* This is Uj+n */
+		t[0] = uu[j+n-1];
+		overflow = spDivide(&qhat, &rhat, t, v[n-1]);
+
+		/* Test Qhat */
+		if (overflow)
+		{	/* Qhat == b so set Qhat = b - 1 */
+			qhat = MAX_DIGIT;
+			rhat = uu[j+n-1];
+			rhat += v[n-1];
+			if (rhat < v[n-1])	/* Rhat >= b, so no re-test */
+				qhatOK = 1;
+		}
+		/* [VERSION 2: Added extra test "qhat && "] */
+		if (qhat && !qhatOK && QhatTooBig(qhat, rhat, v[n-2], uu[j+n-2]))
+		{	/* If Qhat.Vn-2 > b.Rhat + Uj+n-2 
+			   decrease Qhat by one, increase Rhat by Vn-1
+			*/
+			qhat--;
+			rhat += v[n-1];
+			/* Repeat this test if Rhat < b */
+			if (!(rhat < v[n-1]))
+				if (QhatTooBig(qhat, rhat, v[n-2], uu[j+n-2]))
+					qhat--;
+		}
+
+
+		/* Step D4. Multiply and subtract */
+		ww = &uu[j];
+		overflow = mpMultSub(t[1], ww, v, qhat, (size_t)n);
+
+		/* Step D5. Test remainder. Set Qj = Qhat */
+		q[j] = qhat;
+		if (overflow)
+		{	/* Step D6. Add back if D4 was negative */
+			q[j]--;
+			overflow = mpAdd(ww, ww, v, (size_t)n);
+		}
+
+		t[0] = uu[j+n-1];	/* Uj+n on next round */
+
+	}	/* Step D7. Loop on j */
+
+	/* Clear high digits in uu */
+	for (j = n; j < m+n; j++)
+		uu[j] = 0;
+
+	/* Step D8. Unnormalise. */
+
+	mpShiftRight(r, r, shift, n);
+	mpShiftRight(v, v, shift, n);
+
+	return 0;
+}
+
+
+int mpSquare(DIGIT_T w[], const DIGIT_T x[], size_t ndigits)
+/* New in Version 2.0 */
+{
+	/*	Computes square w = x * x
+		where x is a multiprecision integer of ndigits
+		and w is a multiprecision integer of 2*ndigits
+
+		Ref: Menezes p596 Algorithm 14.16 with errata.
+	*/
+
+	DIGIT_T k, p[2], u[2], cbit, carry;
+	size_t i, j, t, i2, cpos;
+
+	assert(w != x);
+
+	t = ndigits;
+
+	/* 1. For i from 0 to (2t-1) do: w_i = 0 */
+	i2 = t << 1;
+	for (i = 0; i < i2; i++)
+		w[i] = 0;
+
+	carry = 0;
+	cpos = i2-1;
+	/* 2. For i from 0 to (t-1) do: */
+	for (i = 0; i < t; i++)
+	{
+		/* 2.1 (uv) = w_2i + x_i * x_i, w_2i = v, c = u 
+		   Careful, w_2i may be double-prec
+		*/
+		i2 = i << 1; /* 2*i */
+		spMultiply(p, x[i], x[i]);
+		p[0] += w[i2];
+		if (p[0] < w[i2])
+			p[1]++;
+		k = 0;	/* p[1] < b, so no overflow here */
+		if (i2 == cpos && carry)
+		{
+			p[1] += carry;
+			if (p[1] < carry)
+				k++;
+			carry = 0;
+		}
+		w[i2] = p[0];
+		u[0] = p[1];
+		u[1] = k;
+
+		/* 2.2 for j from (i+1) to (t-1) do:
+		   (uv) = w_{i+j} + 2x_j * x_i + c,
+		   w_{i+j} = v, c = u,
+		   u is double-prec 
+		   w_{i+j} is dbl if [i+j] == cpos
+		*/
+		k = 0;
+		for (j = i+1; j < t; j++)
+		{
+			/* p = x_j * x_i */
+			spMultiply(p, x[j], x[i]);
+			/* p = 2p <=> p <<= 1 */
+			cbit = (p[0] & HIBITMASK) != 0;
+			k =  (p[1] & HIBITMASK) != 0;
+			p[0] <<= 1;
+			p[1] <<= 1;
+			p[1] |= cbit;
+			/* p = p + c */
+			p[0] += u[0];
+			if (p[0] < u[0])
+			{
+				p[1]++;
+				if (p[1] == 0)
+					k++;
+			}
+			p[1] += u[1];
+			if (p[1] < u[1])
+				k++;
+			/* p = p + w_{i+j} */
+			p[0] += w[i+j];
+			if (p[0] < w[i+j])
+			{
+				p[1]++;
+				if (p[1] == 0)
+					k++;
+			}
+			if ((i+j) == cpos && carry)
+			{	/* catch overflow from last round */
+				p[1] += carry;
+				if (p[1] < carry)
+					k++;
+				carry = 0;
+			}
+			/* w_{i+j} = v, c = u */
+			w[i+j] = p[0];
+			u[0] = p[1];
+			u[1] = k;
+		}
+		/* 2.3 w_{i+t} = u */
+		w[i+t] = u[0];
+		/* remember overflow in w_{i+t} */
+		carry = u[1];	
+		cpos = i+t;
+	}
+
+	/* (NB original step 3 deleted in Menezes errata) */
+
+	/* Return w */
+
+	return 0;
+}
+
+/** Returns true if a == b, else false. Not constant-time. */
+int mpEqual(const DIGIT_T a[], const DIGIT_T b[], size_t ndigits)
+{
+
+	/* if (ndigits == 0) return -1; // deleted [v2.5] */
+
+	while (ndigits--)
+	{
+		if (a[ndigits] != b[ndigits])
+			return 0;	/* False */
+	}
+
+	return (!0);	/* True */
+}
+
+/** Returns sign of (a - b) as 0, +1 or -1. Not constant-time. */
+int mpCompare(const DIGIT_T a[], const DIGIT_T b[], size_t ndigits)
+{
+	/* if (ndigits == 0) return 0; // deleted [v2.5] */
+
+	while (ndigits--)
+	{
+		if (a[ndigits] > b[ndigits])
+			return 1;	/* GT */
+		if (a[ndigits] < b[ndigits])
+			return -1;	/* LT */
+	}
+
+	return 0;	/* EQ */
+}
+
+/** Returns true if a == 0, else false. Not constant-time. */
+int mpIsZero(const DIGIT_T a[], size_t ndigits)
+{
+	size_t i;
+
+	/* if (ndigits == 0) return -1; // deleted [v2.5] */
+
+	for (i = 0; i < ndigits; i++)	/* Start at lsb */
+	{
+		if (a[i] != 0)
+			return 0;	/* False */
+	}
+
+	return (!0);	/* True */
+}
+
+/* CONSTANT-TIME COMPARISONS */
+/* New in [v2.5] but renamed as _ct in [v.6] */
+
+/* Constant-time comparisons of unsigned DIGIT_T's */ 
+#define IS_NONZERO_DIGIT(x) (((x)|(~(x)+1)) >> (BITS_PER_DIGIT-1))
+#define IS_ZER0_DIGIT(x) (1 ^ IS_NONZERO_DIGIT((x)))
+
+/** Returns 1 if a == b, else 0 (constant-time) */
+int mpEqual_ct(const DIGIT_T a[], const DIGIT_T b[], size_t ndigits)
+{
+	DIGIT_T dif = 0;
+
+	while (ndigits--) {
+		dif |= a[ndigits] ^ b[ndigits];
+	}
+
+	return (IS_ZER0_DIGIT(dif));
+}
+
+/** Returns 1 if a == 0, else 0 (constant-time) */
+int mpIsZero_ct(const DIGIT_T a[], size_t ndigits)
+{
+	DIGIT_T dif = 0;
+	const DIGIT_T ZERO = 0;
+
+	while (ndigits--) {
+		dif |= a[ndigits] ^ ZERO;
+	}
+
+	return (IS_ZER0_DIGIT(dif));
+}
+
+/** Returns sign of (a - b) as 0, +1 or -1 (constant-time) */
+int mpCompare_ct(const DIGIT_T a[], const DIGIT_T b[], size_t ndigits)
+{
+	/* All these vars are either 0 or 1 */
+	unsigned int gt = 0;
+	unsigned int lt = 0;
+	unsigned int mask = 1;	/* Set to zero once first inequality found */
+	unsigned int c;
+
+	while (ndigits--) {
+		gt |= (a[ndigits] > b[ndigits]) & mask;
+		lt |= (a[ndigits] < b[ndigits]) & mask;
+		c = (gt | lt);
+		mask &= (c-1);	/* Unchanged if c==0 or mask==0, else mask=0 */
+	}
+
+	return (int)gt - (int)lt;	/* EQ=0 GT=+1 LT=-1 */
+}
+
+/** Returns number of significant digits in a */
+size_t mpSizeof(const DIGIT_T a[], size_t ndigits)
+{		
+	while(ndigits--)
+	{
+		if (a[ndigits] != 0)
+			return (++ndigits);
+	}
+	return 0;
+}
+
+size_t mpBitLength(const DIGIT_T d[], size_t ndigits)
+/* Returns no of significant bits in d */
+{
+	size_t n, i, bits;
+	DIGIT_T mask;
+
+	if (!d || ndigits == 0)
+		return 0;
+
+	n = mpSizeof(d, ndigits);
+	if (0 == n) return 0;
+
+	for (i = 0, mask = HIBITMASK; mask > 0; mask >>= 1, i++)
+	{
+		if (d[n-1] & mask)
+			break;
+	}
+
+	bits = n * BITS_PER_DIGIT - i;
+
+	return bits;
+}
+
+void mpSetEqual(DIGIT_T a[], const DIGIT_T b[], size_t ndigits)
+{	/* Sets a = b */
+	size_t i;
+	
+	for (i = 0; i < ndigits; i++)
+	{
+		a[i] = b[i];
+	}
+}
+
+volatile DIGIT_T mpSetZero(volatile DIGIT_T a[], size_t ndigits)
+{	/* Sets a = 0 */
+
+	/* Prevent optimiser ignoring this */
+	volatile DIGIT_T optdummy;
+	volatile DIGIT_T *p = a;
+
+	while (ndigits--)
+		a[ndigits] = 0;
+	
+	optdummy = *p;
+	return optdummy;
+}
+
+void mpSetDigit(DIGIT_T a[], DIGIT_T d, size_t ndigits)
+{	/* Sets a = d where d is a single digit */
+	size_t i;
+	
+	for (i = 1; i < ndigits; i++)
+	{
+		a[i] = 0;
+	}
+	a[0] = d;
+}
+
+/**********************/
+/* BIT-WISE FUNCTIONS */
+/**********************/
+DIGIT_T mpShiftLeft(DIGIT_T a[], const DIGIT_T *b,
+	size_t shift, size_t ndigits)
+{	/* Computes a = b << shift */
+	/* [v2.1] Modified to cope with shift > BITS_PERDIGIT */
+	size_t i, y, nw, bits;
+	DIGIT_T mask, carry, nextcarry;
+
+	/* Do we shift whole digits? */
+	if (shift >= BITS_PER_DIGIT)
+	{
+		nw = shift / BITS_PER_DIGIT;
+		i = ndigits;
+		while (i--)
+		{
+			if (i >= nw)
+				a[i] = b[i-nw];
+			else
+				a[i] = 0;
+		}
+		/* Call again to shift bits inside digits */
+		bits = shift % BITS_PER_DIGIT;
+		carry = b[ndigits-nw] << bits;
+		if (bits) 
+			carry |= mpShiftLeft(a, a, bits, ndigits);
+		return carry;
+	}
+	else
+	{
+		bits = shift;
+	}
+
+	if (bits == 0)
+	{
+		if (a != b)
+			memmove(a, b, ndigits * sizeof(DIGIT_T));
+		return 0;
+	}
+
+	/* Construct mask = high bits set */
+	mask = ~(~(DIGIT_T)0 >> bits);
+	
+	y = BITS_PER_DIGIT - bits;
+	carry = 0;
+	for (i = 0; i < ndigits; i++)
+	{
+		nextcarry = (b[i] & mask) >> y;
+		a[i] = b[i] << bits | carry;
+		carry = nextcarry;
+	}
+
+	return carry;
+}
+
+DIGIT_T mpShiftRight(DIGIT_T a[], const DIGIT_T b[], size_t shift, size_t ndigits)
+{	/* Computes a = b >> shift */
+	/* [v2.1] Modified to cope with shift > BITS_PERDIGIT */
+	size_t i, y, nw, bits;
+	DIGIT_T mask, carry, nextcarry;
+
+	/* Do we shift whole digits? */
+	if (shift >= BITS_PER_DIGIT)
+	{
+		nw = shift / BITS_PER_DIGIT;
+		for (i = 0; i < ndigits; i++)
+		{
+			if ((i+nw) < ndigits)
+				a[i] = b[i+nw];
+			else
+				a[i] = 0;
+		}
+		/* Call again to shift bits inside digits */
+		bits = shift % BITS_PER_DIGIT;
+		carry = b[nw-1] >> bits;
+		if (bits) 
+			carry |= mpShiftRight(a, a, bits, ndigits);
+		return carry;
+	}
+	else
+	{
+		bits = shift;
+	}
+
+	if (bits == 0)
+	{
+		if (a != b)
+			memmove(a, b, ndigits * sizeof(DIGIT_T));
+		return 0;
+	}
+
+	/* Construct mask to set low bits */
+	/* (thanks to Jesse Chisholm for suggesting this improved technique) */
+	mask = ~(~(DIGIT_T)0 << bits);
+	
+	y = BITS_PER_DIGIT - bits;
+	carry = 0;
+	i = ndigits;
+	while (i--)
+	{
+		nextcarry = (b[i] & mask) << y;
+		a[i] = b[i] >> bits | carry;
+		carry = nextcarry;
+	}
+
+	return carry;
+}
+
+int mpSetBit(DIGIT_T a[], size_t ndigits, size_t ibit, int value)
+	/* Set bit n (0..nbits-1) with value 1 or 0 */
+{
+	size_t idigit, bit_to_set;
+	DIGIT_T mask;
+
+	/* Which digit? (0-based) */
+	idigit = ibit / BITS_PER_DIGIT;
+	if (idigit >= ndigits)
+		return -1;
+
+	/* Set mask */
+	bit_to_set = ibit % BITS_PER_DIGIT;
+	mask = 0x01 << bit_to_set;
+
+	if (value)
+		a[idigit] |= mask;
+	else
+		a[idigit] &= (~mask);
+
+	return 0;
+}
+
+int mpGetBit(const DIGIT_T a[], size_t ndigits, size_t ibit)
+	/* Returns value 1 or 0 of bit n (0..nbits-1); or -1 if out of range */
+{
+	size_t idigit, bit_to_get;
+	DIGIT_T mask;
+
+	/* Which digit? (0-based) */
+	idigit = ibit / BITS_PER_DIGIT;
+	if (idigit >= ndigits)
+		return -1;
+
+	/* Set mask */
+	bit_to_get = ibit % BITS_PER_DIGIT;
+	mask = 0x01 << bit_to_get;
+
+	return ((a[idigit] & mask) ? 1 : 0);
+}
+
+void mpModPowerOf2(DIGIT_T a[], size_t ndigits, size_t L)
+	/* Computes a = a mod 2^L */
+	/* i.e. clears all bits >= L */
+{
+	size_t i, nw, bits;
+	DIGIT_T mask;
+
+	/* High digits to clear */
+	nw = L / BITS_PER_DIGIT;
+	for (i = nw+1; i < ndigits; i++)
+		a[i] = 0;
+	/* Low bits to keep */
+	bits = L % BITS_PER_DIGIT;
+	mask = ~(~0 << bits);
+	if (ndigits > nw)
+		a[nw] &= mask;
+}
+
+void mpXorBits(DIGIT_T a[], const DIGIT_T b[], const DIGIT_T c[], size_t ndigits)
+	/* Computes bitwise a = b XOR c */
+{
+	size_t i;
+	for (i = 0; i < ndigits; i++)
+		a[i] = b[i] ^ c[i];
+}
+
+void mpOrBits(DIGIT_T a[], const DIGIT_T b[], const DIGIT_T c[], size_t ndigits)
+	/* Computes bitwise a = b OR c */
+{
+	size_t i;
+	for (i = 0; i < ndigits; i++)
+		a[i] = b[i] | c[i];
+}
+
+void mpAndBits(DIGIT_T a[], const DIGIT_T b[], const DIGIT_T c[], size_t ndigits)
+	/* Computes bitwise a = b AND c */
+{
+	size_t i;
+	for (i = 0; i < ndigits; i++)
+		a[i] = b[i] & c[i];
+}
+
+void mpNotBits(DIGIT_T a[], const DIGIT_T b[], size_t ndigits)
+	/* Computes bitwise a = NOT b */
+{
+	size_t i;
+	for (i = 0; i < ndigits; i++)
+		a[i] = ~b[i];
+}
+
+/*****************************************/
+/* FUNCTIONS WITH A SINGLE (SHORT) DIGIT */
+/*****************************************/
+DIGIT_T mpShortAdd(DIGIT_T w[], const DIGIT_T u[], DIGIT_T v, 
+			   size_t ndigits)
+{
+	/*	Calculates w = u + v
+		where w, u are multiprecision integers of ndigits each
+		and v is a single precision digit.
+		Returns carry if overflow.
+
+		Ref: Derived from Knuth Algorithm A.
+	*/
+
+	DIGIT_T k;
+	size_t j;
+
+	k = 0;
+
+	/* Add v to first digit of u */
+	w[0] = u[0] + v;
+	if (w[0] < v)
+		k = 1;
+	else
+		k = 0;
+
+	/* Add carry to subsequent digits */
+	for (j = 1; j < ndigits; j++)
+	{
+		w[j] = u[j] + k;
+		if (w[j] < k)
+			k = 1;
+		else
+			k = 0;
+	}
+
+	return k;
+}
+
+DIGIT_T mpShortSub(DIGIT_T w[], const DIGIT_T u[], DIGIT_T v, 
+			   size_t ndigits)
+{
+	/*	Calculates w = u - v
+		where w, u are multiprecision integers of ndigits each
+		and v is a single precision digit.
+		Returns borrow: 0 if u >= v, or 1 if v > u.
+
+		Ref: Derived from Knuth Algorithm S.
+	*/
+
+	DIGIT_T k;
+	size_t j;
+
+	k = 0;
+
+	/* Subtract v from first digit of u */
+	w[0] = u[0] - v;
+	if (w[0] > MAX_DIGIT - v)
+		k = 1;
+	else
+		k = 0;
+
+	/* Subtract borrow from subsequent digits */
+	for (j = 1; j < ndigits; j++)
+	{
+		w[j] = u[j] - k;
+		if (w[j] > MAX_DIGIT - k)
+			k = 1;
+		else
+			k = 0;
+	}
+
+	return k;
+}
+
+DIGIT_T mpShortMult(DIGIT_T w[], const DIGIT_T u[], DIGIT_T v, 
+					size_t ndigits)
+{
+	/*	Computes product w = u * v
+		Returns overflow k
+		where w, u are multiprecision integers of ndigits each
+		and v, k are single precision digits
+
+		Ref: Knuth Algorithm M.
+	*/
+
+	DIGIT_T k, t[2];
+	size_t j;
+
+	if (v == 0) 
+	{	/* [2005-08-29] Set w = 0 */
+		for (j = 0; j < ndigits; j++)
+			w[j] = 0;
+		return 0;
+	}
+
+	k = 0;
+	for (j = 0; j < ndigits; j++)
+	{
+		/* t = x_i * v */
+		spMultiply(t, u[j], v);
+		/* w_i = LOHALF(t) + carry */
+		w[j] = t[0] + k;
+		/* Overflow? */
+		if (w[j] < k)
+			t[1]++;
+		/* Carry forward HIHALF(t) */
+		k = t[1];
+	}
+
+	return k;
+}
+
+DIGIT_T mpShortDiv(DIGIT_T q[], const DIGIT_T u[], DIGIT_T v, 
+				   size_t ndigits)
+{
+	/*	Calculates quotient q = u div v
+		Returns remainder r = u mod v
+		where q, u are multiprecision integers of ndigits each
+		and r, v are single precision digits.
+
+		Makes no assumptions about normalisation.
+		
+		Ref: Knuth Vol 2 Ch 4.3.1 Exercise 16 p625
+	*/
+	size_t j;
+	DIGIT_T t[2], r;
+	size_t shift;
+	DIGIT_T bitmask, overflow, *uu;
+
+	if (ndigits == 0) return 0;
+	if (v == 0)	return 0;	/* Divide by zero error */
+
+	/*	Normalise first */
+	/*	Requires high bit of V
+		to be set, so find most signif. bit then shift left,
+		i.e. d = 2^shift, u' = u * d, v' = v * d.
+	*/
+	bitmask = HIBITMASK;
+	for (shift = 0; shift < BITS_PER_DIGIT; shift++)
+	{
+		if (v & bitmask)
+			break;
+		bitmask >>= 1;
+	}
+
+	v <<= shift;
+	overflow = mpShiftLeft(q, u, shift, ndigits);
+	uu = q;
+	
+	/* Step S1 - modified for extra digit. */
+	r = overflow;	/* New digit Un */
+	j = ndigits;
+	while (j--)
+	{
+		/* Step S2. */
+		t[1] = r;
+		t[0] = uu[j];
+		overflow = spDivide(&q[j], &r, t, v);
+	}
+
+	/* Unnormalise */
+	r >>= shift;
+	
+	return r;
+}
+
+DIGIT_T mpShortMod(const DIGIT_T a[], DIGIT_T d, size_t ndigits)
+{
+	/*	Calculates r = a mod d
+		where a is a multiprecision integer of ndigits
+		and r, d are single precision digits.
+		Use remainder from divide function.
+	*/
+
+	DIGIT_T r = 0;
+/* Allocate temp storage */
+#ifdef NO_ALLOCS
+	DIGIT_T q[MAX_FIXED_DIGITS * 2];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *q;
+	q = mpAlloc(ndigits * 2);
+#endif
+
+	r = mpShortDiv(q, a, d, ndigits);
+
+	mpDESTROY(q, ndigits);
+
+	return r;
+}
+
+/** Returns sign of (a - d) where d is a single digit */
+int mpShortCmp(const DIGIT_T a[], DIGIT_T d, size_t ndigits)
+{
+	size_t i;
+	int gt = 0;
+	int lt = 0;
+
+	/* Zero-length a => a is zero */
+	if (ndigits == 0) return (d ? -1 : 0);
+
+	/* If |a| > 1 then a > d */
+	for (i = 1; i < ndigits; i++) {
+		if (a[i] != 0)
+			return 1;	/* GT */
+	}
+
+	lt = (a[0] < d);
+	gt = (a[0] > d);
+
+	return gt - lt;	/* EQ=0 GT=+1 LT=-1 */
+}
+
+/** Returns true if a == d, else false, where d is a single digit */
+int mpShortIsEqual(const DIGIT_T a[], DIGIT_T d, size_t ndigits)
+{
+	return (0 == mpShortCmp(a, d, ndigits));
+}
+
+/** Returns the least significant digit in a */
+DIGIT_T mpToShort(const DIGIT_T a[], size_t ndigits)
+{
+	return a[0];
+}
+
+
+
+/*********************************/
+/* FUNCTIONS FOR SIGNED INTEGERS */
+/*********************************/
+/* Added [v2.2] */
+
+/** Returns TRUE (1) if x < 0, else FALSE (0) */
+int mpIsNegative(const DIGIT_T x[], size_t ndigits)
+{
+	return ((x[ndigits-1] & HIBITMASK) != 0);
+}
+
+/** Sets x = -y */
+int mpChs(DIGIT_T x[], const DIGIT_T y[], size_t ndigits)
+{
+	int isneg = mpIsNegative(y, ndigits);
+
+	if (isneg)
+	{	/* negative to positive: x = ~(y-1) */
+		mpShortSub(x, y, 1, ndigits);
+		mpNotBits(x, x, ndigits);
+	}
+	else
+	{	/* positive to negative: x = ~(y)+1 */
+		/* [v2.3] FIXED: thanks to Valery Blazhnov of www.lissi.ru */
+		mpNotBits(x, y, ndigits);
+		mpShortAdd(x, x, 1, ndigits);
+	}
+
+	return isneg;
+}
+
+/** Sets x = |y| */
+int mpAbs(DIGIT_T x[], const DIGIT_T y[], size_t ndigits)
+{
+	int isneg = mpIsNegative(y, ndigits);
+
+	if (isneg)
+		mpChs(x, y, ndigits);
+	else
+		mpSetEqual(x, y, ndigits);
+
+	return isneg;
+}
+
+/*******************/
+/* PRINT FUNCTIONS */
+/*******************/
+/* [v2.1] changed to use C99 format types */
+void mpPrint(const DIGIT_T *a, size_t len)
+{
+	while (len--)
+	{
+		printf("%08" PRIxBIGD " ", a[len]);
+	}
+}
+
+void mpPrintNL(const DIGIT_T *a, size_t len)
+{
+	size_t i = 0;
+
+	while (len--)
+	{
+		if ((i % 8) == 0 && i)
+			printf("\n");
+		printf("%08" PRIxBIGD " ", a[len]);
+		i++;
+	}
+	printf("\n");
+}
+
+void mpPrintTrim(const DIGIT_T *a, size_t len)
+{
+	/* Trim leading digits which are zero */
+	while (len--)
+	{
+		if (a[len] != 0)
+			break;
+	}
+	len++;
+	/* Catch empty len to show 0 */
+	if (0 == len) len = 1;
+
+	mpPrint(a, len);
+}
+
+void mpPrintTrimNL(const DIGIT_T *a, size_t len)
+{
+	/* Trim leading zeroes */
+	while (len--)
+	{
+		if (a[len] != 0)
+			break;
+	}
+	len++;
+	/* Catch empty len to show 0 */
+	if (0 == len) len = 1;
+
+	mpPrintNL(a, len);
+}
+
+void mpPrintHex(const char *prefix, const DIGIT_T *a, size_t len, const char *suffix)
+{
+	if (prefix) printf("%s", prefix);
+	/* Trim leading digits which are zero */
+	while (len--)
+	{
+		if (a[len] != 0)
+			break;
+	}
+	len++;
+	if (0 == len) len = 1;
+	/* print first digit without leading zeros */
+	printf("%" PRIxBIGD, a[--len]);
+	while (len--)
+	{
+		printf("%08" PRIxBIGD, a[len]);
+	}
+	if (suffix) printf("%s", suffix);
+}
+
+void mpPrintDecimal(const char *prefix, const DIGIT_T *a, size_t len, const char *suffix)
+{
+#ifdef NO_ALLOCS
+	char s[MAX_ALLOC_SIZE*3];	// [v2.6] increased
+#else
+	char *s;
+#endif
+	size_t nc;
+	/* Put big digit into a string of decimal chars */
+	nc = mpConvToDecimal(a, len, NULL, 0);
+	ALLOC_BYTES(s, nc + 1);
+	nc = mpConvToDecimal(a, len, s, nc + 1);
+	if (prefix) printf("%s", prefix);
+	printf("%s", s);
+	if (suffix) printf("%s", suffix);
+	FREE_BYTES(s, nc + 1);
+}
+
+/* ADDED [v2.5] */
+void mpPrintDecimalSigned(const char *prefix, DIGIT_T *a, size_t len, const char *suffix)
+{
+#ifdef NO_ALLOCS
+	char s[MAX_ALLOC_SIZE*3];	// [v2.6] increased
+#else
+	char *s;
+#endif
+	size_t nc;
+	int isneg = 0;
+	if (prefix) printf("%s", prefix);
+	if (mpIsNegative(a, len)) {
+		/* NB changes a in situ temporarily */
+		mpChs(a, a, len);
+		printf("-");
+		isneg = 1;
+	}
+	/* Put big digit into a string of decimal chars */
+	nc = mpConvToDecimal(a, len, NULL, 0);
+	ALLOC_BYTES(s, nc + 1);
+	nc = mpConvToDecimal(a, len, s, nc + 1);
+	printf("%s", s);
+	if (suffix) printf("%s", suffix);
+	if (isneg) {
+		mpChs(a, a, len);
+	}
+	FREE_BYTES(s, nc + 1);
+}
+
+/* ADDED [v2.6] */
+void mpPrintBits(const char *prefix, DIGIT_T *a, size_t ndigits, const char *suffix)
+{
+	int nbits, i, v;
+	if (prefix) printf("%s", prefix);
+	nbits = (int)mpBitLength(a, ndigits);
+	for (i = nbits; i > 0; i--) {
+		// Could use a mask here to avoid slightly more expensive calls to mpGetBit(), but hey!
+		v = mpGetBit(a, ndigits, i - 1);
+		printf("%c", (v ? '1' : '0'));
+	}
+	if (0 == nbits) printf("0");
+	if (suffix) printf("%s", suffix);
+}
+
+/************************/
+/* CONVERSION FUNCTIONS */
+/************************/
+size_t mpConvFromOctets(DIGIT_T a[], size_t ndigits, const unsigned char *c, size_t nbytes)
+/* Converts nbytes octets into big digit a of max size ndigits
+   Returns actual number of digits set (may be larger than mpSizeof)
+*/
+{
+	size_t i;
+	int j, k;
+	DIGIT_T t;
+
+	mpSetZero(a, ndigits);
+
+	/* Read in octets, least significant first */
+	/* i counts into big_d, j along c, and k is # bits to shift */
+	for (i = 0, j = (int)nbytes - 1; i < ndigits && j >= 0; i++)
+	{
+		t = 0;
+		for (k = 0; j >= 0 && k < BITS_PER_DIGIT; j--, k += 8)
+			t |= ((DIGIT_T)c[j]) << k;
+		a[i] = t;
+	}
+
+	return i;
+}
+
+size_t mpConvToOctets(const DIGIT_T a[], size_t ndigits, unsigned char *c, size_t nbytes)
+/* Convert big digit a into string of octets, in big-endian order,
+   padding on the left to nbytes or truncating if necessary.
+   Return number of octets required excluding leading zero bytes.
+*/
+{
+	int j, k, len;
+	DIGIT_T t;
+	size_t i, noctets, nbits;
+
+	nbits = mpBitLength(a, ndigits);
+	noctets = (nbits + 7) / 8;
+
+	len = (int)nbytes;
+
+	for (i = 0, j = len - 1; i < ndigits && j >= 0; i++)
+	{
+		t = a[i];
+		for (k = 0; j >= 0 && k < BITS_PER_DIGIT; j--, k += 8)
+			c[j] = (unsigned char)(t >> k);
+	}
+
+	for ( ; j >= 0; j--)
+		c[j] = 0;
+
+	return (size_t)noctets;
+}
+
+static size_t uiceil(double x)
+/* Returns ceil(x) as a non-negative integer or 0 if x < 0 */
+{
+	size_t c;
+
+	if (x < 0) return 0;
+	c = (size_t)x;
+	if ((x - c) > 0.0)
+		c++;
+
+	return c;
+}
+
+static size_t conv_to_base(const DIGIT_T a[], size_t ndigits, char *s, size_t smax, int base)
+/* Convert big digit a into a string in given base format, 
+   where s has max size smax.
+   Return number of chars set excluding leading zeroes.
+   smax can be 0 to find out the required length.
+*/
+{
+#ifdef NO_ALLOCS
+	uint8_t bytes[MAX_ALLOC_SIZE], newdigits[MAX_ALLOC_SIZE*3]; // [v2.6] increased
+#else
+	uint8_t *bytes, *newdigits;
+#endif
+	const char DEC_DIGITS[] = "0123456789";
+	const char HEX_DIGITS[] = "0123456789abcdef";
+	size_t newlen, nbytes, nchars;
+	size_t n;
+	unsigned long t;
+	size_t i, j, isig;
+	const char *digits;
+	double factor;
+
+	switch (base)
+	{
+	case 10:
+		digits = DEC_DIGITS;
+		factor = 2.40824;	/* log(256)/log(10)=2.40824 */
+		break;
+	case 16:
+		digits = HEX_DIGITS;
+		factor = 2.0;	/* log(256)/log(16)=2.0 */
+		break;
+	default:
+		assert (10 == base || 16 == base);
+		return 0;
+	}
+
+	/* Set up output string with null chars */
+	if (smax > 0 && s)
+	{
+		memset(s, '0', smax-1);
+		s[smax-1] = '\0';
+	}
+
+	/* Catch zero input value (return 1 not zero) */
+	if (mpIsZero(a, ndigits))
+	{
+		if (smax > 0 && s)
+			s[1] = '\0';
+		return 1;
+	}
+
+	/* First, we convert to 8-bit octets (bytes), which are easier to handle */
+	nbytes = ndigits * BITS_PER_DIGIT / 8;
+	ALLOC_BYTES(bytes, nbytes);
+
+	n = mpConvToOctets(a, ndigits, bytes, nbytes);
+
+	/* Create some temp storage for int values */
+	newlen = uiceil(n * factor);
+	ALLOC_BYTES(newdigits, newlen);
+
+	for (i = 0; i < nbytes; i++)
+	{
+		t = bytes[i];
+		for (j = newlen; j > 0; j--)
+		{
+			t += (unsigned long)newdigits[j-1] * 256;
+			newdigits[j-1] = (unsigned char)(t % base);
+			t /= base;
+		}
+	}
+
+	/* Find index of leading significant digit */
+	for (isig = 0; isig < newlen; isig++)
+		if (newdigits[isig])
+			break;
+
+	nchars = newlen - isig;
+
+	/* Convert to a null-terminated string of decimal chars */
+	/* up to limit, unless user has specified null or size == 0 */
+	if (smax > 0 && s)
+	{
+		for (i = 0; i < nchars && i < smax-1; i++)
+		{
+			s[i] = digits[newdigits[isig+i]];
+		}
+		s[i] = '\0';
+	}
+
+	FREE_BYTES(bytes, nbytes);
+	FREE_BYTES(newdigits, newlen);
+
+	return nchars;
+}
+
+size_t mpConvToDecimal(const DIGIT_T a[], size_t ndigits, char *s, size_t smax)
+/* Convert big digit a into a string in decimal format, 
+   where s has max size smax.
+   Return number of chars set excluding leading zeroes.
+*/
+{
+	return conv_to_base(a, ndigits, s, smax, 10);
+}
+
+size_t mpConvToHex(const DIGIT_T a[], size_t ndigits, char *s, size_t smax)
+/* Convert big digit a into a string in hexadecimal format, 
+   where s has max size smax.
+   Return number of chars set excluding leading zeroes.
+*/
+{
+	return conv_to_base(a, ndigits, s, smax, 16);
+}
+
+size_t mpConvFromDecimal(DIGIT_T a[], size_t ndigits, const char *s)
+/* Convert a string in decimal format to a big digit.
+   Return actual number of digits set (may be larger than mpSizeof).
+   Just ignores invalid characters in s.
+*/
+{
+#ifdef NO_ALLOCS
+	uint8_t newdigits[MAX_ALLOC_SIZE*2];	// [v2.6] increased
+#else
+	uint8_t *newdigits;
+#endif
+	size_t newlen;
+	size_t n;
+	unsigned long t;
+	size_t i, j;
+	const int base = 10;
+
+	mpSetZero(a, ndigits);
+
+	/* Create some temp storage for int values */
+	n = strlen(s);
+	if (0 == n) return 0;
+	newlen = uiceil(n * 0.41524);	/* log(10)/log(256)=0.41524 */
+	ALLOC_BYTES(newdigits, newlen);
+
+	/* Work through zero-terminated string */
+	for (i = 0; s[i]; i++)
+	{
+		t = s[i] - '0';
+		if (t > 9 || t < 0) continue;
+		for (j = newlen; j > 0; j--)
+		{
+			t += (unsigned long)newdigits[j-1] * base;
+			newdigits[j-1] = (unsigned char)(t & 0xFF);
+			t >>= 8;
+		}
+	}
+
+	/* Convert bytes to big digits */
+	n = mpConvFromOctets(a, ndigits, newdigits, newlen);
+
+	/* Clean up */
+	FREE_BYTES(newdigits, newlen);
+
+	return n;
+}
+
+size_t mpConvFromHex(DIGIT_T a[], size_t ndigits, const char *s)
+/* Convert a string in hexadecimal format to a big digit.
+   Return actual number of digits set (may be larger than mpSizeof).
+   Just ignores invalid characters in s.
+*/
+{
+#ifdef NO_ALLOCS
+	uint8_t newdigits[MAX_ALLOC_SIZE*2];	// [v2.6] increased
+#else
+	uint8_t *newdigits;
+#endif
+	size_t newlen;
+	size_t n;
+	unsigned long t;
+	size_t i, j;
+
+	mpSetZero(a, ndigits);
+
+	/* Create some temp storage for int values */
+	n = strlen(s);
+	if (0 == n) return 0;
+	newlen = uiceil(n * 0.5);	/* log(16)/log(256)=0.5 */
+	ALLOC_BYTES(newdigits, newlen);
+
+	/* Work through zero-terminated string */
+	for (i = 0; s[i]; i++)
+	{
+		t = s[i];
+		if ((t >= '0') && (t <= '9')) t = (t - '0');
+		else if ((t >= 'a') && (t <= 'f')) t = (t - 'a' + 10);
+		else if ((t >= 'A') && (t <= 'F')) t = (t - 'A' + 10);
+		else continue;
+		for (j = newlen; j > 0; j--)
+		{
+			t += (unsigned long)newdigits[j-1] << 4;
+			newdigits[j-1] = (unsigned char)(t & 0xFF);
+			t >>= 8;
+		}
+	}
+
+	/* Convert bytes to big digits */
+	n = mpConvFromOctets(a, ndigits, newdigits, newlen);
+
+	/* Clean up */
+	FREE_BYTES(newdigits, newlen);
+
+	return n;
+}
+
+/***************************/
+/* NUMBER THEORY FUNCTIONS */
+/***************************/
+int mpModulo(DIGIT_T r[], const DIGIT_T u[], size_t udigits, 
+			 DIGIT_T v[], size_t vdigits)
+{
+	/*	Computes r = u mod v
+		where r, v are multiprecision integers of length vdigits
+		and u is a multiprecision integer of length udigits.
+		r may overlap v.
+
+		Note that r here is only vdigits long, 
+		whereas in mpDivide it is udigits long.
+
+		Use remainder from mpDivide function.
+	*/
+
+	size_t nn = max(udigits, vdigits);
+/* Allocate temp storage */
+#ifdef NO_ALLOCS
+	// [v2.6] increased to two times
+	DIGIT_T qq[MAX_FIXED_DIGITS*2];
+	DIGIT_T rr[MAX_FIXED_DIGITS*2];
+	assert(nn <= (MAX_FIXED_DIGITS*2));
+#else
+	DIGIT_T *qq, *rr;
+	qq = mpAlloc(udigits);
+	rr = mpAlloc(nn);
+#endif
+
+
+	/* rr[nn] = u mod v */
+	mpDivide(qq, rr, u, udigits, v, vdigits);
+
+	/* Final r is only vdigits long */
+	mpSetEqual(r, rr, vdigits);
+
+	mpDESTROY(rr, udigits);
+	mpDESTROY(qq, udigits);
+
+	return 0;
+}
+
+int mpModMult(DIGIT_T a[], const DIGIT_T x[], const DIGIT_T y[], 
+			  DIGIT_T m[], size_t ndigits)
+{	/*	Computes a = (x * y) mod m */
+	
+/* Double-length temp variable p */
+#ifdef NO_ALLOCS
+	DIGIT_T p[MAX_FIXED_DIGITS * 2];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *p;
+	p = mpAlloc(ndigits * 2);
+#endif
+
+	/* Calc p[2n] = x * y */
+	mpMultiply(p, x, y, ndigits);
+
+	/* Then modulo (NOTE: a is OK at only ndigits long) */
+	mpModulo(a, p, ndigits * 2, m, ndigits);
+
+	mpDESTROY(p, ndigits * 2);
+
+	return 0;
+}
+
+
+// [v2.6] new 
+/**	Computes a = x^2 mod m */
+int mpModSquare(DIGIT_T a[], const DIGIT_T x[], DIGIT_T m[], size_t ndigits)
+{
+	
+/* Double-length temp variable p */
+#ifdef NO_ALLOCS
+	DIGIT_T p[MAX_FIXED_DIGITS * 2];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *p;
+	p = mpAlloc(ndigits * 2);
+#endif
+
+	/* Calc p[2n] = x^2 */
+	mpSquare(p, x, ndigits);
+
+	/* Then modulo (NOTE: a is OK at only ndigits long) */
+	mpModulo(a, p, ndigits * 2, m, ndigits);
+
+	mpDESTROY(p, ndigits * 2);
+
+	return 0;
+}
+
+/* Compute w = u + v (mod m) where 0 <= u,v < m and w != v */
+void mpModAdd(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T v[], const DIGIT_T m[], size_t ndigits)
+{
+	int carry;
+	// w != v
+	carry = mpAdd(w, u, v, ndigits);
+	// NB This works even with overflow beyond ndigits
+	if (carry || mpCompare(w, m, ndigits) >= 0) {
+		mpSubtract(w, w, m, ndigits);
+	}
+}
+
+
+/* Compute w = u - v (mod m) where 0 <= u,v < m and w != v */
+void mpModSub(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T v[], const DIGIT_T m[], size_t ndigits)
+{
+	/* We need a temp variable t [to allow mpModSub(w,w,v,...)] */
+#ifdef NO_ALLOCS
+	DIGIT_T t[MAX_FIXED_DIGITS];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *t;
+	t = mpAlloc(ndigits);
+#endif
+	/* w <-- m - v [always > 0] */
+	mpSubtract(t, m, v, ndigits);
+	/* w <-- w + u (mod m) */
+	mpModAdd(w, u, t, m, ndigits);
+
+	mpDESTROY(t, ndigits);
+}
+
+/** Set w = u/2 (mod p) - actually works modulo any odd integer p */
+void mpModHalve(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T p[], size_t ndigits)
+{
+	int carry;
+
+	if (mpISODD(u, ndigits)) {
+		/* If u is odd then add p and then right-shift by one bit */
+		/* w <-- (u + p)/2 {do not reduce sum modulo p} */
+		carry = mpAdd(w, u, p, ndigits);
+		mpShiftRight(w, w, 1, ndigits);
+		/* Cope with overflow {NB assumes exact number of digits} */
+		if (carry)
+			mpSetBit(w, ndigits, (ndigits * BITS_PER_DIGIT) - 1, 1);
+	}
+	else {
+		/* If u is even then u/2 mod p is same as u/2 i.e. u right-shifted by one bit */
+		mpShiftRight(w, u, 1, ndigits);
+	}
+}
+
+
+/* Compute u = v mod m where 0 <= v < km for small k */
+void mpModSpecial(DIGIT_T u[], const DIGIT_T v[], const DIGIT_T m[], size_t ndigits)
+{
+	mpSetEqual(u, v, ndigits);
+	// Use subtraction instead of full division - faster if k is small, say 2 or 3
+	while (mpCompare(u, m, ndigits) >= 0)
+		mpSubtract(u, u, m, ndigits);
+}
+
+
+/* Compute x = one square root of a (mod p). Return -1 if root does not exist, 0 if successful. */
+int mpModSqrt(DIGIT_T x[], const DIGIT_T a[], DIGIT_T p[], size_t ndigits)
+{
+	DIGIT_T r, m;
+	int result;
+
+	/* Allocate temp storage */
+#ifdef NO_ALLOCS
+	DIGIT_T q[MAX_FIXED_DIGITS];
+	DIGIT_T n[MAX_FIXED_DIGITS];
+	DIGIT_T y[MAX_FIXED_DIGITS];
+	DIGIT_T b[MAX_FIXED_DIGITS];
+	DIGIT_T k[MAX_FIXED_DIGITS];
+	DIGIT_T e[MAX_FIXED_DIGITS];
+	DIGIT_T t[MAX_FIXED_DIGITS];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *q, *n, *y, *b, *k, *e, *t;
+	q = mpAlloc(ndigits);
+	n = mpAlloc(ndigits);
+	y = mpAlloc(ndigits);
+	b = mpAlloc(ndigits);
+	k = mpAlloc(ndigits);
+	e = mpAlloc(ndigits);
+	t = mpAlloc(ndigits);
+#endif
+
+	/* Shanks-Tonelli Algorithm from [BLAKE] Algorithm II.8 and [INF] */
+
+	/* 1. Let r, q be integers such that q is odd and p-1 = q*2^r */
+	mpShortSub(q, p, 1, ndigits);
+	for (r = 0; mpISEVEN(q, ndigits); r++) {
+		mpShiftRight(q, q, 1, ndigits);
+	}
+
+	/* Catch special case */
+	if (1 == r) {
+		/* We have p == 3 (mod 4) so
+		* set x <-- a^((p+1)/4) mod p and return.
+		* { Note that in this case (p+1)/4 = (p>>2) + 1 } */
+		mpShiftRight(k, p, 2, ndigits);
+		mpShortAdd(k, k, 1, ndigits);
+		mpModExp(x, a, k, p, ndigits);
+		goto do_check;
+	}
+
+	/* 2. Choose (random) number n until one is found such that (n|p) = -1 */
+	/* for n <-- 2 until (n|p)= -1 do n <-- n + 1 */
+	mpSetDigit(n, 2, ndigits);
+	while (mpJacobi(n, p, ndigits) != -1) {
+		mpShortAdd(n, n, 1, ndigits);
+	}
+
+	/* Initialize: { Steps 1 to 3 could be pre-computed }*/
+	/* 3. y <-- n^q */
+	mpModExp(y, n, q, p, ndigits);
+
+	/* 4. b <-- a^((q-1)/2) */
+	/* { (q-1)/2 = q >> 1 since q is odd } */
+	mpShiftRight(k, q, 1, ndigits);
+	mpModExp(b, a, k, p, ndigits);
+	/* 5. x <-- a*b = a^((q+1)/2) */
+	mpModMult(x, a, b, p, ndigits);
+	/* 6. b <-- b*x = a^q */
+	mpModMult(b, b, x, p, ndigits);
+	/* 7. while b != 1 do: */
+	while (!mpShortIsEqual(b, 1, ndigits)) {
+		/* 8. Find smallest m such that b^(2^m) == 1 mod p */
+		mpSetEqual(t, b, ndigits); /* t = b^(2^0) = b */
+		for (m = 0; m < r && !mpShortIsEqual(t, 1, ndigits); m++) {
+			/* t = t^2 = b^(2^(m-1))^2 = b^(2^m) */
+			mpModSquare(t, t, p, ndigits);
+		}
+		/* 9. t <-- y^(2^(r-m-1)) */
+		mpSetDigit(e, 1, ndigits);
+		mpShiftLeft(e, e, (r - m - 1), ndigits); /* = 2^(r-m-1) */
+		mpModExp(t, y, e, p, ndigits);
+		/* 10. y <-- t^2 = y^(2^(r-m)) */
+		mpModSquare(y, t, p, ndigits);
+		/* 11. r <-- m */
+		r = m;
+		/* 12. x <-- x*t = x.y^(2^(r-m-1)) */
+		mpModMult(x, x, t, p, ndigits);
+		/* 13. b <-- b*y = b.y^(2^(r-m)) */
+		mpModMult(b, b, y, p, ndigits);
+	}
+
+	/* 14. return x or NO_ROOT_EXISTS */
+
+do_check:
+	/* Check that x^2 = a */
+	mpModSquare(k, x, p, ndigits);
+	result = (mpEqual(k, a, ndigits) ? 0 : -1); /* 0 => OK, -1 => NO_ROOT_EXISTS */
+
+	/* Clear up */
+	mpDESTROY(q, ndigits);
+	mpDESTROY(n, ndigits);
+	mpDESTROY(y, ndigits);
+	mpDESTROY(b, ndigits);
+	mpDESTROY(k, ndigits);
+	mpDESTROY(e, ndigits);
+	mpDESTROY(t, ndigits);
+
+	return result;
+}
+
+
+int mpModInv(DIGIT_T inv[], const DIGIT_T u[], const DIGIT_T v[], size_t ndigits)
+{	/*	Computes inv = u^(-1) mod v */
+	/*	Ref: Knuth Algorithm X Vol 2 p 342
+		ignoring u2, v2, t2
+		and avoiding negative numbers.
+		Returns non-zero if inverse undefined.
+	*/
+	int bIterations;
+	int result;
+/* Allocate temp storage */
+#ifdef NO_ALLOCS
+	DIGIT_T u1[MAX_FIXED_DIGITS];
+	DIGIT_T u3[MAX_FIXED_DIGITS];
+	DIGIT_T v1[MAX_FIXED_DIGITS];
+	DIGIT_T v3[MAX_FIXED_DIGITS];
+	DIGIT_T t1[MAX_FIXED_DIGITS];
+	DIGIT_T t3[MAX_FIXED_DIGITS];
+	DIGIT_T q[MAX_FIXED_DIGITS];
+	DIGIT_T w[2*MAX_FIXED_DIGITS];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *u1, *u3, *v1, *v3, *t1, *t3, *q, *w;
+	u1 = mpAlloc(ndigits);
+	u3 = mpAlloc(ndigits);
+	v1 = mpAlloc(ndigits);
+	v3 = mpAlloc(ndigits);
+	t1 = mpAlloc(ndigits);
+	t3 = mpAlloc(ndigits);
+	q  = mpAlloc(ndigits);
+	w  = mpAlloc(2 * ndigits);
+#endif
+
+	/* Step X1. Initialise */
+	mpSetDigit(u1, 1, ndigits);		/* u1 = 1 */
+	mpSetEqual(u3, u, ndigits);		/* u3 = u */
+	mpSetZero(v1, ndigits);			/* v1 = 0 */
+	mpSetEqual(v3, v, ndigits);		/* v3 = v */
+
+	bIterations = 1;	/* Remember odd/even iterations */
+	while (!mpIsZero(v3, ndigits))		/* Step X2. Loop while v3 != 0 */
+	{					/* Step X3. Divide and "Subtract" */
+		mpDivide(q, t3, u3, ndigits, v3, ndigits);
+						/* q = u3 / v3, t3 = u3 % v3 */
+		mpMultiply(w, q, v1, ndigits);	/* w = q * v1 */
+		mpAdd(t1, u1, w, ndigits);		/* t1 = u1 + w */
+
+		/* Swap u1 = v1; v1 = t1; u3 = v3; v3 = t3 */
+		mpSetEqual(u1, v1, ndigits);
+		mpSetEqual(v1, t1, ndigits);
+		mpSetEqual(u3, v3, ndigits);
+		mpSetEqual(v3, t3, ndigits);
+
+		bIterations = -bIterations;
+	}
+
+	if (bIterations < 0)
+		mpSubtract(inv, v, u1, ndigits);	/* inv = v - u1 */
+	else
+		mpSetEqual(inv, u1, ndigits);	/* inv = u1 */
+
+	/* Make sure u3 = gcd(u,v) == 1 */
+	if (mpShortCmp(u3, 1, ndigits) != 0)
+	{
+		result = 1;
+		mpSetZero(inv, ndigits);
+	}
+	else
+		result = 0;
+
+	/* Clear up */
+	mpDESTROY(u1, ndigits);
+	mpDESTROY(v1, ndigits);
+	mpDESTROY(t1, ndigits);
+	mpDESTROY(u3, ndigits);
+	mpDESTROY(v3, ndigits);
+	mpDESTROY(t3, ndigits);
+	mpDESTROY(q, ndigits);
+	mpDESTROY(w, 2*ndigits);
+
+	return result;
+}
+
+int mpGcd(DIGIT_T d[], const DIGIT_T aa[], const DIGIT_T bb[], size_t ndigits)
+{	
+	/* Computes d = gcd(a, b) */
+	/* Changed to Binary GCD in [v2.3] 
+	 * Ref: Menezes Algorithm 14.54 plus some of Cohen Algorithm 1.3.5. 
+	 */
+
+	unsigned int k;
+
+/*	Allocate temp storage */
+#ifdef NO_ALLOCS
+	DIGIT_T a[MAX_FIXED_DIGITS];
+	DIGIT_T b[MAX_FIXED_DIGITS];
+	DIGIT_T r[MAX_FIXED_DIGITS];
+	DIGIT_T t[MAX_FIXED_DIGITS];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *a, *b, *r, *t;
+	a = mpAlloc(ndigits);
+	b = mpAlloc(ndigits);
+	r = mpAlloc(ndigits);
+	t = mpAlloc(ndigits);
+#endif
+	
+	/* Copy input into temp vars */
+	mpSetEqual(a, aa, ndigits);
+	mpSetEqual(b, bb, ndigits);
+
+	/* 1. [Reduce size once] */
+	if (mpCompare(a, b, ndigits) < 0)
+	{	/* Exchange a and b */
+		mpSetEqual(t, a, ndigits);
+		mpSetEqual(a, b, ndigits);
+		mpSetEqual(b, t, ndigits);
+	}
+	/* If b = 0 output a and stop */
+	if (mpIsZero(b, ndigits))
+	{
+		mpSetEqual(d, a, ndigits);
+		goto done;
+	}
+	/* Set r <-- a mod b, a <-- b, b <-- r */
+	mpModulo(r, a, ndigits, b, ndigits);
+	mpSetEqual(a, b, ndigits);
+	mpSetEqual(b, r, ndigits);
+	/* If b = 0 output a and stop */
+	if (mpIsZero(b, ndigits))
+	{
+		mpSetEqual(d, a, ndigits);
+		goto done;
+	}
+
+	/* 2. [Compute power of 2] */
+	k = 0;	/* g = 2^k <-- 1 */
+	while (mpISEVEN(a, ndigits) && mpISEVEN(b, ndigits))
+	{	/* While a and b are even */
+		mpShiftRight(a, a, 1, ndigits);	/* a <-- a/2 */
+		mpShiftRight(b, b, 1, ndigits);	/* b <-- b/2 */
+		k++;	/* g <-- 2g */
+	}
+	while (!mpIsZero(a, ndigits))
+	{
+		/* 3. [Remove initial powers of 2] */
+		while (mpISEVEN(a, ndigits))
+			mpShiftRight(a, a, 1, ndigits);	/* a <-- a/2 until a is odd */
+		while (mpISEVEN(b, ndigits))
+			mpShiftRight(b, b, 1, ndigits);	/* b <-- b/2 until b is odd */
+		/* 4. [Subtract] t = |a - b|/2 */
+		if (mpCompare(b, a, ndigits) > 0)
+			mpSubtract(t, b, a, ndigits);
+		else
+			mpSubtract(t, a, b, ndigits);
+		mpShiftRight(t, t, 1, ndigits);
+		/* if a >= b then set a <-- t otherwise set b <-- t */
+		if (mpCompare(a, b, ndigits) >= 0)
+			mpSetEqual(a, t, ndigits);
+		else
+			mpSetEqual(b, t, ndigits);
+
+		/* 5. [Loop] */
+	}
+	/* Output (2^k.b) and stop */
+	mpShiftLeft(d, b, k, ndigits);	
+done:
+
+	mpDESTROY(a, ndigits);
+	mpDESTROY(b, ndigits);
+	mpDESTROY(r, ndigits);
+	mpDESTROY(t, ndigits);
+
+	return 0;	/* gcd is in d */
+}
+
+int mpSqrt(DIGIT_T s[], const DIGIT_T n[], size_t ndigits)
+	/* Computes integer square root s = floor(sqrt(n)) i.e. 
+	the largest integer whose square is less than or equal to n */
+	/* [Added v2.1, updated v2.3] Ref: H. Cohen Alg 1.7.1 */
+{
+/*	Allocate temp storage */
+#ifdef NO_ALLOCS
+	DIGIT_T x[MAX_FIXED_DIGITS];
+	DIGIT_T y[MAX_FIXED_DIGITS];
+	DIGIT_T q[MAX_FIXED_DIGITS];
+	DIGIT_T r[MAX_FIXED_DIGITS];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *x, *y, *q, *r;
+	x = mpAlloc(ndigits);
+	y = mpAlloc(ndigits);
+	q = mpAlloc(ndigits);
+	r = mpAlloc(ndigits);
+#endif
+
+	/* if (n <= 1) return n */
+	if (mpShortCmp(n, 1, ndigits) <= 0)
+	{
+		mpSetEqual(s, n, ndigits);
+		goto done;
+	}
+
+	/* 1. [Initialize] Set x = n */
+	mpSetEqual(x, n, ndigits);
+
+	while (1)
+	{
+		/* 2. [Newtonian step] Set y = [x + [n/x]]]/2 */
+		mpDivide(q, r, n, ndigits, x, ndigits);
+		mpAdd(y, x, q, ndigits);
+		mpShiftRight(y, y, 1, ndigits);
+
+		/* 3a. [Finished?] If y < x set x = y and go to step 2 */
+		if (mpCompare(y, x, ndigits) >= 0)
+			break;
+
+		mpSetEqual(x, y, ndigits);
+	}
+
+	/* 3b. Otherwise output x and stop. */
+	mpSetEqual(s, x, ndigits);
+
+done:
+	mpDESTROY(x, ndigits);
+	mpDESTROY(y, ndigits);
+	mpDESTROY(q, ndigits);
+	mpDESTROY(r, ndigits);
+
+	return 0;
+}
+
+int mpCubeRoot(DIGIT_T s[], const DIGIT_T n[], size_t ndigits)
+	/* Computes integer cube root s = floor(cuberoot(n)) i.e. 
+	the largest integer whose cube is less than or equal to n */
+	/* [Added v2.3] */
+{
+/*	Allocate temp storage */
+#ifdef NO_ALLOCS
+	DIGIT_T x[MAX_FIXED_DIGITS];
+	DIGIT_T y[MAX_FIXED_DIGITS];
+	DIGIT_T q[MAX_FIXED_DIGITS];
+	DIGIT_T r[MAX_FIXED_DIGITS];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *x, *y, *q, *r;
+	x = mpAlloc(ndigits);
+	y = mpAlloc(ndigits);
+	q = mpAlloc(ndigits);
+	r = mpAlloc(ndigits);
+#endif
+
+	/* if (n <= 1) return n */
+	if (mpShortCmp(n, 1, ndigits) <= 0)
+	{
+		mpSetEqual(s, n, ndigits);
+		goto done;
+	}
+
+	/* 1. [Initialize] Set x = n */
+	mpSetEqual(x, n, ndigits);
+
+	while (1)
+	{
+		/* 2. [Newtonian step] Set y = [2x + [n/x^2]]/3 */
+		mpDivide(y, r, n, ndigits, x, ndigits);
+		mpDivide(q, r, y, ndigits, x, ndigits);
+		mpAdd(y, q, x, ndigits);
+		mpAdd(q, y, x, ndigits);
+		mpShortDiv(y, q, 3, ndigits);
+
+		/* 3a. [Finished?] If y < x set x = y and go to step 2 */
+		if (mpCompare(y, x, ndigits) >= 0)
+			break;
+
+		mpSetEqual(x, y, ndigits);
+	}
+
+	/* 3b. Otherwise output x and stop. */
+	mpSetEqual(s, x, ndigits);
+
+done:
+	mpDESTROY(x, ndigits);
+	mpDESTROY(y, ndigits);
+	mpDESTROY(q, ndigits);
+	mpDESTROY(r, ndigits);
+
+	return 0;
+}
+
+int mpJacobi(const DIGIT_T a[], const DIGIT_T n[], size_t ndigits)
+	/* Returns Jacobi(a, n) = {0, +1, -1} */
+	/* [Added v2.2] */
+{
+/* Ref: Menezes.
+Algorithm 2.149 Jacobi symbol (and Legendre symbol) computation
+JACOBI(a,n)
+INPUT: an odd integer n >= 3, and an integer a, 0 <= a < n.
+OUTPUT: the Jacobi symbol (a/n) (and hence the Legendre symbol when n is prime).
+1. If a = 0 then return(0).
+2. If a = 1 then return(1).
+3. Write a = 2^e.a_1, where a_1 is odd.
+4. If e is even then set s <-- 1. Otherwise set s <-- 1 if n \equiv 1 or 7 (mod 8), 
+or set s <-- -1 if n \equiv 3 or 5 (mod 8).
+5. If n \equiv 3 (mod 4) and a1 \equiv 3 (mod 4) then set s <-- -s.
+6. Set n1 <-- n mod a1.
+7. If a1 = 1 then return(s); otherwise return(s * JACOBI(n1,a1)).
+*/
+	
+	int s;
+	DIGIT_T nmod8;
+	unsigned e;
+
+/*	Allocate temp storage */
+#ifdef NO_ALLOCS
+	DIGIT_T a1[MAX_FIXED_DIGITS];
+	DIGIT_T n1[MAX_FIXED_DIGITS];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *a1, *n1;
+	a1 = mpAlloc(ndigits);
+	n1 = mpAlloc(ndigits);
+#endif
+
+
+	/* 1. If a = 0 then return(0). */
+	if (mpIsZero(a, ndigits))
+	{
+		s = 0;
+		goto done;
+	}
+	/* 2. If a = 1 then return(1). */
+	if (mpShortCmp(a, 1, ndigits) == 0)
+	{
+		s = 1;
+		goto done;
+	}
+	/* 3. Write a = 2^e.a_1, where a_1 is odd. */
+	mpSetEqual(a1, a, ndigits);
+	for (e = 0; mpISEVEN(a1, ndigits); e++)
+	{
+		 mpShiftRight(a1, a1, 1, ndigits);
+	}
+	/* 4. 
+	If e is even then set s <-- 1. Otherwise set s <-- 1 if n \equiv 1 or 7 (mod 8), 
+	or set s <-- -1 if n \equiv 3 or 5 (mod 8). */
+	if (ISEVEN(e))
+		s = 1;
+	else
+	{
+		nmod8 = mpShortMod(n, 8, ndigits);
+		if (nmod8 == 1 || nmod8 == 7)
+			s = 1;
+		else
+			s = -1;
+	}
+	/* 5. If n \equiv 3 (mod 4) and a1 \equiv 3 (mod 4) then set s <-- -s. */
+	if (mpShortMod(n, 4, ndigits) == 3 && mpShortMod(a1, 4, ndigits) == 3)
+		s = -s;
+	
+	/* 
+	6. Set n1 <-- n mod a1.
+	7. If a1 = 1 then return(s); otherwise return(s * JACOBI(n1,a1)). 
+	*/
+	if (mpShortCmp(a1, 1, ndigits) != 0)
+	{
+		mpModulo(n1, n, ndigits, a1, ndigits);
+		s = s * mpJacobi(n1, a1, ndigits);
+	}
+	
+done:
+	mpDESTROY(a1, ndigits);
+	mpDESTROY(n1, ndigits);
+
+	return s;
+}
+
+
+/* mpIsPrime: Changes in Version 2: 
+   Added mpAlloc for dynamic allocation
+   Increased no of small primes
+   Broke out mpRabinMiller() as a separate function
+*/
+
+static DIGIT_T SMALL_PRIMES[] = {
+	3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 
+	47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 
+	103, 107, 109, 113,
+	127, 131, 137, 139, 149, 151, 157, 163, 167, 173,
+	179, 181, 191, 193, 197, 199, 211, 223, 227, 229,
+	233, 239, 241, 251, 257, 263, 269, 271, 277, 281,
+	283, 293, 307, 311, 313, 317, 331, 337, 347, 349,
+	353, 359, 367, 373, 379, 383, 389, 397, 401, 409,
+	419, 421, 431, 433, 439, 443, 449, 457, 461, 463,
+	467, 479, 487, 491, 499, 503, 509, 521, 523, 541,
+	547, 557, 563, 569, 571, 577, 587, 593, 599, 601,
+	607, 613, 617, 619, 631, 641, 643, 647, 653, 659,
+	661, 673, 677, 683, 691, 701, 709, 719, 727, 733,
+	739, 743, 751, 757, 761, 769, 773, 787, 797, 809,
+	811, 821, 823, 827, 829, 839, 853, 857, 859, 863,
+	877, 881, 883, 887, 907, 911, 919, 929, 937, 941,
+	947, 953, 967, 971, 977, 983, 991, 997,
+};
+#define N_SMALL_PRIMES (sizeof(SMALL_PRIMES)/sizeof(SMALL_PRIMES[0]))
+
+int mpIsPrime(DIGIT_T w[], size_t ndigits, size_t t)
+{	/*	Returns true if w is a probable prime */
+	/*	Version 2: split out mpRabinMiller. */
+
+	size_t i;
+
+	/* Check the obvious */
+	if (mpShortCmp(w, 2, ndigits) <= 0)
+	{
+		if (mpShortCmp(w, 2, ndigits) < 0)
+			return 0;	/* 0 and 1 are not primes */
+		return 1;		/* but 2 is a prime */
+	}
+	/* Otherwise any even number > 2 is not a prime */
+	if (mpISEVEN(w, ndigits))
+		return 0;
+
+	/* First check for small primes, unless we could be one ourself */
+	if (mpShortCmp(w, SMALL_PRIMES[N_SMALL_PRIMES-1], ndigits) > 0)
+	{
+		for (i = 0; i < N_SMALL_PRIMES; i++)
+		{
+			if (mpShortMod(w, SMALL_PRIMES[i], ndigits) == 0)
+				return 0; /* Failed, so not a prime */
+		}
+	}
+	else
+	{	/* w is a small number, so check directly */
+		for (i = 0; i < N_SMALL_PRIMES; i++)
+		{
+			if (mpShortCmp(w, SMALL_PRIMES[i], ndigits) == 0)
+				return 1;	/* w is a small prime */
+		}
+		return 0;	/* w is not a small prime */
+	}
+
+	return mpRabinMiller(w, ndigits, t);
+}
+
+/* Local, simple rng functions used in Rabin-Miller */
+static void rand_seed(void);
+static DIGIT_T rand_between(DIGIT_T lower, DIGIT_T upper);
+
+int mpRabinMiller(DIGIT_T w[], size_t ndigits, size_t t)
+{	
+/*	Returns true (1) if w is a probable prime using the
+	Rabin-Miller Probabilistic Primality Test.
+	Carries out t iterations specified by user.
+	Ref: FIPS-186-2 Appendix 2 Section 2.1.
+	Also Schneier 2nd ed p 260 & Knuth Vol 2, p 379
+	and ANSI 9.42-2003 Annex B.1.1.
+
+	DSS Standard and ANSI 9.42 recommend using t >= 50
+	for probability of error less than or equal to 2^-100.
+	Ferguson & Schneier recommend t = 64 for prob error < 2^-128
+	In practice, most random composites are caught in the first
+	round or two and so specifying a large t will only affect
+	the final check.
+
+	[v2.1] Updated range of bases from [2, N-1] to [2, N-2]
+	See ANSI 9.42-2003 Annex F.1.1 `Range of bases in Miller-Rabin test'
+	(NB this does not impact existing implementations because N-1 
+	is unlikely to be chosen as a base).
+*/
+
+	/* Temp big digits */
+	DIGIT_T maxrand;
+	int failed, isprime;
+	size_t i;
+/*	Allocate temp storage */
+#ifdef NO_ALLOCS
+	DIGIT_T m[MAX_FIXED_DIGITS];
+	DIGIT_T a[MAX_FIXED_DIGITS];
+	DIGIT_T b[MAX_FIXED_DIGITS];
+	DIGIT_T z[MAX_FIXED_DIGITS];
+	DIGIT_T w1[MAX_FIXED_DIGITS];
+	DIGIT_T j[MAX_FIXED_DIGITS];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *m, *a, *b, *z, *w1, *j;
+	m = mpAlloc(ndigits);
+	a = mpAlloc(ndigits);
+	b = mpAlloc(ndigits);
+	z = mpAlloc(ndigits);
+	w1 = mpAlloc(ndigits);
+	j = mpAlloc(ndigits);
+#endif
+
+	/* Catch w <= 1 */
+	if (mpShortCmp(w, 1, ndigits) <= 0)
+	{
+		isprime = 0;
+		goto done;
+	}
+	
+	/* Seed the simple RNG for later on */
+	rand_seed();
+
+	/*	Rabin-Miller from FIPS-186-2 Appendix 2. 
+		Step 1. Set i = 1 [but do # tests requested by user].
+		Step 2. Find a and m where w = 1 + (2^a)m
+		m is odd and 2^a is largest power of 2 dividing w - 1 
+	*/
+	mpShortSub(w1, w, 1, ndigits);	/* Store w1 = w - 1 */
+	mpSetEqual(m, w1, ndigits);		/* Set m = w - 1 */
+	/* for (a = 0; iseven(m); a++) */
+	for (mpSetZero(a, ndigits); mpISEVEN(m, ndigits); 
+		mpShortAdd(a, a, 1, ndigits))
+	{	/* Divide by 2 until m is odd */
+		mpShiftRight(m, m, 1, ndigits);
+	}
+
+	/* assert((1 << a) * m + 1 == w); */
+
+	/* Catch a small w */
+	if (mpSizeof(w, ndigits) == 1)
+		maxrand = w[0] - 2;	/* [v2.1] changed 1 to 2 */
+	else
+		maxrand = MAX_DIGIT;
+
+	isprime = 1;
+	for (i = 0; i < t; i++)
+	{
+		failed = 1;	/* Assume fail unless passed in loop */
+		/* Step 3. Generate random integer b, 1 < b < w */
+		/* [v2.1] changed to 1 < b < w-1 (see ANSI X9.42-2003 Annex B.1.1) */
+		mpSetZero(b, ndigits);
+		do
+		{
+			b[0] = rand_between(2, maxrand);
+		} while (mpCompare(b, w, ndigits) >= 0);
+
+		/* assert(1 < b && b < w); */
+
+		/* Step 4. Set j = 0 and z = b^m mod w */
+		mpSetZero(j, ndigits);
+		mpModExp(z, b, m, w, ndigits);
+		do
+		{
+			/* Step 5. If j = 0 and z = 1, or if z = w - 1 */
+			/* i.e. if ((j == 0 && z == 1) || (z == w - 1)) */
+			if ((mpIsZero(j, ndigits) 
+				&& mpShortCmp(z, 1, ndigits) == 0)
+				|| (mpCompare(z, w1, ndigits) == 0))
+			{	/* Passes on this loop  - go to Step 9 */
+				failed = 0;
+				break;
+			}
+
+			/* Step 6. If j > 0 and z = 1 */
+			if (!mpIsZero(j, ndigits) 
+				&& (mpShortCmp(z, 1, ndigits) == 0))
+			{	/* Fails - go to Step 8 */
+				failed = 1;
+				break;
+			}
+
+			/* Step 7. j = j + 1. If j < a set z = z^2 mod w */
+			mpShortAdd(j, j, 1, ndigits);
+			if (mpCompare(j, a, ndigits) < 0)
+				mpModMult(z, z, z, w, ndigits);
+			/* Loop: if j < a go to Step 5 */
+		} while (mpCompare(j, a, ndigits) < 0);
+
+		if (failed)
+		{	/* Step 8. Not a prime - stop */
+			isprime = 0;
+			break;
+		}
+	}	/* Step 9. Go to Step 3 until i >= n */
+	/* Else, if i = n, w is probably prime => success */
+
+	/* Clean up */
+done:
+	mpDESTROY(m, ndigits);
+	mpDESTROY(a, ndigits);
+	mpDESTROY(b, ndigits);
+	mpDESTROY(z, ndigits);
+	mpDESTROY(w1, ndigits);
+	mpDESTROY(j, ndigits);
+
+	return isprime;
+}
+
+/***************************/
+/* RANDOM NUMBER FUNCTIONS */
+/***************************/
+
+/* New in [v2.4] */
+/** Generate a quick-and-dirty random mp number a <= 2^{nbits}-1 using plain-old-rand */
+size_t mpQuickRandBits(DIGIT_T a[], size_t ndigits, size_t nbits)
+{
+	size_t ndig, nodd, i;
+	DIGIT_T r;
+
+	mpSetZero(a, ndigits);
+
+	/* Catch too long nbits */
+	if (nbits / BITS_PER_DIGIT > ndigits)
+		nbits = ndigits * BITS_PER_DIGIT;
+
+	ndig = nbits / BITS_PER_DIGIT;	/* # of complete digits */
+	nodd = nbits % BITS_PER_DIGIT;	/* # of odd bits, perhaps zero */
+
+	/* Fill each complete digit with random bits */
+	for (i = 0; i < ndig; i++)
+	{
+		a[i] = spSimpleRand(0, MAX_DIGIT);
+	}
+	if (nodd)
+	{
+		r = spSimpleRand(0, MAX_DIGIT);
+		r >>= BITS_PER_DIGIT - nodd;
+		a[ndig] = r;
+		i++;
+	}
+
+	return i;
+}
+
+/* Internal functions used for "simple" random numbers */
+
+static void rand_seed()
+/* [v2.2] Moved seeding process inside this function.
+   Added clock() to time() to improve precision. 
+   [v2.4] Extra fudge with time shifted left by 16
+*/
+{
+	/* Seed with system time and clock */
+	unsigned int seed = (((unsigned int)time(NULL) & 0xFFFF) << 16) ^ (unsigned int)clock();
+	srand(seed);
+}
+
+static DIGIT_T rand_between(DIGIT_T lower, DIGIT_T upper)
+/* Returns a single pseudo-random digit between lower and upper.
+   Uses rand(). Assumes srand() already called. */
+{
+	DIGIT_T d, range;
+	unsigned char *bp;
+	int i, nbits;
+	DIGIT_T mask;
+
+	if (upper <= lower) return lower;
+	range = upper - lower;
+
+	do
+	{
+		/* Generate a random DIGIT byte-by-byte using rand() */
+		bp = (unsigned char *)&d;
+		for (i = 0; i < sizeof(DIGIT_T); i++)
+		{
+			bp[i] = (unsigned char)(rand() & 0xFF);
+		}
+
+		/* Trim to next highest bit above required range */
+		mask = HIBITMASK;
+		for (nbits = BITS_PER_DIGIT; nbits > 0; nbits--, mask >>= 1)
+		{
+			if (range & mask)
+				break;
+		}
+		if (nbits < BITS_PER_DIGIT)
+		{
+			mask <<= 1;
+			mask--;
+		}
+		else
+			mask = MAX_DIGIT;
+
+		d &= mask;
+
+	} while (d > range); 
+
+	return (lower + d);
+}
+
+DIGIT_T spSimpleRand(DIGIT_T lower, DIGIT_T upper)
+{	/*	Returns a pseudo-random digit.
+		Handles own seeding using time.
+		NOT for cryptographically-secure random numbers.
+		NOT thread-safe because of static variable.
+		Changed in Version 2 to use internal funcs.
+	*/
+	static unsigned seeded = 0;
+
+	if (!seeded)
+	{
+		rand_seed();
+		seeded++;
+	}
+	return rand_between(lower, upper);
+}
+
+/**************************/
+/* MODULAR EXPONENTIATION */
+/**************************/
+/*	[v2.2] Modified to use sliding-window exponentiation.
+	mpModExp_1 is the earlier version [<2.2] now using macros for modular squaring & mult
+*/
+
+static int mpModExp_1(DIGIT_T y[], const DIGIT_T x[], const DIGIT_T n[], DIGIT_T d[], size_t ndigits);
+static int mpModExp_windowed(DIGIT_T y[], const DIGIT_T x[], const DIGIT_T n[], DIGIT_T d[], size_t ndigits);
+
+/** Computes y = x^n mod d */
+int mpModExp(DIGIT_T y[], const DIGIT_T x[], const DIGIT_T n[], DIGIT_T d[], size_t ndigits)
+{
+#ifdef NO_ALLOCS
+	return mpModExp_1(y, x, n, d, ndigits);
+#else
+	return mpModExp_windowed(y, x, n, d, ndigits);
+#endif
+}
+
+/* MACROS TO DO MODULAR SQUARING AND MULTIPLICATION USING PRE-ALLOCATED TEMPS */
+/* Required lengths |y|=|t1|=|t2|=2*n, |m|=n; but final |y|=n */
+/* Square: y = (y * y) mod m */
+#define mpMODSQUARETEMP(y,m,n,t1,t2) do{mpSquare(t1,y,n);mpDivide(t2,y,t1,n*2,m,n);}while(0)
+/* Mult:   y = (y * x) mod m */
+#define mpMODMULTTEMP(y,x,m,n,t1,t2) do{mpMultiply(t1,x,y,n);mpDivide(t2,y,t1,n*2,m,n);}while(0)
+/* Mult:   w = (y * x) mod m */
+#define mpMODMULTXYTEMP(w,y,x,m,n,t1,t2) do{mpMultiply(t1,x,y,(n));mpDivide(t2,w,t1,(n)*2,m,(n));}while(0)
+
+static int mpModExp_1(DIGIT_T yout[], const DIGIT_T x[], const DIGIT_T e[], DIGIT_T m[], size_t ndigits)
+{	/*	Computes y = x^e mod m */
+	/*	"Classic" binary left-to-right method */
+	/*  [v2.2] removed const restriction on m[] to avoid using an extra alloc'd var 
+		(m is changed in-situ during the divide operation then restored) */
+	DIGIT_T mask;
+	size_t n;
+	size_t nn = ndigits * 2;
+	/* Create some double-length temps */
+#ifdef NO_ALLOCS
+	DIGIT_T t1[MAX_FIXED_DIGITS * 2];
+	DIGIT_T t2[MAX_FIXED_DIGITS * 2];
+	DIGIT_T y[MAX_FIXED_DIGITS * 2];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *t1, *t2, *y;
+	t1 = mpAlloc(nn);
+	t2 = mpAlloc(nn);
+	y  = mpAlloc(nn);
+#endif
+	
+	assert(ndigits != 0);
+
+	n = mpSizeof(e, ndigits);
+	/* Catch e==0 => x^0=1 */
+	if (0 == n)
+	{
+		mpSetDigit(yout, 1, ndigits);
+		goto done;
+	}
+	/* Find second-most significant bit in e */
+	for (mask = HIBITMASK; mask > 0; mask >>= 1)
+	{
+		if (e[n-1] & mask)
+			break;
+	}
+	mpNEXTBITMASK(mask, n);
+
+	/* Set y = x */
+	mpSetEqual(y, x, ndigits);
+
+	/* For bit j = k-2 downto 0 */
+	while (n)
+	{
+		/* Square y = y * y mod n */
+		mpMODSQUARETEMP(y, m, ndigits, t1, t2);
+		if (e[n-1] & mask)
+		{	/*	if e(j) == 1 then multiply
+				y = y * x mod n */
+			mpMODMULTTEMP(y, x, m, ndigits, t1, t2);
+		} 
+		
+		/* Move to next bit */
+		mpNEXTBITMASK(mask, n);
+	}
+
+	/* Return y */
+	mpSetEqual(yout, y, ndigits);
+
+done:
+	mpDESTROY(t1, nn);
+	mpDESTROY(t2, nn);
+	mpDESTROY(y, ndigits);
+
+	return 0;
+}
+
+/**	Computes y = x^e mod m in constant time using Coron's algorithm */
+int mpModExp_ct(DIGIT_T yout[], const DIGIT_T x[], const DIGIT_T e[], DIGIT_T m[], size_t ndigits)
+{	
+	/* Algorithm: Coron’s exponentiation (left-to-right)
+	 * Square-and-multiply resistant against simple power attacks (SPA)
+	 * Ref: Jean-Sebastian Coron, "Resistance Against Differential Power Analysis for 
+	 * Elliptic Curve Cryptosystems", August 1999.
+	 * -- This version adapted from Coron's elliptic curve point scalar multiplication 
+	 *    to RSA-style modular exponentiation.
+	 * Input: base x, modulus m, and
+	 *   exponent e = (e_k, e_{k-1},...,e_0) with e_k = 1
+	 * Output: c = x^e mod m
+	 * 1. c[0] = x
+	 * 2. For i = k-2 downto 0 do:
+	 * 3.    c[0] = c[0]^2 mod m
+	 * 4.    c[1] = c[0] * x mod m
+	 * 5.    c[0] = c[d_i]
+	 * 6. Return c[0]
+	 */
+	DIGIT_T mask;
+	size_t n;
+	size_t nn = ndigits * 2;
+	unsigned int ej;
+
+	/* Create some double-length temps */
+#ifdef NO_ALLOCS
+	DIGIT_T t1[MAX_FIXED_DIGITS * 2];
+	DIGIT_T t2[MAX_FIXED_DIGITS * 2];
+	DIGIT_T c[2][MAX_FIXED_DIGITS * 2];
+	assert(ndigits <= MAX_FIXED_DIGITS);
+#else
+	DIGIT_T *t1, *t2;
+	DIGIT_T *c[2];
+	t1 = mpAlloc(nn);
+	t2 = mpAlloc(nn);
+	c[0] = mpAlloc(nn);
+	c[1] = mpAlloc(nn);
+#endif
+	
+	assert(ndigits != 0);
+
+	n = mpSizeof(e, ndigits);
+	/* Catch e==0 => x^0=1 */
+	if (0 == n)
+	{
+		mpSetDigit(yout, 1, ndigits);
+		goto done;
+	}
+	/* Find second-most significant bit in e */
+	for (mask = HIBITMASK; mask > 0; mask >>= 1)
+	{
+		if (e[n-1] & mask)
+			break;
+	}
+	mpNEXTBITMASK(mask, n);
+
+	/* Set c[0] = x */
+	mpSetEqual(c[0], x, ndigits);
+
+	/* For bit j = k-2 downto 0 */
+	while (n)
+	{
+		/* Square c[0] = c[0]^2 mod n */
+		mpMODSQUARETEMP(c[0], m, ndigits, t1, t2);
+		/* Multiply c[1] = c[0] * x mod n */
+		mpMODMULTXYTEMP(c[1], c[0], x, m, ndigits, t1, t2);
+		/* c[0] = c[e(j)] */
+		ej = (e[n-1] & mask) != 0;
+		assert(ej <= 1);
+		mpSetEqual(c[0], c[ej], ndigits);
+		
+		/* Move to next bit */
+		mpNEXTBITMASK(mask, n);
+	}
+
+	/* Return c[0] */
+	mpSetEqual(yout, c[0], ndigits);
+
+done:
+	mpDESTROY(t1, nn);
+	mpDESTROY(t2, nn);
+	mpDESTROY(c[0], ndigits);
+	mpDESTROY(c[1], ndigits);
+
+	return 0;
+}
+
+
+/* Use sliding window alternative only if NO_ALLOCS not defined */
+#ifndef NO_ALLOCS
+
+/*
+SLIDING-WINDOW EXPONENTIATION
+Ref: Menezes, chap 14, p616.
+k is called the window size.
+
+14.85 Algorithm Sliding-window exponentiation
+INPUT: g, e = (e_t.e_{t-1}...e1.e0)_2 with e_t = 1, and an integer k >= 1.
+OUTPUT: g^e.
+1. Precomputation.
+	1.1 g_1 <-- g, g_2 <-- g^2.
+	1.2 For i from 1 to (2^{k-1} - 1) do: g_{2i+1} <-- g_{2i-1} * g_2.
+2. A <-- 1, i <-- t.
+3. While i >= 0 do the following:
+	3.1 If e_i = 0 then do: A <-- A^2, i <-- i - 1.
+	3.2 Otherwise (e_i != 0), find the longest bitstring e_i.e_{i-1}...e_l such that i-l+1 <= k
+and e_l = 1, and do the following:
+	A <-- A^{2i-l+1} * g_{(e_i.e_{i-1}...e_l)_2}
+	i <-- l - 1.
+4. Return(A).
+*/
+
+/* 
+Optimal values of k for various exponent sizes.
+	The references on this differ in their recommendations. 
+	These values reflect experiments we've done on our systems.
+	You can adjust this to suit your own situation.
+*/
+static size_t WindowLenTable[] = 
+{
+/* k=1   2   3   4    5     6     7     8 */
+	 5, 16, 64, 240, 768, 1024, 2048, 4096
+};
+#define WINLENTBLMAX (sizeof(WindowLenTable)/sizeof(WindowLenTable[0]))
+
+/*	The process used here to read bits into the lookahead buffer could be improved slightly as
+	some bits are read in more than once. But we think this function is tricky enough without 
+	adding more complexity for marginal benefit.
+*/
+
+static int mpModExp_windowed(DIGIT_T yout[], const DIGIT_T g[], 
+			const DIGIT_T e[], DIGIT_T m[], size_t ndigits)
+/* Computes y = g^e mod m using sliding-window exponentiation */
+{
+	size_t nbits;	/* Number of significant bits in e */
+	size_t winlen;	/* Window size */ 
+	DIGIT_T mask;	/* Bit mask used for main loop */
+	size_t nwd;		/* Digit counter for main loop */
+	DIGIT_T lkamask;	/* Bit mask for lookahead */
+	size_t lkanwd;		/* Digit counter for lookahead */
+	DIGIT_T lkabuf;	/* One-digit lookahead buffer */
+	size_t lkalen;	/* Actual size of window for current lookahead buffer */
+	int in_window;	/* Flag for in-window state */
+	DIGIT_T *gtable[(1 << (WINLENTBLMAX-1))];	/* Table of ptrs to g1, g3, g5,... */
+	size_t ngt;		/* No of elements in gtable */
+	size_t idxmult;	/* Index (in gtable) of next multiplier to use: 0=g1, 1=g3, 2=g5,... */
+	DIGIT_T *g2;	/* g2 = g^2 */
+	DIGIT_T *temp1, *temp2;		/* Temp big digits, needed for MULT and SQUARE macros */
+	DIGIT_T *a;		/* A */
+	int aisone;		/* Flag that A == 1 */
+	size_t nn;		/* 2 * ndigits */
+	size_t i;		/* Temp counter */
+	
+	/* Get actual size of e */
+	nbits = mpBitLength(e, ndigits);
+	DPRINTF1("nbits=%d\n", nbits);
+
+	/* Catch easy ones */
+	if (nbits == 0)
+	{	/* g^0 = 1 */
+		mpSetDigit(yout, 1, ndigits);
+		return 1;
+	}
+	if (nbits == 1)
+	{	/* g^1 = g mod m */
+		mpModulo(yout, g, ndigits, m, ndigits);
+		return 1;
+	}
+
+	/* Lookup optimised window length for this size of e */
+	for (winlen = 0; winlen < WINLENTBLMAX && winlen < BITS_PER_DIGIT; winlen++)
+	{
+		if (WindowLenTable[winlen] > nbits)
+			break;
+	}
+	DPRINTF1("winlen=%d\n", winlen);
+
+	/* Default to simple L-R method for 1-bit window */
+	if (winlen <= 1)
+		return mpModExp_1(yout, g, e, m, ndigits);
+
+	/* Allocate temp vars - NOTE: all are 2n long */
+	nn = 2 * ndigits;
+	temp1 = mpAlloc(nn);
+	temp2 = mpAlloc(nn);
+	g2 = mpAlloc(nn);
+	a = mpAlloc(nn);
+
+	/* 1. PRECOMPUTATION */
+	/* 1.1 g1 <-- g, (we already have g in the input, so just point to it) */
+	gtable[0] = (DIGIT_T *)g;
+	/* g2 <-- g^2 */
+	mpModMult(g2, gtable[0], gtable[0], m, ndigits);
+
+	/* 1.2 For i from 1 to (2^{k-1} - 1) do: g_{2i+1} <-- g_{2i-1} * g_2. */
+	/* i.e. we store (g1, g3, g5, g7,...) */
+	ngt = ((size_t)1 << (winlen - 1));
+	for (i = 1; i < ngt; i++)
+	{
+		/* NOTE: we need these elements to be 2n digits long for the mpMODMULTTEMP fn, 
+			but the final result is only n digits long */
+		gtable[i] = mpAlloc(nn);
+		//mpModMult(gtable[i], gtable[i-1], g2, m, ndigits);
+		mpSetEqual(gtable[i], gtable[i-1], ndigits);
+		mpMODMULTTEMP(gtable[i], g2, m, ndigits, temp1, temp2);
+	}
+
+	/* 2. A <-- 1 (use flag) */
+	//mpSetDigit(a, 1, ndigits);
+	aisone = 1;
+
+	/* Find most significant bit in e */
+	nwd = mpSizeof(e, ndigits);
+	for (mask = HIBITMASK; mask > 0; mask >>= 1)
+	{
+		if (e[nwd-1] & mask)
+			break;
+	}
+
+	/* i <-- t; 3. While i >= 0 do the following: */
+	/* i.e. look at high bit and every subsequent bit L->R in turn */
+	lkalen = 0;
+	in_window = 0;
+	idxmult = 0;
+	while (nwd)
+	{
+		/* We always square each time around */
+		/* A <-- A^2 */
+		if (!aisone)	/* 1^2 = 1! */
+		{
+			mpMODSQUARETEMP(a, m, ndigits, temp1, temp2);
+		}
+
+		if (!in_window)
+		{	/* Do we start another window? */
+			if ((e[nwd-1] & mask))
+			{	/* Yes, bit is '1', so setup this window */
+				in_window = 1;
+				/* Read in look-ahead buffer (a single digit) */
+				lkamask = mask;
+				lkanwd = nwd;
+				/* Read in this and the next winlen-1 bits into lkabuf */
+				lkabuf = 0x1;	
+				for (i = 0; i < winlen-1; i++)
+				{
+					mpNEXTBITMASK(lkamask, lkanwd);
+					lkabuf <<= 1;
+					/* if lkanwd==0 we have passed the end, so just append a zero bit */
+					if (lkanwd && (e[lkanwd-1] & lkamask))
+					{
+						lkabuf |= 0x1;
+					}
+				}
+				DPRINTF1("(%x)", lkabuf);		
+				/* Compute this window's length */
+				/* i.e. keep shifting right until we have a '1' bit at the end */
+				for (lkalen = winlen - 1; lkalen > 0; lkalen--, lkabuf >>= 1)
+				{
+					if (ISODD(lkabuf))
+						break;
+				}
+				/* Set next multipler to use */
+				/* idx = (value(buf) - 1) / 2 */
+				idxmult = lkabuf >> 1;
+
+				DPRINTF0("1");
+
+			}
+			else
+			{	/* No, bit is '0', so just loop */
+				DPRINTF0("0 ");
+			}
+		}
+		else
+		{	/* We are in a window... */
+			DPRINTF1("%s", ((e[nwd-1] & mask) ? "1" : "0"));
+			/* Has it finished yet? */
+			if (lkalen > 0)
+			{
+				lkalen--;
+			}
+		}
+		/* Are we at end of this window? */
+		if (in_window && lkalen < 1)
+		{	/* Yes, so compute A <-- A * g_l */
+			if (aisone)
+			{
+				mpSetEqual(a, gtable[idxmult], ndigits);
+				aisone = 0;
+			}
+			else
+			{
+				mpMODMULTTEMP(a, gtable[idxmult], m, ndigits, temp1, temp2);
+			}
+			DPRINTF1("[%x]", idxmult);		
+			DPRINTF0("/ ");
+			in_window = 0;
+			lkalen = 0;
+		}
+		mpNEXTBITMASK(mask, nwd);
+	}
+	/* Finally, cope with anything left in the final window */
+	if (in_window)
+	{
+		if (aisone)
+		{
+			mpSetEqual(a, gtable[idxmult], ndigits);
+			aisone = 0;
+		}
+		else
+		{
+			mpMODMULTTEMP(a, gtable[idxmult], m, ndigits, temp1, temp2);
+		}
+		DPRINTF1("[%x]", idxmult);		
+		DPRINTF0("//");
+	}
+	DPRINTF0("\n");
+
+	/* 4. Return (A) */
+	mpSetEqual(yout, a, ndigits);
+
+	/* Clean up */
+	mpDESTROY(a, nn);
+	mpDESTROY(g2, nn);
+	mpDESTROY(temp1, nn);
+	mpDESTROY(temp2, nn);
+	/* CAUTION: don't clean gtable[0] */
+	for (i = 1; i < ngt; i++)
+		mpDESTROY(gtable[i], nn);
+
+	return 0;
+}
+
+#endif /* !NO_ALLOCS */

--- a/src/bigdigits.h
+++ b/src/bigdigits.h
@@ -1,0 +1,577 @@
+/* $Id: bigdigits.h $ */
+
+/** @file
+	Interface to core BigDigits "mp" functions using fixed-length arrays 
+*/
+
+/***** BEGIN LICENSE BLOCK *****
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2001-16 David Ireland, D.I. Management Services Pty Limited
+ * <http://www.di-mgt.com.au/bigdigits.html>. All rights reserved.
+ *
+ ***** END LICENSE BLOCK *****/
+/*
+ * Last updated:
+ * $Date: 2016-03-31 09:51:00 $
+ * $Revision: 2.6.1 $
+ * $Author: dai $
+ */
+
+#ifndef BIGDIGITS_H_
+#define BIGDIGITS_H_ 1
+
+#include <stdlib.h>
+#include "bigdtypes.h"
+
+/**** USER CONFIGURABLE SECTION ****/
+
+/* Define type and size of DIGIT */
+
+/* [v2.1] Changed to use C99 exact-width types. */
+/* [v2.2] Put macros for exact-width types in separate file "bigdtypes.h" */
+
+/** The basic BigDigit element, an unsigned 32-bit integer */
+typedef uint32_t DIGIT_T;
+/** @cond */
+typedef uint16_t HALF_DIGIT_T;
+
+/* Sizes to match */
+#define MAX_DIGIT 0xFFFFFFFFUL
+#define MAX_HALF_DIGIT 0xFFFFUL	/* NB 'L' */
+#define BITS_PER_DIGIT 32
+#define HIBITMASK 0x80000000UL
+
+/*	[v2.2] added option to avoid allocating temp storage in the heap
+	and use (faster) fixed automatic arrays on the stack instead.
+	Define NO_ALLOCS to invoke this.
+	Only applicable to mp functions. Do not use with bd.
+*/
+/* Specify the maximum number of digits allowed in a temp mp array
+   -- ignored unless NO_ALLOCS is defined
+   -- [v2.6] user may override MAX_FIXED_BIT_LENGTH with global definition
+	  e.g. /D "MAX_FIXED_BIT_LENGTH=640" or -D MAX_FIXED_BIT_LENGTH=640
+*/ 
+#ifdef NO_ALLOCS
+#ifndef MAX_FIXED_BIT_LENGTH
+#define MAX_FIXED_BIT_LENGTH 8192
+#endif
+#define MAX_FIXED_DIGITS ((MAX_FIXED_BIT_LENGTH + BITS_PER_DIGIT - 1) / BITS_PER_DIGIT)
+#endif
+
+/**** END OF USER CONFIGURABLE SECTION ****/
+
+/**** OPTIONAL PREPROCESSOR DEFINITIONS ****/
+/* 
+   Choose one of {USE_SPASM | USE_64WITH32}
+   USE_SPASM: to use the faster x86 ASM routines (if __asm option is available with your compiler).
+   USE_64WITH32: to use the 64-bit integers if available (e.g. long long).
+   Default: use default internal routines spDivide and spMultiply.
+   The USE_SPASM option takes precedence over USE_64WITH32.
+*/
+
+/* Useful macros */
+#define ISODD(x) ((x) & 0x1)
+#define ISEVEN(x) (!ISODD(x))
+#define mpISODD(x, n) (x[0] & 0x1)
+#define mpISEVEN(x, n) (!(x[0] & 0x1))
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Forces linker to include copyright notice in executable */
+	volatile char *copyright_notice(void);
+/** @endcond */
+
+/*	
+ * Multiple precision calculations	
+ * Using known, equal ndigits
+ * except where noted
+ */
+
+/*************************/
+/* ARITHMETIC OPERATIONS */
+/*************************/
+
+/** Computes w = u + v, returns carry 
+@pre `w` and `v` must not overlap. 
+*/
+DIGIT_T mpAdd(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T v[], size_t ndigits);
+
+/** Computes w = u - v, returns borrow 
+@pre `w` and `v` must not overlap. 
+*/
+DIGIT_T mpSubtract(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T v[], size_t ndigits);
+
+/** Computes product w = u * v
+@param[out] w To receive the product, an array of size 2 x `ndigits`
+@param[in] u An array of size `ndigits`
+@param[in] v An array of size `ndigits`
+@param[in] ndigits size of arrays `u` and `v`
+@pre `w` and `u` must not overlap. 
+@warning The product must be of size 2 x `ndigits`
+*/
+int mpMultiply(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T v[], size_t ndigits);
+
+/** Computes integer division of u by v such that u=qv+r
+@param[out] q to receive quotient = u div v, an array of size `udigits`
+@param[out] r to receive divisor = u mod v, an array of size `udigits` 
+@param[in]  u dividend of size `udigits`
+@param[in] udigits size of arrays `q` `r` and `u`
+@param[in]  v divisor of size `vdigits`
+@param[in] vdigits size of array `v`
+@pre `q` and `r` must be independent of `u` and `v`. 
+@warning Trashes q and r first
+*/
+int mpDivide(DIGIT_T q[], DIGIT_T r[], const DIGIT_T u[], 
+	size_t udigits, DIGIT_T v[], size_t vdigits);
+
+/** Computes remainder r = u mod v
+@param[out] r to receive divisor = u mod v, an array of size `vdigits`
+@param[in]  u dividend of size `udigits`
+@param[in] udigits size of arrays `r` and `u`
+@param[in]  v divisor of size `vdigits`
+@param[in] vdigits size of array `v`
+@pre `r` and `u` must not overlap. 
+@remark Note that `r` is `vdigits` long here, but is `udigits` long in mpDivide().
+*/
+int mpModulo(DIGIT_T r[], const DIGIT_T u[], size_t udigits, DIGIT_T v[], size_t vdigits);
+
+/** Computes square w = x^2
+@param[out] w array of size 2 x `ndigits` to receive square
+@param[in] x array of size `ndigits`
+@param[in] ndigits size of array `x`
+@pre `w` and `x` must not overlap.
+@warning The product `w` must be of size 2 x `ndigits`
+*/
+int mpSquare(DIGIT_T w[], const DIGIT_T x[], size_t ndigits);
+
+/** Computes integer square root s = floor(sqrt(x)) */
+int mpSqrt(DIGIT_T s[], const DIGIT_T x[], size_t ndigits);
+
+/** Computes integer cube root s = floor(cuberoot(x)) */
+int mpCubeRoot(DIGIT_T s[], const DIGIT_T x[], size_t ndigits);
+
+/*************************/
+/* COMPARISON OPERATIONS */
+/*************************/
+/** Returns true if a == b, else false
+ *  @remark Not constant-time.
+ */
+int mpEqual(const DIGIT_T a[], const DIGIT_T b[], size_t ndigits);
+
+/** Returns sign of `(a-b)` as `{-1,0,+1}`
+ *  @remark Not constant-time.
+ */
+int mpCompare(const DIGIT_T a[], const DIGIT_T b[], size_t ndigits);
+
+/** Returns true if a is zero, else false
+ *  @remark Not constant-time.
+ */
+int mpIsZero(const DIGIT_T a[], size_t ndigits);
+
+/***************************************/
+/* CONSTANT-TIME COMPARISON ALGORITHMS */
+/***************************************/
+/* -- added [v2.5] to replace originals. Renamed as "_ct" in [v2.6] */
+
+/** Returns true if a == b, else false, using constant-time algorithm */
+int mpEqual_ct(const DIGIT_T a[], const DIGIT_T b[], size_t ndigits);
+
+/** Returns sign of `(a-b)` as `{-1,0,+1}` using constant-time algorithm */
+int mpCompare_ct(const DIGIT_T a[], const DIGIT_T b[], size_t ndigits);
+
+/** Returns true if a is zero, else false, using constant-time algorithm */
+int mpIsZero_ct(const DIGIT_T a[], size_t ndigits);
+
+/* Keep the faith for [v2.5] users - DEPRECATED in [v2.6] */
+#define mpEqual_q(a,b,n) mpEqual((a),(b),(n))
+#define mpCompare_q(a,b,n) mpCompare((a),(b),(n))
+#define mpIsZero_q(a,n) mpIsZero((a),(n))
+
+
+/****************************/
+/* NUMBER THEORY OPERATIONS */
+/****************************/
+/* [v2.2] removed `const` restriction on m[] for mpModMult and mpModExp 
+ *   (to allow faster in-place manipulation instead of using a temp variable).
+ * [v2.5] added mpModExp_ct(), a constant-time variant of mpModExp().
+ * [v2.6] added mpModSquare(), mpModAdd(), mpModSubtract() and mpModSqrt().
+ */
+
+/** Computes y = x^e mod m */
+int mpModExp(DIGIT_T y[], const DIGIT_T x[], const DIGIT_T e[], DIGIT_T m[], size_t ndigits);
+
+/**	Computes y = x^e mod m in constant time 
+ *  @remark Resistant to simple power analysis attack on private exponent. 
+ *  Slower than mpModExp(). 
+ */
+int mpModExp_ct(DIGIT_T yout[], const DIGIT_T x[], const DIGIT_T e[], DIGIT_T m[], size_t ndigits);
+
+/** Computes a = (x * y) mod m */
+int mpModMult(DIGIT_T a[], const DIGIT_T x[], const DIGIT_T y[], DIGIT_T m[], size_t ndigits);
+
+/** Computes a = x^2 mod m */
+int mpModSquare(DIGIT_T a[], const DIGIT_T x[], DIGIT_T m[], size_t ndigits);
+
+/** Computes the inverse of `u` modulo `m`, inv = u^{-1} mod m */
+int mpModInv(DIGIT_T inv[], const DIGIT_T u[], const DIGIT_T m[], size_t ndigits);
+
+/** Computes g = gcd(x, y), the greatest common divisor of x and y */
+int mpGcd(DIGIT_T g[], const DIGIT_T x[], const DIGIT_T y[], size_t ndigits);
+
+/** Returns the Jacobi symbol (a/n) in {-1, 0, +1} 
+@remark If n is prime then the Jacobi symbol becomes the Legendre symbol (a/p) defined to be
+- (a/p) = +1 if a is a quadratic residue modulo p
+- (a/p) = -1 if a is a quadratic non-residue modulo p
+- (a/p) = 0 if a is divisible by p
+*/
+int mpJacobi(const DIGIT_T a[], const DIGIT_T n[], size_t ndigits);
+
+
+/** Computes x = one square root of an integer `a` modulo an odd prime `p`
+ *  @param x To receive the result
+ *  @param a An integer expected to be a quadratic residue modulo p
+ *  @param p An odd prime
+ *  @param ndigits The number of digits in each of the parameters
+ *  @return 0 if successful, or -1 if square root does not exist
+ *  @remark More precisely, find an integer x such that x^2 mod p = a.
+ *  Uses the Tonelli-Shanks algorithm. The other square root is `p - x`.
+ *  @warning Check the return value before using the result `x`.
+ */
+int mpModSqrt(DIGIT_T x[], const DIGIT_T a[], DIGIT_T p[], size_t ndigits);
+
+/** Computes w = u/2 (mod p) for an odd prime p 
+ *  @pre Require u to be in the range `[0,p-1]` */
+void mpModHalve(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T p[], size_t ndigits);
+
+/** Computes w = u + v (mod m)
+*  @pre Require u and v to be in the range `[0, m-1]`.
+*  The variables `w` and `v` must not overlap.
+*  @remark Quicker than adding then using mpModulo()
+*/
+void mpModAdd(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T v[], const DIGIT_T m[], size_t ndigits);
+
+/** Computes w = u - v (mod m)
+*  @pre Require u and v to be in the range `[0, m-1]`.
+*  The variables `w` and `v` must not overlap.
+*  @remark Quicker than subtracting then using mpModulo()
+*/
+void mpModSub(DIGIT_T w[], const DIGIT_T u[], const DIGIT_T v[], const DIGIT_T m[], size_t ndigits);
+
+
+/** Computes u = v (mod m) in the special case where `0<=v<km` for small k
+ *  @remark Uses subtraction instead of division, so is much faster than mpModulo() in this case.
+ *  @pre `v` is in the range `[0,km]` where `k` is a small integer
+ *  @warning Use only if you know `k` is small, say < 3.
+ */
+void mpModSpecial(DIGIT_T u[], const DIGIT_T v[], const DIGIT_T m[], size_t ndigits);
+
+
+/**********************/
+/* BITWISE OPERATIONS */
+/**********************/
+
+/** Returns number of significant bits in a */
+size_t mpBitLength(const DIGIT_T a[], size_t ndigits);
+
+/** Computes a = b << x */
+DIGIT_T mpShiftLeft(DIGIT_T a[], const DIGIT_T b[], size_t x, size_t ndigits);
+
+/** Computes a = b >> x */
+DIGIT_T mpShiftRight(DIGIT_T a[], const DIGIT_T b[], size_t x, size_t ndigits);
+
+/** Computes bitwise a = b XOR c */
+void mpXorBits(DIGIT_T a[], const DIGIT_T b[], const DIGIT_T c[], size_t ndigits);
+
+/** Computes bitwise a = b OR c */
+void mpOrBits(DIGIT_T a[], const DIGIT_T b[], const DIGIT_T c[], size_t ndigits);
+
+/** Computes bitwise a = b AND c */
+void mpAndBits(DIGIT_T a[], const DIGIT_T b[], const DIGIT_T c[], size_t ndigits);
+
+/** Computes bitwise a = NOT b */
+void mpNotBits(DIGIT_T a[], const DIGIT_T b[], size_t ndigits);
+
+/** Computes a = a mod 2^L, ie clears all bits greater than L */
+void mpModPowerOf2(DIGIT_T a[], size_t ndigits, size_t L);
+
+/** Sets bit n of a (0..nbits-1) with value 1 or 0 */
+int mpSetBit(DIGIT_T a[], size_t ndigits, size_t n, int value);
+
+/** Returns value 1 or 0 of bit n (0..nbits-1) */
+int mpGetBit(const DIGIT_T a[], size_t ndigits, size_t n);
+
+
+/*************************/
+/* ASSIGNMENT OPERATIONS */
+/*************************/
+
+/** Sets a = 0 */
+volatile DIGIT_T mpSetZero(volatile DIGIT_T a[], size_t ndigits);
+
+/** Sets a = d where d is a single digit */
+void mpSetDigit(DIGIT_T a[], DIGIT_T d, size_t ndigits);
+
+/** Sets a = b */
+void mpSetEqual(DIGIT_T a[], const DIGIT_T b[], size_t ndigits);
+
+
+/**********************/
+/* OTHER MP UTILITIES */
+/**********************/
+
+/** Returns number of significant non-zero digits in a */
+size_t mpSizeof(const DIGIT_T a[], size_t ndigits);
+
+/** Returns true (1) if `w` is probably prime
+@param[in] w Number to test
+@param[in] ndigits size of array `w`
+@param[in] t The count of Rabin-Miller primality tests to carry out (recommended at least 80)
+@returns true (1) if w is probably prime otherwise false (0)
+@remark Uses FIPS-186-2/Rabin-Miller with trial division by small primes, 
+which is faster in most cases than mpRabinMiller().
+@see mpRabinMiller().
+*/
+int mpIsPrime(DIGIT_T w[], size_t ndigits, size_t t);
+
+/** Returns true (1) if `w` is probably prime using just the Rabin-Miller test
+@see mpIsPrime() is preferred.
+*/
+int mpRabinMiller(DIGIT_T w[], size_t ndigits, size_t t);
+
+
+/**********************************************/
+/* FUNCTIONS THAT OPERATE WITH A SINGLE DIGIT */
+/**********************************************/
+
+/** Computes w = u + d, returns carry */
+DIGIT_T mpShortAdd(DIGIT_T w[], const DIGIT_T u[], DIGIT_T d, size_t ndigits);
+
+/** Computes w = u - d, returns borrow */
+DIGIT_T mpShortSub(DIGIT_T w[], const DIGIT_T u[], DIGIT_T d, size_t ndigits);
+
+/** Computes product p = x * d */
+DIGIT_T mpShortMult(DIGIT_T p[], const DIGIT_T x[], DIGIT_T d, size_t ndigits);
+
+/** Computes quotient q = u div d, returns remainder */
+DIGIT_T mpShortDiv(DIGIT_T q[], const DIGIT_T u[], DIGIT_T d, size_t ndigits);
+
+/** Computes remainder r = a mod d */
+DIGIT_T mpShortMod(const DIGIT_T a[], DIGIT_T d, size_t ndigits);
+
+/** Returns sign of (a - d) where d is a single digit */
+int mpShortCmp(const DIGIT_T a[], DIGIT_T d, size_t ndigits);
+
+/** Returns true if a == d, else false, where d is a single digit */
+int mpShortIsEqual(const DIGIT_T a[], DIGIT_T d, size_t ndigits);
+
+/** Returns the least significant digit in a */
+DIGIT_T mpToShort(const DIGIT_T a[], size_t ndigits);
+
+/**************************************/
+/* CORE SINGLE PRECISION CALCULATIONS */
+/* (double where necessary)           */
+/**************************************/
+
+/* NOTE spMultiply and spDivide are used by almost all mp functions. 
+   Using the Intel MASM alternatives gives significant speed improvements
+   -- to use, define USE_SPASM as a preprocessor directive.
+   [v2.2] Removed references to spasm* versions.
+*/
+
+/** Computes p = x * y, where x and y are single digits */
+int spMultiply(DIGIT_T p[2], DIGIT_T x, DIGIT_T y);
+
+/** Computes quotient q = u div v, remainder r = u mod v, where q, r and v are single digits */
+DIGIT_T spDivide(DIGIT_T *q, DIGIT_T *r, const DIGIT_T u[2], DIGIT_T v);
+
+/****************************/
+/* RANDOM NUMBER FUNCTIONS  */
+/* CAUTION: NOT thread-safe */
+/****************************/
+
+/** Returns a simple pseudo-random digit between lower and upper.
+@remark Not crypto secure. 
+@see spBetterRand() 
+*/
+DIGIT_T spSimpleRand(DIGIT_T lower, DIGIT_T upper);
+
+/** Generate a quick-and-dirty random mp number a of bit length at most `nbits` using plain-old-rand 
+@remark Not crypto secure.
+@see mpRandomBits()
+*/
+size_t mpQuickRandBits(DIGIT_T a[], size_t ndigits, size_t nbits);
+
+/* [Version 2.1: spBetterRand moved to spRandom.h] */
+
+/*******************/
+/* PRINT UTILITIES */
+/*******************/
+
+/* [v2.3] Added these more convenient print functions */
+
+/** Print in hex format with optional prefix and suffix strings */
+void mpPrintHex(const char *prefix, const DIGIT_T *a, size_t ndigits, const char *suffix);
+/** Print in decimal format with optional prefix and suffix strings */
+void mpPrintDecimal(const char *prefix, const DIGIT_T *a, size_t ndigits, const char *suffix);
+
+/* See also mpPrintDecimalSigned() - new in [v2.5] */
+
+/* New in [v2.6] */
+/** Print in bit (0/1) format with optional prefix and suffix strings */
+void mpPrintBits(const char *prefix, DIGIT_T *a, size_t ndigits, const char *suffix);
+
+/* OLDER PRINT FUNCTIONS, ALL PRINTING IN HEX */
+/** Print all digits in hex incl leading zero digits */
+void mpPrint(const DIGIT_T *a, size_t ndigits);
+/** Print all digits in hex with newlines */
+void mpPrintNL(const DIGIT_T *a, size_t ndigits);
+/** Print in hex but trim leading zero digits 
+@deprecated Use mpPrintHex()
+*/
+void mpPrintTrim(const DIGIT_T *a, size_t ndigits);
+/** Print in hex, trim leading zeroes, add newlines 
+@deprecated Use mpPrintHex()
+*/
+void mpPrintTrimNL(const DIGIT_T *a, size_t ndigits);
+
+/************************/
+/* CONVERSION UTILITIES */
+/************************/
+
+/** Converts nbytes octets into big digit a of max size ndigits
+@returns actual number of digits set */
+size_t mpConvFromOctets(DIGIT_T a[], size_t ndigits, const unsigned char *c, size_t nbytes);
+/** Converts big digit a into string of octets, in big-endian order, padding to nbytes or truncating if necessary.
+@returns number of non-zero octets required. */
+size_t mpConvToOctets(const DIGIT_T a[], size_t ndigits, unsigned char *c, size_t nbytes);
+/** Converts a string in decimal format to a big digit.
+@returns actual number of (possibly zero) digits set. */
+size_t mpConvFromDecimal(DIGIT_T a[], size_t ndigits, const char *s);
+/** Converts big digit a into a string in decimal format, where s has size smax including the terminating zero.
+@returns number of chars required excluding leading zeroes. */
+size_t mpConvToDecimal(const DIGIT_T a[], size_t ndigits, char *s, size_t smax);
+/** Converts a string in hexadecimal format to a big digit.
+@return actual number of (possibly zero) digits set. */
+size_t mpConvFromHex(DIGIT_T a[], size_t ndigits, const char *s);
+/** Converts big digit a into a string in hexadecimal format, 
+   where s has size smax including the terminating zero.
+@return number of chars required excluding leading zeroes. */
+size_t mpConvToHex(const DIGIT_T a[], size_t ndigits, char *s, size_t smax);
+
+
+/****************************/
+/* SIGNED INTEGER FUNCTIONS */
+/****************************/
+
+/* 
+NOTES ON SIGNED-INTEGER OPERATIONS
+----------------------------------
+You can choose to treat BigDigits integers as "signed" with their values stored in two's-complement representation.
+A negative number will be a BigDigit integer with its left-most bit set to one, i.e.
+
+	mpGetBit(a, ndigits, (ndigits * BITS_PER_DIGIT - 1)) == 1
+
+This works automatically for simple arithmetic operations like add, subtract and multiply (but not division). 
+For example,
+
+	mpSetDigit(u, 2, NDIGITS);
+	mpSetDigit(v, 5, NDIGITS);
+	mpSubtract(w, u, v, NDIGITS);
+	mpPrintDecimalSigned("signed w=", w, NDIGITS, "\n");
+	mpPrintHex("unsigned w=", w, NDIGITS, "\n");
+
+will result in the output
+
+	signed w=-3
+	unsigned w=0xfffffffffffffffffffffffffffffffd    
+
+It does *not* work for division or any number-theoretic function like mpModExp(), 
+all of which treat their parameters as "unsigned" integers and will not give the "signed" result you expect.
+
+To set a small negative number do:
+
+	mpSetDigit(v, 5, NDIGITS);
+	mpChs(v, v, NDIGITS);
+
+--------------
+*/
+
+
+/** Returns true (1) if x < 0, else false (0) 
+ *  @remark Expects a negative number to be stored in two's-complement representation.
+ */
+int mpIsNegative(const DIGIT_T x[], size_t ndigits);
+
+/** Sets x = -y
+ *  @remark Expects a negative number to be stored in two's-complement representation.
+ */
+int mpChs(DIGIT_T x[], const DIGIT_T y[], size_t ndigits);
+
+/** Sets x = |y|, the absolute value of y 
+ *  @remark Expects a negative number to be stored in two's-complement representation.
+ */
+int mpAbs(DIGIT_T x[], const DIGIT_T y[], size_t ndigits);
+
+/* New in [v2.5] - note that `a` is not `const` */
+
+/** Print a signed integer in decimal format with optional prefix and suffix strings 
+ *  @remark Expects a negative number to be stored in two's-complement representation.
+ */
+void mpPrintDecimalSigned(const char *prefix, DIGIT_T *a, size_t ndigits, const char *suffix);
+
+
+/****************/
+/* VERSION INFO */
+/****************/
+/** Returns version number = major*1000+minor*100+release*10+PP_OPTIONS */
+int mpVersion(void);
+	/* Version number = major*1000+minor*100+release*10+uses_asm(0|1)+uses_64(0|2)+uses_noalloc(0|5) 
+		 E.g. Version 2.3.0 will return 230x where x denotes the preprocessor options
+		 x | USE_SPASM | USE_64WITH32 | NO_ALLOCS
+		 ----------------------------------------
+		 0      No            No           No
+		 1      Yes           No           No
+		 2      No            Yes          No
+		 3      Yes           Yes*         No
+		 5      No            No           Yes
+		 6      Yes           No           Yes
+		 7      No            Yes          Yes
+		 8      Yes           Yes*         Yes
+		 ----------------------------------------
+		 * USE_SPASM will take precedence over USE_64WITH32.
+	 */
+
+/** Returns a pointer to a static string containing the time of compilation */
+const char *mpCompileTime(void);
+
+/** @cond */
+/*************************************************************/
+/* MEMORY ALLOCATION FUNCTIONS - USED INTERNALLY AND BY BIGD */
+/*************************************************************/
+/* [v2.2] added option to avoid memory allocation if NO_ALLOCS is defined */
+#ifndef NO_ALLOCS
+DIGIT_T *mpAlloc(size_t ndigits);
+void mpFree(DIGIT_T **p);
+#endif
+void mpFail(char *msg);
+
+/* Clean up by zeroising and freeing allocated memory */
+#ifdef NO_ALLOCS
+#define mpDESTROY(b, n) do{if(b)mpSetZero(b,n);}while(0)
+#else
+#define mpDESTROY(b, n) do{if(b)mpSetZero(b,n);mpFree(&b);}while(0)
+#endif
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* BIGDIGITS_H_ */

--- a/src/bigdtypes.h
+++ b/src/bigdtypes.h
@@ -1,0 +1,71 @@
+/* $Id: bigdtypes.h $ */
+
+/***** BEGIN LICENSE BLOCK *****
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2001-16 David Ireland, D.I. Management Services Pty Limited
+ * <http://www.di-mgt.com.au/bigdigits.html>. All rights reserved.
+ *
+ ***** END LICENSE BLOCK *****/
+/*
+ * Last updated:
+ * $Date: 2016-03-31 09:51:00 $
+ * $Revision: 2.6.1 $
+ * $Author: dai $
+ */
+
+#ifndef BIGDTYPES_H_
+#define BIGDTYPES_H_ 1
+
+#include <stddef.h>
+
+/*
+The following PP instructions assume that all Linux systems have a C99-conforming 
+<stdint.h>; that other Unix systems have the uint32_t definitions in <sys/types.h>;
+and that MS et al don't have them at all. This version assumes that a long is 32 bits.
+Adjust if necessary to suit your system. 
+You can override by defining HAVE_C99INCLUDES or HAVE_SYS_TYPES.
+*/
+
+#ifndef EXACT_INTS_DEFINED_
+#define EXACT_INTS_DEFINED_ 1
+#ifndef HAVE_C99INCLUDES
+	#if (__STDC_VERSION >= 199901L) || defined(linux) || defined(__linux__) || defined(__APPLE__)
+	#define HAVE_C99INCLUDES
+	#endif
+#endif
+#ifndef HAVE_SYS_TYPES
+	#if defined(unix) || defined(__unix__)
+	#define HAVE_SYS_TYPES
+	#endif
+#endif
+#ifdef HAVE_C99INCLUDES
+	#include <stdint.h>
+#elif defined(HAVE_SYS_TYPES)
+	#include <sys/types.h>
+#else 
+	#define uint32_t unsigned long 
+	#define uint16_t unsigned short
+	#define uint8_t unsigned char
+#endif	/* HAVE_C99INCLUDES */
+#endif	/* EXACT_INTS_DEFINED_ */
+
+/* Macros for format specifiers 
+-- change to "u", "x" and "X" if necessary */
+#ifdef HAVE_C99INCLUDES
+	#include <inttypes.h>
+#else 
+	#define PRIu32 "lu" 
+	#define PRIx32 "lx" 
+	#define PRIX32 "lX" 
+#endif
+/* We define our own 
+-- Example: ``printf("%" PRIxBIGD "\n", d);`` */
+#define PRIuBIGD PRIu32
+#define PRIxBIGD PRIx32
+#define PRIXBIGD PRIX32
+
+#endif /* BIGDTYPES_H_ */

--- a/src/copy_stream.cpp
+++ b/src/copy_stream.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -17,6 +17,8 @@
 */
 
 #include "copy_stream.hpp"
+
+#include "error.hpp"
 
 #include <array>
 #include <algorithm>
@@ -45,5 +47,11 @@ namespace util
         bytes_to_write -= is_.gcount();
       }
     while(is_ && os_ && (bytes_to_write > 0));
+
+    if(bytes_to_write > 0)
+      throw Error("copy_stream: short copy, " +
+                  std::to_string(bytes_to_write) +
+                  " of " + std::to_string(len_) +
+                  " bytes not transferred");
   }
 }

--- a/src/copy_stream.hpp
+++ b/src/copy_stream.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/crc32b.c
+++ b/src/crc32b.c
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/crc32b.h
+++ b/src/crc32b.h
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/error.hpp
+++ b/src/error.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -18,36 +18,56 @@
 
 #pragma once
 
+#include <exception>
 #include <string>
 
-struct Error
+struct Error : public std::exception
 {
   Error()
+    : code(1)
   {
   }
 
   Error(const Error &err_)
-    : str(err_.str)
+    : str(err_.str),
+      code(err_.code)
   {
   }
 
   Error(Error &&err_)
-    : str(std::move(err_.str))
+    : str(std::move(err_.str)),
+      code(err_.code)
   {
   }
 
   Error(const char *str_)
-    : str(str_)
+    : str(str_),
+      code(1)
   {
   }
 
   Error(const std::string &str_)
-    : str(str_)
+    : str(str_),
+      code(1)
   {
   }
 
-  Error& operator=(const Error &err_) { str = err_.str; return *this; }
-  Error& operator=(const std::string &str_) { str = str_; return *this; }
+  Error(const char *str_,
+        const int   code_)
+    : str(str_),
+      code(code_)
+  {
+  }
+
+  Error(const std::string &str_,
+        const int          code_)
+    : str(str_),
+      code(code_)
+  {
+  }
+
+  Error& operator=(const Error &err_) { str = err_.str; code = err_.code; return *this; }
+  Error& operator=(const std::string &str_) { str = str_; code = 1; return *this; }
 
   operator bool() { return !str.empty(); }
   operator const std::string&() const { return str; }
@@ -55,6 +75,8 @@ struct Error
 
   const char *c_str() const { return str.c_str(); }
 
+  const char *what() const noexcept override { return str.c_str(); }
 
   std::string str;
+  int         code;
 };

--- a/src/error_unknown_image_format.hpp
+++ b/src/error_unknown_image_format.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/fmt.hpp
+++ b/src/fmt.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/fmt_md5_digest.hpp
+++ b/src/fmt_md5_digest.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "fmt.hpp"
+
+#include "md5.h"
+#include "types_ints.h"
+
+template<>
+struct fmt::formatter<md5_digest_t> : formatter<std::string>
+{
+  template <typename FormatContext>
+  auto
+  format(const md5_digest_t  digest_,
+         FormatContext      &ctx_)
+  {
+    std::string s;
+
+    for(u64 i = 0; i < sizeof(md5_digest_t); i++)
+      s += fmt::format("{:02X}",digest_[i]);
+    
+    return formatter<std::string>::format(s,ctx_);
+  }
+};

--- a/src/fmt_rsa512_sig.hpp
+++ b/src/fmt_rsa512_sig.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "fmt.hpp"
+
+#include "tdo_rsa.h"
+#include "types_ints.h"
+
+template<>
+struct fmt::formatter<rsa512_sig_t> : formatter<std::string>
+{
+  template <typename FormatContext>
+  auto
+  format(const rsa512_sig_t  sig_,
+         FormatContext      &ctx_)
+  {
+    std::string s;
+
+    for(u64 i = 0; i < sizeof(rsa512_sig_t); i++)
+      s += fmt::format("{:02X}",sig_[i]);
+    
+    return formatter<std::string>::format(s,ctx_);
+  }
+};

--- a/src/json.hpp
+++ b/src/json.hpp
@@ -1,0 +1,24765 @@
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+/****************************************************************************\
+ * Note on documentation: The source files contain links to the online      *
+ * documentation of the public API at https://json.nlohmann.me. This URL    *
+ * contains the most recent documentation and should also be applicable to  *
+ * previous versions; documentation for deprecated functions is not         *
+ * removed, but marked deprecated. See "Generate documentation" section in  *
+ * file docs/README.md.                                                     *
+\****************************************************************************/
+
+#ifndef INCLUDE_NLOHMANN_JSON_HPP_
+#define INCLUDE_NLOHMANN_JSON_HPP_
+
+#include <algorithm> // all_of, find, for_each
+#include <cstddef> // nullptr_t, ptrdiff_t, size_t
+#include <functional> // hash, less
+#include <initializer_list> // initializer_list
+#ifndef JSON_NO_IO
+    #include <iosfwd> // istream, ostream
+#endif  // JSON_NO_IO
+#include <iterator> // random_access_iterator_tag
+#include <memory> // unique_ptr
+#include <string> // string, stoi, to_string
+#include <utility> // declval, forward, move, pair, swap
+#include <vector> // vector
+
+// #include <nlohmann/adl_serializer.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <utility>
+
+// #include <nlohmann/detail/abi_macros.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+// This file contains all macro definitions affecting or depending on the ABI
+
+#ifndef JSON_SKIP_LIBRARY_VERSION_CHECK
+    #if defined(NLOHMANN_JSON_VERSION_MAJOR) && defined(NLOHMANN_JSON_VERSION_MINOR) && defined(NLOHMANN_JSON_VERSION_PATCH)
+        #if NLOHMANN_JSON_VERSION_MAJOR != 3 || NLOHMANN_JSON_VERSION_MINOR != 11 || NLOHMANN_JSON_VERSION_PATCH != 3
+            #warning "Already included a different version of the library!"
+        #endif
+    #endif
+#endif
+
+#define NLOHMANN_JSON_VERSION_MAJOR 3   // NOLINT(modernize-macro-to-enum)
+#define NLOHMANN_JSON_VERSION_MINOR 11  // NOLINT(modernize-macro-to-enum)
+#define NLOHMANN_JSON_VERSION_PATCH 3   // NOLINT(modernize-macro-to-enum)
+
+#ifndef JSON_DIAGNOSTICS
+    #define JSON_DIAGNOSTICS 0
+#endif
+
+#ifndef JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON
+    #define JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON 0
+#endif
+
+#if JSON_DIAGNOSTICS
+    #define NLOHMANN_JSON_ABI_TAG_DIAGNOSTICS _diag
+#else
+    #define NLOHMANN_JSON_ABI_TAG_DIAGNOSTICS
+#endif
+
+#if JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON
+    #define NLOHMANN_JSON_ABI_TAG_LEGACY_DISCARDED_VALUE_COMPARISON _ldvcmp
+#else
+    #define NLOHMANN_JSON_ABI_TAG_LEGACY_DISCARDED_VALUE_COMPARISON
+#endif
+
+#ifndef NLOHMANN_JSON_NAMESPACE_NO_VERSION
+    #define NLOHMANN_JSON_NAMESPACE_NO_VERSION 0
+#endif
+
+// Construct the namespace ABI tags component
+#define NLOHMANN_JSON_ABI_TAGS_CONCAT_EX(a, b) json_abi ## a ## b
+#define NLOHMANN_JSON_ABI_TAGS_CONCAT(a, b) \
+    NLOHMANN_JSON_ABI_TAGS_CONCAT_EX(a, b)
+
+#define NLOHMANN_JSON_ABI_TAGS                                       \
+    NLOHMANN_JSON_ABI_TAGS_CONCAT(                                   \
+            NLOHMANN_JSON_ABI_TAG_DIAGNOSTICS,                       \
+            NLOHMANN_JSON_ABI_TAG_LEGACY_DISCARDED_VALUE_COMPARISON)
+
+// Construct the namespace version component
+#define NLOHMANN_JSON_NAMESPACE_VERSION_CONCAT_EX(major, minor, patch) \
+    _v ## major ## _ ## minor ## _ ## patch
+#define NLOHMANN_JSON_NAMESPACE_VERSION_CONCAT(major, minor, patch) \
+    NLOHMANN_JSON_NAMESPACE_VERSION_CONCAT_EX(major, minor, patch)
+
+#if NLOHMANN_JSON_NAMESPACE_NO_VERSION
+#define NLOHMANN_JSON_NAMESPACE_VERSION
+#else
+#define NLOHMANN_JSON_NAMESPACE_VERSION                                 \
+    NLOHMANN_JSON_NAMESPACE_VERSION_CONCAT(NLOHMANN_JSON_VERSION_MAJOR, \
+                                           NLOHMANN_JSON_VERSION_MINOR, \
+                                           NLOHMANN_JSON_VERSION_PATCH)
+#endif
+
+// Combine namespace components
+#define NLOHMANN_JSON_NAMESPACE_CONCAT_EX(a, b) a ## b
+#define NLOHMANN_JSON_NAMESPACE_CONCAT(a, b) \
+    NLOHMANN_JSON_NAMESPACE_CONCAT_EX(a, b)
+
+#ifndef NLOHMANN_JSON_NAMESPACE
+#define NLOHMANN_JSON_NAMESPACE               \
+    nlohmann::NLOHMANN_JSON_NAMESPACE_CONCAT( \
+            NLOHMANN_JSON_ABI_TAGS,           \
+            NLOHMANN_JSON_NAMESPACE_VERSION)
+#endif
+
+#ifndef NLOHMANN_JSON_NAMESPACE_BEGIN
+#define NLOHMANN_JSON_NAMESPACE_BEGIN                \
+    namespace nlohmann                               \
+    {                                                \
+    inline namespace NLOHMANN_JSON_NAMESPACE_CONCAT( \
+                NLOHMANN_JSON_ABI_TAGS,              \
+                NLOHMANN_JSON_NAMESPACE_VERSION)     \
+    {
+#endif
+
+#ifndef NLOHMANN_JSON_NAMESPACE_END
+#define NLOHMANN_JSON_NAMESPACE_END                                     \
+    }  /* namespace (inline namespace) NOLINT(readability/namespace) */ \
+    }  // namespace nlohmann
+#endif
+
+// #include <nlohmann/detail/conversions/from_json.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <algorithm> // transform
+#include <array> // array
+#include <forward_list> // forward_list
+#include <iterator> // inserter, front_inserter, end
+#include <map> // map
+#include <string> // string
+#include <tuple> // tuple, make_tuple
+#include <type_traits> // is_arithmetic, is_same, is_enum, underlying_type, is_convertible
+#include <unordered_map> // unordered_map
+#include <utility> // pair, declval
+#include <valarray> // valarray
+
+// #include <nlohmann/detail/exceptions.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cstddef> // nullptr_t
+#include <exception> // exception
+#if JSON_DIAGNOSTICS
+    #include <numeric> // accumulate
+#endif
+#include <stdexcept> // runtime_error
+#include <string> // to_string
+#include <vector> // vector
+
+// #include <nlohmann/detail/value_t.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <array> // array
+#include <cstddef> // size_t
+#include <cstdint> // uint8_t
+#include <string> // string
+
+// #include <nlohmann/detail/macro_scope.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <utility> // declval, pair
+// #include <nlohmann/detail/meta/detected.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <type_traits>
+
+// #include <nlohmann/detail/meta/void_t.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+template<typename ...Ts> struct make_void
+{
+    using type = void;
+};
+template<typename ...Ts> using void_t = typename make_void<Ts...>::type;
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+// https://en.cppreference.com/w/cpp/experimental/is_detected
+struct nonesuch
+{
+    nonesuch() = delete;
+    ~nonesuch() = delete;
+    nonesuch(nonesuch const&) = delete;
+    nonesuch(nonesuch const&&) = delete;
+    void operator=(nonesuch const&) = delete;
+    void operator=(nonesuch&&) = delete;
+};
+
+template<class Default,
+         class AlwaysVoid,
+         template<class...> class Op,
+         class... Args>
+struct detector
+{
+    using value_t = std::false_type;
+    using type = Default;
+};
+
+template<class Default, template<class...> class Op, class... Args>
+struct detector<Default, void_t<Op<Args...>>, Op, Args...>
+{
+    using value_t = std::true_type;
+    using type = Op<Args...>;
+};
+
+template<template<class...> class Op, class... Args>
+using is_detected = typename detector<nonesuch, void, Op, Args...>::value_t;
+
+template<template<class...> class Op, class... Args>
+struct is_detected_lazy : is_detected<Op, Args...> { };
+
+template<template<class...> class Op, class... Args>
+using detected_t = typename detector<nonesuch, void, Op, Args...>::type;
+
+template<class Default, template<class...> class Op, class... Args>
+using detected_or = detector<Default, void, Op, Args...>;
+
+template<class Default, template<class...> class Op, class... Args>
+using detected_or_t = typename detected_or<Default, Op, Args...>::type;
+
+template<class Expected, template<class...> class Op, class... Args>
+using is_detected_exact = std::is_same<Expected, detected_t<Op, Args...>>;
+
+template<class To, template<class...> class Op, class... Args>
+using is_detected_convertible =
+    std::is_convertible<detected_t<Op, Args...>, To>;
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/thirdparty/hedley/hedley.hpp>
+
+
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2016-2021 Evan Nemerson <evan@nemerson.com>
+// SPDX-License-Identifier: MIT
+
+/* Hedley - https://nemequ.github.io/hedley
+ * Created by Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(JSON_HEDLEY_VERSION) || (JSON_HEDLEY_VERSION < 15)
+#if defined(JSON_HEDLEY_VERSION)
+    #undef JSON_HEDLEY_VERSION
+#endif
+#define JSON_HEDLEY_VERSION 15
+
+#if defined(JSON_HEDLEY_STRINGIFY_EX)
+    #undef JSON_HEDLEY_STRINGIFY_EX
+#endif
+#define JSON_HEDLEY_STRINGIFY_EX(x) #x
+
+#if defined(JSON_HEDLEY_STRINGIFY)
+    #undef JSON_HEDLEY_STRINGIFY
+#endif
+#define JSON_HEDLEY_STRINGIFY(x) JSON_HEDLEY_STRINGIFY_EX(x)
+
+#if defined(JSON_HEDLEY_CONCAT_EX)
+    #undef JSON_HEDLEY_CONCAT_EX
+#endif
+#define JSON_HEDLEY_CONCAT_EX(a,b) a##b
+
+#if defined(JSON_HEDLEY_CONCAT)
+    #undef JSON_HEDLEY_CONCAT
+#endif
+#define JSON_HEDLEY_CONCAT(a,b) JSON_HEDLEY_CONCAT_EX(a,b)
+
+#if defined(JSON_HEDLEY_CONCAT3_EX)
+    #undef JSON_HEDLEY_CONCAT3_EX
+#endif
+#define JSON_HEDLEY_CONCAT3_EX(a,b,c) a##b##c
+
+#if defined(JSON_HEDLEY_CONCAT3)
+    #undef JSON_HEDLEY_CONCAT3
+#endif
+#define JSON_HEDLEY_CONCAT3(a,b,c) JSON_HEDLEY_CONCAT3_EX(a,b,c)
+
+#if defined(JSON_HEDLEY_VERSION_ENCODE)
+    #undef JSON_HEDLEY_VERSION_ENCODE
+#endif
+#define JSON_HEDLEY_VERSION_ENCODE(major,minor,revision) (((major) * 1000000) + ((minor) * 1000) + (revision))
+
+#if defined(JSON_HEDLEY_VERSION_DECODE_MAJOR)
+    #undef JSON_HEDLEY_VERSION_DECODE_MAJOR
+#endif
+#define JSON_HEDLEY_VERSION_DECODE_MAJOR(version) ((version) / 1000000)
+
+#if defined(JSON_HEDLEY_VERSION_DECODE_MINOR)
+    #undef JSON_HEDLEY_VERSION_DECODE_MINOR
+#endif
+#define JSON_HEDLEY_VERSION_DECODE_MINOR(version) (((version) % 1000000) / 1000)
+
+#if defined(JSON_HEDLEY_VERSION_DECODE_REVISION)
+    #undef JSON_HEDLEY_VERSION_DECODE_REVISION
+#endif
+#define JSON_HEDLEY_VERSION_DECODE_REVISION(version) ((version) % 1000)
+
+#if defined(JSON_HEDLEY_GNUC_VERSION)
+    #undef JSON_HEDLEY_GNUC_VERSION
+#endif
+#if defined(__GNUC__) && defined(__GNUC_PATCHLEVEL__)
+    #define JSON_HEDLEY_GNUC_VERSION JSON_HEDLEY_VERSION_ENCODE(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#elif defined(__GNUC__)
+    #define JSON_HEDLEY_GNUC_VERSION JSON_HEDLEY_VERSION_ENCODE(__GNUC__, __GNUC_MINOR__, 0)
+#endif
+
+#if defined(JSON_HEDLEY_GNUC_VERSION_CHECK)
+    #undef JSON_HEDLEY_GNUC_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_GNUC_VERSION)
+    #define JSON_HEDLEY_GNUC_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_GNUC_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_GNUC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_MSVC_VERSION)
+    #undef JSON_HEDLEY_MSVC_VERSION
+#endif
+#if defined(_MSC_FULL_VER) && (_MSC_FULL_VER >= 140000000) && !defined(__ICL)
+    #define JSON_HEDLEY_MSVC_VERSION JSON_HEDLEY_VERSION_ENCODE(_MSC_FULL_VER / 10000000, (_MSC_FULL_VER % 10000000) / 100000, (_MSC_FULL_VER % 100000) / 100)
+#elif defined(_MSC_FULL_VER) && !defined(__ICL)
+    #define JSON_HEDLEY_MSVC_VERSION JSON_HEDLEY_VERSION_ENCODE(_MSC_FULL_VER / 1000000, (_MSC_FULL_VER % 1000000) / 10000, (_MSC_FULL_VER % 10000) / 10)
+#elif defined(_MSC_VER) && !defined(__ICL)
+    #define JSON_HEDLEY_MSVC_VERSION JSON_HEDLEY_VERSION_ENCODE(_MSC_VER / 100, _MSC_VER % 100, 0)
+#endif
+
+#if defined(JSON_HEDLEY_MSVC_VERSION_CHECK)
+    #undef JSON_HEDLEY_MSVC_VERSION_CHECK
+#endif
+#if !defined(JSON_HEDLEY_MSVC_VERSION)
+    #define JSON_HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (0)
+#elif defined(_MSC_VER) && (_MSC_VER >= 1400)
+    #define JSON_HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (_MSC_FULL_VER >= ((major * 10000000) + (minor * 100000) + (patch)))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1200)
+    #define JSON_HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (_MSC_FULL_VER >= ((major * 1000000) + (minor * 10000) + (patch)))
+#else
+    #define JSON_HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (_MSC_VER >= ((major * 100) + (minor)))
+#endif
+
+#if defined(JSON_HEDLEY_INTEL_VERSION)
+    #undef JSON_HEDLEY_INTEL_VERSION
+#endif
+#if defined(__INTEL_COMPILER) && defined(__INTEL_COMPILER_UPDATE) && !defined(__ICL)
+    #define JSON_HEDLEY_INTEL_VERSION JSON_HEDLEY_VERSION_ENCODE(__INTEL_COMPILER / 100, __INTEL_COMPILER % 100, __INTEL_COMPILER_UPDATE)
+#elif defined(__INTEL_COMPILER) && !defined(__ICL)
+    #define JSON_HEDLEY_INTEL_VERSION JSON_HEDLEY_VERSION_ENCODE(__INTEL_COMPILER / 100, __INTEL_COMPILER % 100, 0)
+#endif
+
+#if defined(JSON_HEDLEY_INTEL_VERSION_CHECK)
+    #undef JSON_HEDLEY_INTEL_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_INTEL_VERSION)
+    #define JSON_HEDLEY_INTEL_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_INTEL_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_INTEL_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_INTEL_CL_VERSION)
+    #undef JSON_HEDLEY_INTEL_CL_VERSION
+#endif
+#if defined(__INTEL_COMPILER) && defined(__INTEL_COMPILER_UPDATE) && defined(__ICL)
+    #define JSON_HEDLEY_INTEL_CL_VERSION JSON_HEDLEY_VERSION_ENCODE(__INTEL_COMPILER, __INTEL_COMPILER_UPDATE, 0)
+#endif
+
+#if defined(JSON_HEDLEY_INTEL_CL_VERSION_CHECK)
+    #undef JSON_HEDLEY_INTEL_CL_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_INTEL_CL_VERSION)
+    #define JSON_HEDLEY_INTEL_CL_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_INTEL_CL_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_INTEL_CL_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_PGI_VERSION)
+    #undef JSON_HEDLEY_PGI_VERSION
+#endif
+#if defined(__PGI) && defined(__PGIC__) && defined(__PGIC_MINOR__) && defined(__PGIC_PATCHLEVEL__)
+    #define JSON_HEDLEY_PGI_VERSION JSON_HEDLEY_VERSION_ENCODE(__PGIC__, __PGIC_MINOR__, __PGIC_PATCHLEVEL__)
+#endif
+
+#if defined(JSON_HEDLEY_PGI_VERSION_CHECK)
+    #undef JSON_HEDLEY_PGI_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_PGI_VERSION)
+    #define JSON_HEDLEY_PGI_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_PGI_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_PGI_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_SUNPRO_VERSION)
+    #undef JSON_HEDLEY_SUNPRO_VERSION
+#endif
+#if defined(__SUNPRO_C) && (__SUNPRO_C > 0x1000)
+    #define JSON_HEDLEY_SUNPRO_VERSION JSON_HEDLEY_VERSION_ENCODE((((__SUNPRO_C >> 16) & 0xf) * 10) + ((__SUNPRO_C >> 12) & 0xf), (((__SUNPRO_C >> 8) & 0xf) * 10) + ((__SUNPRO_C >> 4) & 0xf), (__SUNPRO_C & 0xf) * 10)
+#elif defined(__SUNPRO_C)
+    #define JSON_HEDLEY_SUNPRO_VERSION JSON_HEDLEY_VERSION_ENCODE((__SUNPRO_C >> 8) & 0xf, (__SUNPRO_C >> 4) & 0xf, (__SUNPRO_C) & 0xf)
+#elif defined(__SUNPRO_CC) && (__SUNPRO_CC > 0x1000)
+    #define JSON_HEDLEY_SUNPRO_VERSION JSON_HEDLEY_VERSION_ENCODE((((__SUNPRO_CC >> 16) & 0xf) * 10) + ((__SUNPRO_CC >> 12) & 0xf), (((__SUNPRO_CC >> 8) & 0xf) * 10) + ((__SUNPRO_CC >> 4) & 0xf), (__SUNPRO_CC & 0xf) * 10)
+#elif defined(__SUNPRO_CC)
+    #define JSON_HEDLEY_SUNPRO_VERSION JSON_HEDLEY_VERSION_ENCODE((__SUNPRO_CC >> 8) & 0xf, (__SUNPRO_CC >> 4) & 0xf, (__SUNPRO_CC) & 0xf)
+#endif
+
+#if defined(JSON_HEDLEY_SUNPRO_VERSION_CHECK)
+    #undef JSON_HEDLEY_SUNPRO_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_SUNPRO_VERSION)
+    #define JSON_HEDLEY_SUNPRO_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_SUNPRO_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_SUNPRO_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_EMSCRIPTEN_VERSION)
+    #undef JSON_HEDLEY_EMSCRIPTEN_VERSION
+#endif
+#if defined(__EMSCRIPTEN__)
+    #define JSON_HEDLEY_EMSCRIPTEN_VERSION JSON_HEDLEY_VERSION_ENCODE(__EMSCRIPTEN_major__, __EMSCRIPTEN_minor__, __EMSCRIPTEN_tiny__)
+#endif
+
+#if defined(JSON_HEDLEY_EMSCRIPTEN_VERSION_CHECK)
+    #undef JSON_HEDLEY_EMSCRIPTEN_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_EMSCRIPTEN_VERSION)
+    #define JSON_HEDLEY_EMSCRIPTEN_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_EMSCRIPTEN_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_EMSCRIPTEN_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_ARM_VERSION)
+    #undef JSON_HEDLEY_ARM_VERSION
+#endif
+#if defined(__CC_ARM) && defined(__ARMCOMPILER_VERSION)
+    #define JSON_HEDLEY_ARM_VERSION JSON_HEDLEY_VERSION_ENCODE(__ARMCOMPILER_VERSION / 1000000, (__ARMCOMPILER_VERSION % 1000000) / 10000, (__ARMCOMPILER_VERSION % 10000) / 100)
+#elif defined(__CC_ARM) && defined(__ARMCC_VERSION)
+    #define JSON_HEDLEY_ARM_VERSION JSON_HEDLEY_VERSION_ENCODE(__ARMCC_VERSION / 1000000, (__ARMCC_VERSION % 1000000) / 10000, (__ARMCC_VERSION % 10000) / 100)
+#endif
+
+#if defined(JSON_HEDLEY_ARM_VERSION_CHECK)
+    #undef JSON_HEDLEY_ARM_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_ARM_VERSION)
+    #define JSON_HEDLEY_ARM_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_ARM_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_ARM_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_IBM_VERSION)
+    #undef JSON_HEDLEY_IBM_VERSION
+#endif
+#if defined(__ibmxl__)
+    #define JSON_HEDLEY_IBM_VERSION JSON_HEDLEY_VERSION_ENCODE(__ibmxl_version__, __ibmxl_release__, __ibmxl_modification__)
+#elif defined(__xlC__) && defined(__xlC_ver__)
+    #define JSON_HEDLEY_IBM_VERSION JSON_HEDLEY_VERSION_ENCODE(__xlC__ >> 8, __xlC__ & 0xff, (__xlC_ver__ >> 8) & 0xff)
+#elif defined(__xlC__)
+    #define JSON_HEDLEY_IBM_VERSION JSON_HEDLEY_VERSION_ENCODE(__xlC__ >> 8, __xlC__ & 0xff, 0)
+#endif
+
+#if defined(JSON_HEDLEY_IBM_VERSION_CHECK)
+    #undef JSON_HEDLEY_IBM_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_IBM_VERSION)
+    #define JSON_HEDLEY_IBM_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_IBM_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_IBM_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_TI_VERSION)
+    #undef JSON_HEDLEY_TI_VERSION
+#endif
+#if \
+    defined(__TI_COMPILER_VERSION__) && \
+    ( \
+      defined(__TMS470__) || defined(__TI_ARM__) || \
+      defined(__MSP430__) || \
+      defined(__TMS320C2000__) \
+    )
+#if (__TI_COMPILER_VERSION__ >= 16000000)
+    #define JSON_HEDLEY_TI_VERSION JSON_HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+#endif
+
+#if defined(JSON_HEDLEY_TI_VERSION_CHECK)
+    #undef JSON_HEDLEY_TI_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_TI_VERSION)
+    #define JSON_HEDLEY_TI_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_TI_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_TI_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_TI_CL2000_VERSION)
+    #undef JSON_HEDLEY_TI_CL2000_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && defined(__TMS320C2000__)
+    #define JSON_HEDLEY_TI_CL2000_VERSION JSON_HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(JSON_HEDLEY_TI_CL2000_VERSION_CHECK)
+    #undef JSON_HEDLEY_TI_CL2000_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_TI_CL2000_VERSION)
+    #define JSON_HEDLEY_TI_CL2000_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_TI_CL2000_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_TI_CL2000_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_TI_CL430_VERSION)
+    #undef JSON_HEDLEY_TI_CL430_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && defined(__MSP430__)
+    #define JSON_HEDLEY_TI_CL430_VERSION JSON_HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(JSON_HEDLEY_TI_CL430_VERSION_CHECK)
+    #undef JSON_HEDLEY_TI_CL430_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_TI_CL430_VERSION)
+    #define JSON_HEDLEY_TI_CL430_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_TI_CL430_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_TI_CL430_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_TI_ARMCL_VERSION)
+    #undef JSON_HEDLEY_TI_ARMCL_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && (defined(__TMS470__) || defined(__TI_ARM__))
+    #define JSON_HEDLEY_TI_ARMCL_VERSION JSON_HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(JSON_HEDLEY_TI_ARMCL_VERSION_CHECK)
+    #undef JSON_HEDLEY_TI_ARMCL_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_TI_ARMCL_VERSION)
+    #define JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_TI_ARMCL_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_TI_CL6X_VERSION)
+    #undef JSON_HEDLEY_TI_CL6X_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && defined(__TMS320C6X__)
+    #define JSON_HEDLEY_TI_CL6X_VERSION JSON_HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(JSON_HEDLEY_TI_CL6X_VERSION_CHECK)
+    #undef JSON_HEDLEY_TI_CL6X_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_TI_CL6X_VERSION)
+    #define JSON_HEDLEY_TI_CL6X_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_TI_CL6X_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_TI_CL6X_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_TI_CL7X_VERSION)
+    #undef JSON_HEDLEY_TI_CL7X_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && defined(__C7000__)
+    #define JSON_HEDLEY_TI_CL7X_VERSION JSON_HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(JSON_HEDLEY_TI_CL7X_VERSION_CHECK)
+    #undef JSON_HEDLEY_TI_CL7X_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_TI_CL7X_VERSION)
+    #define JSON_HEDLEY_TI_CL7X_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_TI_CL7X_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_TI_CL7X_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_TI_CLPRU_VERSION)
+    #undef JSON_HEDLEY_TI_CLPRU_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && defined(__PRU__)
+    #define JSON_HEDLEY_TI_CLPRU_VERSION JSON_HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(JSON_HEDLEY_TI_CLPRU_VERSION_CHECK)
+    #undef JSON_HEDLEY_TI_CLPRU_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_TI_CLPRU_VERSION)
+    #define JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_TI_CLPRU_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_CRAY_VERSION)
+    #undef JSON_HEDLEY_CRAY_VERSION
+#endif
+#if defined(_CRAYC)
+    #if defined(_RELEASE_PATCHLEVEL)
+        #define JSON_HEDLEY_CRAY_VERSION JSON_HEDLEY_VERSION_ENCODE(_RELEASE_MAJOR, _RELEASE_MINOR, _RELEASE_PATCHLEVEL)
+    #else
+        #define JSON_HEDLEY_CRAY_VERSION JSON_HEDLEY_VERSION_ENCODE(_RELEASE_MAJOR, _RELEASE_MINOR, 0)
+    #endif
+#endif
+
+#if defined(JSON_HEDLEY_CRAY_VERSION_CHECK)
+    #undef JSON_HEDLEY_CRAY_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_CRAY_VERSION)
+    #define JSON_HEDLEY_CRAY_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_CRAY_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_CRAY_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_IAR_VERSION)
+    #undef JSON_HEDLEY_IAR_VERSION
+#endif
+#if defined(__IAR_SYSTEMS_ICC__)
+    #if __VER__ > 1000
+        #define JSON_HEDLEY_IAR_VERSION JSON_HEDLEY_VERSION_ENCODE((__VER__ / 1000000), ((__VER__ / 1000) % 1000), (__VER__ % 1000))
+    #else
+        #define JSON_HEDLEY_IAR_VERSION JSON_HEDLEY_VERSION_ENCODE(__VER__ / 100, __VER__ % 100, 0)
+    #endif
+#endif
+
+#if defined(JSON_HEDLEY_IAR_VERSION_CHECK)
+    #undef JSON_HEDLEY_IAR_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_IAR_VERSION)
+    #define JSON_HEDLEY_IAR_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_IAR_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_IAR_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_TINYC_VERSION)
+    #undef JSON_HEDLEY_TINYC_VERSION
+#endif
+#if defined(__TINYC__)
+    #define JSON_HEDLEY_TINYC_VERSION JSON_HEDLEY_VERSION_ENCODE(__TINYC__ / 1000, (__TINYC__ / 100) % 10, __TINYC__ % 100)
+#endif
+
+#if defined(JSON_HEDLEY_TINYC_VERSION_CHECK)
+    #undef JSON_HEDLEY_TINYC_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_TINYC_VERSION)
+    #define JSON_HEDLEY_TINYC_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_TINYC_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_TINYC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_DMC_VERSION)
+    #undef JSON_HEDLEY_DMC_VERSION
+#endif
+#if defined(__DMC__)
+    #define JSON_HEDLEY_DMC_VERSION JSON_HEDLEY_VERSION_ENCODE(__DMC__ >> 8, (__DMC__ >> 4) & 0xf, __DMC__ & 0xf)
+#endif
+
+#if defined(JSON_HEDLEY_DMC_VERSION_CHECK)
+    #undef JSON_HEDLEY_DMC_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_DMC_VERSION)
+    #define JSON_HEDLEY_DMC_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_DMC_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_DMC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_COMPCERT_VERSION)
+    #undef JSON_HEDLEY_COMPCERT_VERSION
+#endif
+#if defined(__COMPCERT_VERSION__)
+    #define JSON_HEDLEY_COMPCERT_VERSION JSON_HEDLEY_VERSION_ENCODE(__COMPCERT_VERSION__ / 10000, (__COMPCERT_VERSION__ / 100) % 100, __COMPCERT_VERSION__ % 100)
+#endif
+
+#if defined(JSON_HEDLEY_COMPCERT_VERSION_CHECK)
+    #undef JSON_HEDLEY_COMPCERT_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_COMPCERT_VERSION)
+    #define JSON_HEDLEY_COMPCERT_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_COMPCERT_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_COMPCERT_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_PELLES_VERSION)
+    #undef JSON_HEDLEY_PELLES_VERSION
+#endif
+#if defined(__POCC__)
+    #define JSON_HEDLEY_PELLES_VERSION JSON_HEDLEY_VERSION_ENCODE(__POCC__ / 100, __POCC__ % 100, 0)
+#endif
+
+#if defined(JSON_HEDLEY_PELLES_VERSION_CHECK)
+    #undef JSON_HEDLEY_PELLES_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_PELLES_VERSION)
+    #define JSON_HEDLEY_PELLES_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_PELLES_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_PELLES_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_MCST_LCC_VERSION)
+    #undef JSON_HEDLEY_MCST_LCC_VERSION
+#endif
+#if defined(__LCC__) && defined(__LCC_MINOR__)
+    #define JSON_HEDLEY_MCST_LCC_VERSION JSON_HEDLEY_VERSION_ENCODE(__LCC__ / 100, __LCC__ % 100, __LCC_MINOR__)
+#endif
+
+#if defined(JSON_HEDLEY_MCST_LCC_VERSION_CHECK)
+    #undef JSON_HEDLEY_MCST_LCC_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_MCST_LCC_VERSION)
+    #define JSON_HEDLEY_MCST_LCC_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_MCST_LCC_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_MCST_LCC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_GCC_VERSION)
+    #undef JSON_HEDLEY_GCC_VERSION
+#endif
+#if \
+    defined(JSON_HEDLEY_GNUC_VERSION) && \
+    !defined(__clang__) && \
+    !defined(JSON_HEDLEY_INTEL_VERSION) && \
+    !defined(JSON_HEDLEY_PGI_VERSION) && \
+    !defined(JSON_HEDLEY_ARM_VERSION) && \
+    !defined(JSON_HEDLEY_CRAY_VERSION) && \
+    !defined(JSON_HEDLEY_TI_VERSION) && \
+    !defined(JSON_HEDLEY_TI_ARMCL_VERSION) && \
+    !defined(JSON_HEDLEY_TI_CL430_VERSION) && \
+    !defined(JSON_HEDLEY_TI_CL2000_VERSION) && \
+    !defined(JSON_HEDLEY_TI_CL6X_VERSION) && \
+    !defined(JSON_HEDLEY_TI_CL7X_VERSION) && \
+    !defined(JSON_HEDLEY_TI_CLPRU_VERSION) && \
+    !defined(__COMPCERT__) && \
+    !defined(JSON_HEDLEY_MCST_LCC_VERSION)
+    #define JSON_HEDLEY_GCC_VERSION JSON_HEDLEY_GNUC_VERSION
+#endif
+
+#if defined(JSON_HEDLEY_GCC_VERSION_CHECK)
+    #undef JSON_HEDLEY_GCC_VERSION_CHECK
+#endif
+#if defined(JSON_HEDLEY_GCC_VERSION)
+    #define JSON_HEDLEY_GCC_VERSION_CHECK(major,minor,patch) (JSON_HEDLEY_GCC_VERSION >= JSON_HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+    #define JSON_HEDLEY_GCC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(JSON_HEDLEY_HAS_ATTRIBUTE)
+    #undef JSON_HEDLEY_HAS_ATTRIBUTE
+#endif
+#if \
+  defined(__has_attribute) && \
+  ( \
+    (!defined(JSON_HEDLEY_IAR_VERSION) || JSON_HEDLEY_IAR_VERSION_CHECK(8,5,9)) \
+  )
+#  define JSON_HEDLEY_HAS_ATTRIBUTE(attribute) __has_attribute(attribute)
+#else
+#  define JSON_HEDLEY_HAS_ATTRIBUTE(attribute) (0)
+#endif
+
+#if defined(JSON_HEDLEY_GNUC_HAS_ATTRIBUTE)
+    #undef JSON_HEDLEY_GNUC_HAS_ATTRIBUTE
+#endif
+#if defined(__has_attribute)
+    #define JSON_HEDLEY_GNUC_HAS_ATTRIBUTE(attribute,major,minor,patch) JSON_HEDLEY_HAS_ATTRIBUTE(attribute)
+#else
+    #define JSON_HEDLEY_GNUC_HAS_ATTRIBUTE(attribute,major,minor,patch) JSON_HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_GCC_HAS_ATTRIBUTE)
+    #undef JSON_HEDLEY_GCC_HAS_ATTRIBUTE
+#endif
+#if defined(__has_attribute)
+    #define JSON_HEDLEY_GCC_HAS_ATTRIBUTE(attribute,major,minor,patch) JSON_HEDLEY_HAS_ATTRIBUTE(attribute)
+#else
+    #define JSON_HEDLEY_GCC_HAS_ATTRIBUTE(attribute,major,minor,patch) JSON_HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_HAS_CPP_ATTRIBUTE)
+    #undef JSON_HEDLEY_HAS_CPP_ATTRIBUTE
+#endif
+#if \
+    defined(__has_cpp_attribute) && \
+    defined(__cplusplus) && \
+    (!defined(JSON_HEDLEY_SUNPRO_VERSION) || JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,15,0))
+    #define JSON_HEDLEY_HAS_CPP_ATTRIBUTE(attribute) __has_cpp_attribute(attribute)
+#else
+    #define JSON_HEDLEY_HAS_CPP_ATTRIBUTE(attribute) (0)
+#endif
+
+#if defined(JSON_HEDLEY_HAS_CPP_ATTRIBUTE_NS)
+    #undef JSON_HEDLEY_HAS_CPP_ATTRIBUTE_NS
+#endif
+#if !defined(__cplusplus) || !defined(__has_cpp_attribute)
+    #define JSON_HEDLEY_HAS_CPP_ATTRIBUTE_NS(ns,attribute) (0)
+#elif \
+    !defined(JSON_HEDLEY_PGI_VERSION) && \
+    !defined(JSON_HEDLEY_IAR_VERSION) && \
+    (!defined(JSON_HEDLEY_SUNPRO_VERSION) || JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,15,0)) && \
+    (!defined(JSON_HEDLEY_MSVC_VERSION) || JSON_HEDLEY_MSVC_VERSION_CHECK(19,20,0))
+    #define JSON_HEDLEY_HAS_CPP_ATTRIBUTE_NS(ns,attribute) JSON_HEDLEY_HAS_CPP_ATTRIBUTE(ns::attribute)
+#else
+    #define JSON_HEDLEY_HAS_CPP_ATTRIBUTE_NS(ns,attribute) (0)
+#endif
+
+#if defined(JSON_HEDLEY_GNUC_HAS_CPP_ATTRIBUTE)
+    #undef JSON_HEDLEY_GNUC_HAS_CPP_ATTRIBUTE
+#endif
+#if defined(__has_cpp_attribute) && defined(__cplusplus)
+    #define JSON_HEDLEY_GNUC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) __has_cpp_attribute(attribute)
+#else
+    #define JSON_HEDLEY_GNUC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) JSON_HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_GCC_HAS_CPP_ATTRIBUTE)
+    #undef JSON_HEDLEY_GCC_HAS_CPP_ATTRIBUTE
+#endif
+#if defined(__has_cpp_attribute) && defined(__cplusplus)
+    #define JSON_HEDLEY_GCC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) __has_cpp_attribute(attribute)
+#else
+    #define JSON_HEDLEY_GCC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) JSON_HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_HAS_BUILTIN)
+    #undef JSON_HEDLEY_HAS_BUILTIN
+#endif
+#if defined(__has_builtin)
+    #define JSON_HEDLEY_HAS_BUILTIN(builtin) __has_builtin(builtin)
+#else
+    #define JSON_HEDLEY_HAS_BUILTIN(builtin) (0)
+#endif
+
+#if defined(JSON_HEDLEY_GNUC_HAS_BUILTIN)
+    #undef JSON_HEDLEY_GNUC_HAS_BUILTIN
+#endif
+#if defined(__has_builtin)
+    #define JSON_HEDLEY_GNUC_HAS_BUILTIN(builtin,major,minor,patch) __has_builtin(builtin)
+#else
+    #define JSON_HEDLEY_GNUC_HAS_BUILTIN(builtin,major,minor,patch) JSON_HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_GCC_HAS_BUILTIN)
+    #undef JSON_HEDLEY_GCC_HAS_BUILTIN
+#endif
+#if defined(__has_builtin)
+    #define JSON_HEDLEY_GCC_HAS_BUILTIN(builtin,major,minor,patch) __has_builtin(builtin)
+#else
+    #define JSON_HEDLEY_GCC_HAS_BUILTIN(builtin,major,minor,patch) JSON_HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_HAS_FEATURE)
+    #undef JSON_HEDLEY_HAS_FEATURE
+#endif
+#if defined(__has_feature)
+    #define JSON_HEDLEY_HAS_FEATURE(feature) __has_feature(feature)
+#else
+    #define JSON_HEDLEY_HAS_FEATURE(feature) (0)
+#endif
+
+#if defined(JSON_HEDLEY_GNUC_HAS_FEATURE)
+    #undef JSON_HEDLEY_GNUC_HAS_FEATURE
+#endif
+#if defined(__has_feature)
+    #define JSON_HEDLEY_GNUC_HAS_FEATURE(feature,major,minor,patch) __has_feature(feature)
+#else
+    #define JSON_HEDLEY_GNUC_HAS_FEATURE(feature,major,minor,patch) JSON_HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_GCC_HAS_FEATURE)
+    #undef JSON_HEDLEY_GCC_HAS_FEATURE
+#endif
+#if defined(__has_feature)
+    #define JSON_HEDLEY_GCC_HAS_FEATURE(feature,major,minor,patch) __has_feature(feature)
+#else
+    #define JSON_HEDLEY_GCC_HAS_FEATURE(feature,major,minor,patch) JSON_HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_HAS_EXTENSION)
+    #undef JSON_HEDLEY_HAS_EXTENSION
+#endif
+#if defined(__has_extension)
+    #define JSON_HEDLEY_HAS_EXTENSION(extension) __has_extension(extension)
+#else
+    #define JSON_HEDLEY_HAS_EXTENSION(extension) (0)
+#endif
+
+#if defined(JSON_HEDLEY_GNUC_HAS_EXTENSION)
+    #undef JSON_HEDLEY_GNUC_HAS_EXTENSION
+#endif
+#if defined(__has_extension)
+    #define JSON_HEDLEY_GNUC_HAS_EXTENSION(extension,major,minor,patch) __has_extension(extension)
+#else
+    #define JSON_HEDLEY_GNUC_HAS_EXTENSION(extension,major,minor,patch) JSON_HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_GCC_HAS_EXTENSION)
+    #undef JSON_HEDLEY_GCC_HAS_EXTENSION
+#endif
+#if defined(__has_extension)
+    #define JSON_HEDLEY_GCC_HAS_EXTENSION(extension,major,minor,patch) __has_extension(extension)
+#else
+    #define JSON_HEDLEY_GCC_HAS_EXTENSION(extension,major,minor,patch) JSON_HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_HAS_DECLSPEC_ATTRIBUTE)
+    #undef JSON_HEDLEY_HAS_DECLSPEC_ATTRIBUTE
+#endif
+#if defined(__has_declspec_attribute)
+    #define JSON_HEDLEY_HAS_DECLSPEC_ATTRIBUTE(attribute) __has_declspec_attribute(attribute)
+#else
+    #define JSON_HEDLEY_HAS_DECLSPEC_ATTRIBUTE(attribute) (0)
+#endif
+
+#if defined(JSON_HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE)
+    #undef JSON_HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE
+#endif
+#if defined(__has_declspec_attribute)
+    #define JSON_HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) __has_declspec_attribute(attribute)
+#else
+    #define JSON_HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) JSON_HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE)
+    #undef JSON_HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE
+#endif
+#if defined(__has_declspec_attribute)
+    #define JSON_HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) __has_declspec_attribute(attribute)
+#else
+    #define JSON_HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) JSON_HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_HAS_WARNING)
+    #undef JSON_HEDLEY_HAS_WARNING
+#endif
+#if defined(__has_warning)
+    #define JSON_HEDLEY_HAS_WARNING(warning) __has_warning(warning)
+#else
+    #define JSON_HEDLEY_HAS_WARNING(warning) (0)
+#endif
+
+#if defined(JSON_HEDLEY_GNUC_HAS_WARNING)
+    #undef JSON_HEDLEY_GNUC_HAS_WARNING
+#endif
+#if defined(__has_warning)
+    #define JSON_HEDLEY_GNUC_HAS_WARNING(warning,major,minor,patch) __has_warning(warning)
+#else
+    #define JSON_HEDLEY_GNUC_HAS_WARNING(warning,major,minor,patch) JSON_HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_GCC_HAS_WARNING)
+    #undef JSON_HEDLEY_GCC_HAS_WARNING
+#endif
+#if defined(__has_warning)
+    #define JSON_HEDLEY_GCC_HAS_WARNING(warning,major,minor,patch) __has_warning(warning)
+#else
+    #define JSON_HEDLEY_GCC_HAS_WARNING(warning,major,minor,patch) JSON_HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if \
+    (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) || \
+    defined(__clang__) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,0,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_IAR_VERSION_CHECK(8,0,0) || \
+    JSON_HEDLEY_PGI_VERSION_CHECK(18,4,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,7,0) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(2,0,1) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,1,0) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,0,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+    JSON_HEDLEY_CRAY_VERSION_CHECK(5,0,0) || \
+    JSON_HEDLEY_TINYC_VERSION_CHECK(0,9,17) || \
+    JSON_HEDLEY_SUNPRO_VERSION_CHECK(8,0,0) || \
+    (JSON_HEDLEY_IBM_VERSION_CHECK(10,1,0) && defined(__C99_PRAGMA_OPERATOR))
+    #define JSON_HEDLEY_PRAGMA(value) _Pragma(#value)
+#elif JSON_HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+    #define JSON_HEDLEY_PRAGMA(value) __pragma(value)
+#else
+    #define JSON_HEDLEY_PRAGMA(value)
+#endif
+
+#if defined(JSON_HEDLEY_DIAGNOSTIC_PUSH)
+    #undef JSON_HEDLEY_DIAGNOSTIC_PUSH
+#endif
+#if defined(JSON_HEDLEY_DIAGNOSTIC_POP)
+    #undef JSON_HEDLEY_DIAGNOSTIC_POP
+#endif
+#if defined(__clang__)
+    #define JSON_HEDLEY_DIAGNOSTIC_PUSH _Pragma("clang diagnostic push")
+    #define JSON_HEDLEY_DIAGNOSTIC_POP _Pragma("clang diagnostic pop")
+#elif JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_PUSH _Pragma("warning(push)")
+    #define JSON_HEDLEY_DIAGNOSTIC_POP _Pragma("warning(pop)")
+#elif JSON_HEDLEY_GCC_VERSION_CHECK(4,6,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")
+    #define JSON_HEDLEY_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
+#elif \
+    JSON_HEDLEY_MSVC_VERSION_CHECK(15,0,0) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_PUSH __pragma(warning(push))
+    #define JSON_HEDLEY_DIAGNOSTIC_POP __pragma(warning(pop))
+#elif JSON_HEDLEY_ARM_VERSION_CHECK(5,6,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_PUSH _Pragma("push")
+    #define JSON_HEDLEY_DIAGNOSTIC_POP _Pragma("pop")
+#elif \
+    JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,4,0) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(8,1,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_PUSH _Pragma("diag_push")
+    #define JSON_HEDLEY_DIAGNOSTIC_POP _Pragma("diag_pop")
+#elif JSON_HEDLEY_PELLES_VERSION_CHECK(2,90,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_PUSH _Pragma("warning(push)")
+    #define JSON_HEDLEY_DIAGNOSTIC_POP _Pragma("warning(pop)")
+#else
+    #define JSON_HEDLEY_DIAGNOSTIC_PUSH
+    #define JSON_HEDLEY_DIAGNOSTIC_POP
+#endif
+
+/* JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_ is for
+   HEDLEY INTERNAL USE ONLY.  API subject to change without notice. */
+#if defined(JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_)
+    #undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_
+#endif
+#if defined(__cplusplus)
+#  if JSON_HEDLEY_HAS_WARNING("-Wc++98-compat")
+#    if JSON_HEDLEY_HAS_WARNING("-Wc++17-extensions")
+#      if JSON_HEDLEY_HAS_WARNING("-Wc++1z-extensions")
+#        define JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(xpr) \
+    JSON_HEDLEY_DIAGNOSTIC_PUSH \
+    _Pragma("clang diagnostic ignored \"-Wc++98-compat\"") \
+    _Pragma("clang diagnostic ignored \"-Wc++17-extensions\"") \
+    _Pragma("clang diagnostic ignored \"-Wc++1z-extensions\"") \
+    xpr \
+    JSON_HEDLEY_DIAGNOSTIC_POP
+#      else
+#        define JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(xpr) \
+    JSON_HEDLEY_DIAGNOSTIC_PUSH \
+    _Pragma("clang diagnostic ignored \"-Wc++98-compat\"") \
+    _Pragma("clang diagnostic ignored \"-Wc++17-extensions\"") \
+    xpr \
+    JSON_HEDLEY_DIAGNOSTIC_POP
+#      endif
+#    else
+#      define JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(xpr) \
+    JSON_HEDLEY_DIAGNOSTIC_PUSH \
+    _Pragma("clang diagnostic ignored \"-Wc++98-compat\"") \
+    xpr \
+    JSON_HEDLEY_DIAGNOSTIC_POP
+#    endif
+#  endif
+#endif
+#if !defined(JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(x) x
+#endif
+
+#if defined(JSON_HEDLEY_CONST_CAST)
+    #undef JSON_HEDLEY_CONST_CAST
+#endif
+#if defined(__cplusplus)
+#  define JSON_HEDLEY_CONST_CAST(T, expr) (const_cast<T>(expr))
+#elif \
+  JSON_HEDLEY_HAS_WARNING("-Wcast-qual") || \
+  JSON_HEDLEY_GCC_VERSION_CHECK(4,6,0) || \
+  JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define JSON_HEDLEY_CONST_CAST(T, expr) (__extension__ ({ \
+        JSON_HEDLEY_DIAGNOSTIC_PUSH \
+        JSON_HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL \
+        ((T) (expr)); \
+        JSON_HEDLEY_DIAGNOSTIC_POP \
+    }))
+#else
+#  define JSON_HEDLEY_CONST_CAST(T, expr) ((T) (expr))
+#endif
+
+#if defined(JSON_HEDLEY_REINTERPRET_CAST)
+    #undef JSON_HEDLEY_REINTERPRET_CAST
+#endif
+#if defined(__cplusplus)
+    #define JSON_HEDLEY_REINTERPRET_CAST(T, expr) (reinterpret_cast<T>(expr))
+#else
+    #define JSON_HEDLEY_REINTERPRET_CAST(T, expr) ((T) (expr))
+#endif
+
+#if defined(JSON_HEDLEY_STATIC_CAST)
+    #undef JSON_HEDLEY_STATIC_CAST
+#endif
+#if defined(__cplusplus)
+    #define JSON_HEDLEY_STATIC_CAST(T, expr) (static_cast<T>(expr))
+#else
+    #define JSON_HEDLEY_STATIC_CAST(T, expr) ((T) (expr))
+#endif
+
+#if defined(JSON_HEDLEY_CPP_CAST)
+    #undef JSON_HEDLEY_CPP_CAST
+#endif
+#if defined(__cplusplus)
+#  if JSON_HEDLEY_HAS_WARNING("-Wold-style-cast")
+#    define JSON_HEDLEY_CPP_CAST(T, expr) \
+    JSON_HEDLEY_DIAGNOSTIC_PUSH \
+    _Pragma("clang diagnostic ignored \"-Wold-style-cast\"") \
+    ((T) (expr)) \
+    JSON_HEDLEY_DIAGNOSTIC_POP
+#  elif JSON_HEDLEY_IAR_VERSION_CHECK(8,3,0)
+#    define JSON_HEDLEY_CPP_CAST(T, expr) \
+    JSON_HEDLEY_DIAGNOSTIC_PUSH \
+    _Pragma("diag_suppress=Pe137") \
+    JSON_HEDLEY_DIAGNOSTIC_POP
+#  else
+#    define JSON_HEDLEY_CPP_CAST(T, expr) ((T) (expr))
+#  endif
+#else
+#  define JSON_HEDLEY_CPP_CAST(T, expr) (expr)
+#endif
+
+#if defined(JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED)
+    #undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED
+#endif
+#if JSON_HEDLEY_HAS_WARNING("-Wdeprecated-declarations")
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("warning(disable:1478 1786)")
+#elif JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED __pragma(warning(disable:1478 1786))
+#elif JSON_HEDLEY_PGI_VERSION_CHECK(20,7,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress 1215,1216,1444,1445")
+#elif JSON_HEDLEY_PGI_VERSION_CHECK(17,10,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress 1215,1444")
+#elif JSON_HEDLEY_GCC_VERSION_CHECK(4,3,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif JSON_HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED __pragma(warning(disable:4996))
+#elif JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress 1215,1444")
+#elif \
+    JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    (JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    (JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+    (JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+    (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress 1291,1718")
+#elif JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,13,0) && !defined(__cplusplus)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("error_messages(off,E_DEPRECATED_ATT,E_DEPRECATED_ATT_MESS)")
+#elif JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,13,0) && defined(__cplusplus)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("error_messages(off,symdeprecated,symdeprecated2)")
+#elif JSON_HEDLEY_IAR_VERSION_CHECK(8,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress=Pe1444,Pe1215")
+#elif JSON_HEDLEY_PELLES_VERSION_CHECK(2,90,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("warn(disable:2241)")
+#else
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED
+#endif
+
+#if defined(JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS)
+    #undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS
+#endif
+#if JSON_HEDLEY_HAS_WARNING("-Wunknown-pragmas")
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("clang diagnostic ignored \"-Wunknown-pragmas\"")
+#elif JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("warning(disable:161)")
+#elif JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS __pragma(warning(disable:161))
+#elif JSON_HEDLEY_PGI_VERSION_CHECK(17,10,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 1675")
+#elif JSON_HEDLEY_GCC_VERSION_CHECK(4,3,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")
+#elif JSON_HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS __pragma(warning(disable:4068))
+#elif \
+    JSON_HEDLEY_TI_VERSION_CHECK(16,9,0) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(8,0,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,3,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 163")
+#elif JSON_HEDLEY_TI_CL6X_VERSION_CHECK(8,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 163")
+#elif JSON_HEDLEY_IAR_VERSION_CHECK(8,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress=Pe161")
+#elif JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 161")
+#else
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS
+#endif
+
+#if defined(JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES)
+    #undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES
+#endif
+#if JSON_HEDLEY_HAS_WARNING("-Wunknown-attributes")
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("clang diagnostic ignored \"-Wunknown-attributes\"")
+#elif JSON_HEDLEY_GCC_VERSION_CHECK(4,6,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif JSON_HEDLEY_INTEL_VERSION_CHECK(17,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("warning(disable:1292)")
+#elif JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES __pragma(warning(disable:1292))
+#elif JSON_HEDLEY_MSVC_VERSION_CHECK(19,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES __pragma(warning(disable:5030))
+#elif JSON_HEDLEY_PGI_VERSION_CHECK(20,7,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("diag_suppress 1097,1098")
+#elif JSON_HEDLEY_PGI_VERSION_CHECK(17,10,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("diag_suppress 1097")
+#elif JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,14,0) && defined(__cplusplus)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("error_messages(off,attrskipunsup)")
+#elif \
+    JSON_HEDLEY_TI_VERSION_CHECK(18,1,0) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(8,3,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("diag_suppress 1173")
+#elif JSON_HEDLEY_IAR_VERSION_CHECK(8,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("diag_suppress=Pe1097")
+#elif JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("diag_suppress 1097")
+#else
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES
+#endif
+
+#if defined(JSON_HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL)
+    #undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL
+#endif
+#if JSON_HEDLEY_HAS_WARNING("-Wcast-qual")
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL _Pragma("clang diagnostic ignored \"-Wcast-qual\"")
+#elif JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL _Pragma("warning(disable:2203 2331)")
+#elif JSON_HEDLEY_GCC_VERSION_CHECK(3,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL _Pragma("GCC diagnostic ignored \"-Wcast-qual\"")
+#else
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL
+#endif
+
+#if defined(JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION)
+    #undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION
+#endif
+#if JSON_HEDLEY_HAS_WARNING("-Wunused-function")
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION _Pragma("clang diagnostic ignored \"-Wunused-function\"")
+#elif JSON_HEDLEY_GCC_VERSION_CHECK(3,4,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
+#elif JSON_HEDLEY_MSVC_VERSION_CHECK(1,0,0)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION __pragma(warning(disable:4505))
+#elif JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION _Pragma("diag_suppress 3142")
+#else
+    #define JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION
+#endif
+
+#if defined(JSON_HEDLEY_DEPRECATED)
+    #undef JSON_HEDLEY_DEPRECATED
+#endif
+#if defined(JSON_HEDLEY_DEPRECATED_FOR)
+    #undef JSON_HEDLEY_DEPRECATED_FOR
+#endif
+#if \
+    JSON_HEDLEY_MSVC_VERSION_CHECK(14,0,0) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_DEPRECATED(since) __declspec(deprecated("Since " # since))
+    #define JSON_HEDLEY_DEPRECATED_FOR(since, replacement) __declspec(deprecated("Since " #since "; use " #replacement))
+#elif \
+    (JSON_HEDLEY_HAS_EXTENSION(attribute_deprecated_with_message) && !defined(JSON_HEDLEY_IAR_VERSION)) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(4,5,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(5,6,0) || \
+    JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,13,0) || \
+    JSON_HEDLEY_PGI_VERSION_CHECK(17,10,0) || \
+    JSON_HEDLEY_TI_VERSION_CHECK(18,1,0) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(18,1,0) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(8,3,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,3,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_DEPRECATED(since) __attribute__((__deprecated__("Since " #since)))
+    #define JSON_HEDLEY_DEPRECATED_FOR(since, replacement) __attribute__((__deprecated__("Since " #since "; use " #replacement)))
+#elif defined(__cplusplus) && (__cplusplus >= 201402L)
+    #define JSON_HEDLEY_DEPRECATED(since) JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[deprecated("Since " #since)]])
+    #define JSON_HEDLEY_DEPRECATED_FOR(since, replacement) JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[deprecated("Since " #since "; use " #replacement)]])
+#elif \
+    JSON_HEDLEY_HAS_ATTRIBUTE(deprecated) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    (JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    (JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+    (JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+    (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10) || \
+    JSON_HEDLEY_IAR_VERSION_CHECK(8,10,0)
+    #define JSON_HEDLEY_DEPRECATED(since) __attribute__((__deprecated__))
+    #define JSON_HEDLEY_DEPRECATED_FOR(since, replacement) __attribute__((__deprecated__))
+#elif \
+    JSON_HEDLEY_MSVC_VERSION_CHECK(13,10,0) || \
+    JSON_HEDLEY_PELLES_VERSION_CHECK(6,50,0) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_DEPRECATED(since) __declspec(deprecated)
+    #define JSON_HEDLEY_DEPRECATED_FOR(since, replacement) __declspec(deprecated)
+#elif JSON_HEDLEY_IAR_VERSION_CHECK(8,0,0)
+    #define JSON_HEDLEY_DEPRECATED(since) _Pragma("deprecated")
+    #define JSON_HEDLEY_DEPRECATED_FOR(since, replacement) _Pragma("deprecated")
+#else
+    #define JSON_HEDLEY_DEPRECATED(since)
+    #define JSON_HEDLEY_DEPRECATED_FOR(since, replacement)
+#endif
+
+#if defined(JSON_HEDLEY_UNAVAILABLE)
+    #undef JSON_HEDLEY_UNAVAILABLE
+#endif
+#if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(warning) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(4,3,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_UNAVAILABLE(available_since) __attribute__((__warning__("Not available until " #available_since)))
+#else
+    #define JSON_HEDLEY_UNAVAILABLE(available_since)
+#endif
+
+#if defined(JSON_HEDLEY_WARN_UNUSED_RESULT)
+    #undef JSON_HEDLEY_WARN_UNUSED_RESULT
+#endif
+#if defined(JSON_HEDLEY_WARN_UNUSED_RESULT_MSG)
+    #undef JSON_HEDLEY_WARN_UNUSED_RESULT_MSG
+#endif
+#if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(warn_unused_result) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    (JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    (JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+    (JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+    (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+    (JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,15,0) && defined(__cplusplus)) || \
+    JSON_HEDLEY_PGI_VERSION_CHECK(17,10,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_WARN_UNUSED_RESULT __attribute__((__warn_unused_result__))
+    #define JSON_HEDLEY_WARN_UNUSED_RESULT_MSG(msg) __attribute__((__warn_unused_result__))
+#elif (JSON_HEDLEY_HAS_CPP_ATTRIBUTE(nodiscard) >= 201907L)
+    #define JSON_HEDLEY_WARN_UNUSED_RESULT JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[nodiscard]])
+    #define JSON_HEDLEY_WARN_UNUSED_RESULT_MSG(msg) JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[nodiscard(msg)]])
+#elif JSON_HEDLEY_HAS_CPP_ATTRIBUTE(nodiscard)
+    #define JSON_HEDLEY_WARN_UNUSED_RESULT JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[nodiscard]])
+    #define JSON_HEDLEY_WARN_UNUSED_RESULT_MSG(msg) JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[nodiscard]])
+#elif defined(_Check_return_) /* SAL */
+    #define JSON_HEDLEY_WARN_UNUSED_RESULT _Check_return_
+    #define JSON_HEDLEY_WARN_UNUSED_RESULT_MSG(msg) _Check_return_
+#else
+    #define JSON_HEDLEY_WARN_UNUSED_RESULT
+    #define JSON_HEDLEY_WARN_UNUSED_RESULT_MSG(msg)
+#endif
+
+#if defined(JSON_HEDLEY_SENTINEL)
+    #undef JSON_HEDLEY_SENTINEL
+#endif
+#if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(sentinel) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(4,0,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(5,4,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_SENTINEL(position) __attribute__((__sentinel__(position)))
+#else
+    #define JSON_HEDLEY_SENTINEL(position)
+#endif
+
+#if defined(JSON_HEDLEY_NO_RETURN)
+    #undef JSON_HEDLEY_NO_RETURN
+#endif
+#if JSON_HEDLEY_IAR_VERSION_CHECK(8,0,0)
+    #define JSON_HEDLEY_NO_RETURN __noreturn
+#elif \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_NO_RETURN __attribute__((__noreturn__))
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+    #define JSON_HEDLEY_NO_RETURN _Noreturn
+#elif defined(__cplusplus) && (__cplusplus >= 201103L)
+    #define JSON_HEDLEY_NO_RETURN JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[noreturn]])
+#elif \
+    JSON_HEDLEY_HAS_ATTRIBUTE(noreturn) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,2,0) || \
+    JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    JSON_HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+    JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    (JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    (JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+    (JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+    (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+    JSON_HEDLEY_IAR_VERSION_CHECK(8,10,0)
+    #define JSON_HEDLEY_NO_RETURN __attribute__((__noreturn__))
+#elif JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,10,0)
+    #define JSON_HEDLEY_NO_RETURN _Pragma("does_not_return")
+#elif \
+    JSON_HEDLEY_MSVC_VERSION_CHECK(13,10,0) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_NO_RETURN __declspec(noreturn)
+#elif JSON_HEDLEY_TI_CL6X_VERSION_CHECK(6,0,0) && defined(__cplusplus)
+    #define JSON_HEDLEY_NO_RETURN _Pragma("FUNC_NEVER_RETURNS;")
+#elif JSON_HEDLEY_COMPCERT_VERSION_CHECK(3,2,0)
+    #define JSON_HEDLEY_NO_RETURN __attribute((noreturn))
+#elif JSON_HEDLEY_PELLES_VERSION_CHECK(9,0,0)
+    #define JSON_HEDLEY_NO_RETURN __declspec(noreturn)
+#else
+    #define JSON_HEDLEY_NO_RETURN
+#endif
+
+#if defined(JSON_HEDLEY_NO_ESCAPE)
+    #undef JSON_HEDLEY_NO_ESCAPE
+#endif
+#if JSON_HEDLEY_HAS_ATTRIBUTE(noescape)
+    #define JSON_HEDLEY_NO_ESCAPE __attribute__((__noescape__))
+#else
+    #define JSON_HEDLEY_NO_ESCAPE
+#endif
+
+#if defined(JSON_HEDLEY_UNREACHABLE)
+    #undef JSON_HEDLEY_UNREACHABLE
+#endif
+#if defined(JSON_HEDLEY_UNREACHABLE_RETURN)
+    #undef JSON_HEDLEY_UNREACHABLE_RETURN
+#endif
+#if defined(JSON_HEDLEY_ASSUME)
+    #undef JSON_HEDLEY_ASSUME
+#endif
+#if \
+    JSON_HEDLEY_MSVC_VERSION_CHECK(13,10,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_ASSUME(expr) __assume(expr)
+#elif JSON_HEDLEY_HAS_BUILTIN(__builtin_assume)
+    #define JSON_HEDLEY_ASSUME(expr) __builtin_assume(expr)
+#elif \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,2,0) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(4,0,0)
+    #if defined(__cplusplus)
+        #define JSON_HEDLEY_ASSUME(expr) std::_nassert(expr)
+    #else
+        #define JSON_HEDLEY_ASSUME(expr) _nassert(expr)
+    #endif
+#endif
+#if \
+    (JSON_HEDLEY_HAS_BUILTIN(__builtin_unreachable) && (!defined(JSON_HEDLEY_ARM_VERSION))) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(4,5,0) || \
+    JSON_HEDLEY_PGI_VERSION_CHECK(18,10,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_IBM_VERSION_CHECK(13,1,5) || \
+    JSON_HEDLEY_CRAY_VERSION_CHECK(10,0,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_UNREACHABLE() __builtin_unreachable()
+#elif defined(JSON_HEDLEY_ASSUME)
+    #define JSON_HEDLEY_UNREACHABLE() JSON_HEDLEY_ASSUME(0)
+#endif
+#if !defined(JSON_HEDLEY_ASSUME)
+    #if defined(JSON_HEDLEY_UNREACHABLE)
+        #define JSON_HEDLEY_ASSUME(expr) JSON_HEDLEY_STATIC_CAST(void, ((expr) ? 1 : (JSON_HEDLEY_UNREACHABLE(), 1)))
+    #else
+        #define JSON_HEDLEY_ASSUME(expr) JSON_HEDLEY_STATIC_CAST(void, expr)
+    #endif
+#endif
+#if defined(JSON_HEDLEY_UNREACHABLE)
+    #if  \
+        JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,2,0) || \
+        JSON_HEDLEY_TI_CL6X_VERSION_CHECK(4,0,0)
+        #define JSON_HEDLEY_UNREACHABLE_RETURN(value) return (JSON_HEDLEY_STATIC_CAST(void, JSON_HEDLEY_ASSUME(0)), (value))
+    #else
+        #define JSON_HEDLEY_UNREACHABLE_RETURN(value) JSON_HEDLEY_UNREACHABLE()
+    #endif
+#else
+    #define JSON_HEDLEY_UNREACHABLE_RETURN(value) return (value)
+#endif
+#if !defined(JSON_HEDLEY_UNREACHABLE)
+    #define JSON_HEDLEY_UNREACHABLE() JSON_HEDLEY_ASSUME(0)
+#endif
+
+JSON_HEDLEY_DIAGNOSTIC_PUSH
+#if JSON_HEDLEY_HAS_WARNING("-Wpedantic")
+    #pragma clang diagnostic ignored "-Wpedantic"
+#endif
+#if JSON_HEDLEY_HAS_WARNING("-Wc++98-compat-pedantic") && defined(__cplusplus)
+    #pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
+#endif
+#if JSON_HEDLEY_GCC_HAS_WARNING("-Wvariadic-macros",4,0,0)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wvariadic-macros"
+    #elif defined(JSON_HEDLEY_GCC_VERSION)
+        #pragma GCC diagnostic ignored "-Wvariadic-macros"
+    #endif
+#endif
+#if defined(JSON_HEDLEY_NON_NULL)
+    #undef JSON_HEDLEY_NON_NULL
+#endif
+#if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(nonnull) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0)
+    #define JSON_HEDLEY_NON_NULL(...) __attribute__((__nonnull__(__VA_ARGS__)))
+#else
+    #define JSON_HEDLEY_NON_NULL(...)
+#endif
+JSON_HEDLEY_DIAGNOSTIC_POP
+
+#if defined(JSON_HEDLEY_PRINTF_FORMAT)
+    #undef JSON_HEDLEY_PRINTF_FORMAT
+#endif
+#if defined(__MINGW32__) && JSON_HEDLEY_GCC_HAS_ATTRIBUTE(format,4,4,0) && !defined(__USE_MINGW_ANSI_STDIO)
+    #define JSON_HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __attribute__((__format__(ms_printf, string_idx, first_to_check)))
+#elif defined(__MINGW32__) && JSON_HEDLEY_GCC_HAS_ATTRIBUTE(format,4,4,0) && defined(__USE_MINGW_ANSI_STDIO)
+    #define JSON_HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __attribute__((__format__(gnu_printf, string_idx, first_to_check)))
+#elif \
+    JSON_HEDLEY_HAS_ATTRIBUTE(format) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(5,6,0) || \
+    JSON_HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+    JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    (JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    (JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+    (JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+    (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __attribute__((__format__(__printf__, string_idx, first_to_check)))
+#elif JSON_HEDLEY_PELLES_VERSION_CHECK(6,0,0)
+    #define JSON_HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __declspec(vaformat(printf,string_idx,first_to_check))
+#else
+    #define JSON_HEDLEY_PRINTF_FORMAT(string_idx,first_to_check)
+#endif
+
+#if defined(JSON_HEDLEY_CONSTEXPR)
+    #undef JSON_HEDLEY_CONSTEXPR
+#endif
+#if defined(__cplusplus)
+    #if __cplusplus >= 201103L
+        #define JSON_HEDLEY_CONSTEXPR JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(constexpr)
+    #endif
+#endif
+#if !defined(JSON_HEDLEY_CONSTEXPR)
+    #define JSON_HEDLEY_CONSTEXPR
+#endif
+
+#if defined(JSON_HEDLEY_PREDICT)
+    #undef JSON_HEDLEY_PREDICT
+#endif
+#if defined(JSON_HEDLEY_LIKELY)
+    #undef JSON_HEDLEY_LIKELY
+#endif
+#if defined(JSON_HEDLEY_UNLIKELY)
+    #undef JSON_HEDLEY_UNLIKELY
+#endif
+#if defined(JSON_HEDLEY_UNPREDICTABLE)
+    #undef JSON_HEDLEY_UNPREDICTABLE
+#endif
+#if JSON_HEDLEY_HAS_BUILTIN(__builtin_unpredictable)
+    #define JSON_HEDLEY_UNPREDICTABLE(expr) __builtin_unpredictable((expr))
+#endif
+#if \
+  (JSON_HEDLEY_HAS_BUILTIN(__builtin_expect_with_probability) && !defined(JSON_HEDLEY_PGI_VERSION)) || \
+  JSON_HEDLEY_GCC_VERSION_CHECK(9,0,0) || \
+  JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+#  define JSON_HEDLEY_PREDICT(expr, value, probability) __builtin_expect_with_probability(  (expr), (value), (probability))
+#  define JSON_HEDLEY_PREDICT_TRUE(expr, probability)   __builtin_expect_with_probability(!!(expr),    1   , (probability))
+#  define JSON_HEDLEY_PREDICT_FALSE(expr, probability)  __builtin_expect_with_probability(!!(expr),    0   , (probability))
+#  define JSON_HEDLEY_LIKELY(expr)                      __builtin_expect                 (!!(expr),    1                  )
+#  define JSON_HEDLEY_UNLIKELY(expr)                    __builtin_expect                 (!!(expr),    0                  )
+#elif \
+  (JSON_HEDLEY_HAS_BUILTIN(__builtin_expect) && !defined(JSON_HEDLEY_INTEL_CL_VERSION)) || \
+  JSON_HEDLEY_GCC_VERSION_CHECK(3,0,0) || \
+  JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  (JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,15,0) && defined(__cplusplus)) || \
+  JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  JSON_HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,7,0) || \
+  JSON_HEDLEY_TI_CL430_VERSION_CHECK(3,1,0) || \
+  JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,1,0) || \
+  JSON_HEDLEY_TI_CL6X_VERSION_CHECK(6,1,0) || \
+  JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+  JSON_HEDLEY_TINYC_VERSION_CHECK(0,9,27) || \
+  JSON_HEDLEY_CRAY_VERSION_CHECK(8,1,0) || \
+  JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+#  define JSON_HEDLEY_PREDICT(expr, expected, probability) \
+    (((probability) >= 0.9) ? __builtin_expect((expr), (expected)) : (JSON_HEDLEY_STATIC_CAST(void, expected), (expr)))
+#  define JSON_HEDLEY_PREDICT_TRUE(expr, probability) \
+    (__extension__ ({ \
+        double hedley_probability_ = (probability); \
+        ((hedley_probability_ >= 0.9) ? __builtin_expect(!!(expr), 1) : ((hedley_probability_ <= 0.1) ? __builtin_expect(!!(expr), 0) : !!(expr))); \
+    }))
+#  define JSON_HEDLEY_PREDICT_FALSE(expr, probability) \
+    (__extension__ ({ \
+        double hedley_probability_ = (probability); \
+        ((hedley_probability_ >= 0.9) ? __builtin_expect(!!(expr), 0) : ((hedley_probability_ <= 0.1) ? __builtin_expect(!!(expr), 1) : !!(expr))); \
+    }))
+#  define JSON_HEDLEY_LIKELY(expr)   __builtin_expect(!!(expr), 1)
+#  define JSON_HEDLEY_UNLIKELY(expr) __builtin_expect(!!(expr), 0)
+#else
+#  define JSON_HEDLEY_PREDICT(expr, expected, probability) (JSON_HEDLEY_STATIC_CAST(void, expected), (expr))
+#  define JSON_HEDLEY_PREDICT_TRUE(expr, probability) (!!(expr))
+#  define JSON_HEDLEY_PREDICT_FALSE(expr, probability) (!!(expr))
+#  define JSON_HEDLEY_LIKELY(expr) (!!(expr))
+#  define JSON_HEDLEY_UNLIKELY(expr) (!!(expr))
+#endif
+#if !defined(JSON_HEDLEY_UNPREDICTABLE)
+    #define JSON_HEDLEY_UNPREDICTABLE(expr) JSON_HEDLEY_PREDICT(expr, 1, 0.5)
+#endif
+
+#if defined(JSON_HEDLEY_MALLOC)
+    #undef JSON_HEDLEY_MALLOC
+#endif
+#if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(malloc) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    JSON_HEDLEY_IBM_VERSION_CHECK(12,1,0) || \
+    JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    (JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    (JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+    (JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+    (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_MALLOC __attribute__((__malloc__))
+#elif JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,10,0)
+    #define JSON_HEDLEY_MALLOC _Pragma("returns_new_memory")
+#elif \
+    JSON_HEDLEY_MSVC_VERSION_CHECK(14,0,0) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_MALLOC __declspec(restrict)
+#else
+    #define JSON_HEDLEY_MALLOC
+#endif
+
+#if defined(JSON_HEDLEY_PURE)
+    #undef JSON_HEDLEY_PURE
+#endif
+#if \
+  JSON_HEDLEY_HAS_ATTRIBUTE(pure) || \
+  JSON_HEDLEY_GCC_VERSION_CHECK(2,96,0) || \
+  JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  JSON_HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+  JSON_HEDLEY_PGI_VERSION_CHECK(17,10,0) || \
+  JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+#  define JSON_HEDLEY_PURE __attribute__((__pure__))
+#elif JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,10,0)
+#  define JSON_HEDLEY_PURE _Pragma("does_not_write_global_data")
+#elif defined(__cplusplus) && \
+    ( \
+      JSON_HEDLEY_TI_CL430_VERSION_CHECK(2,0,1) || \
+      JSON_HEDLEY_TI_CL6X_VERSION_CHECK(4,0,0) || \
+      JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) \
+    )
+#  define JSON_HEDLEY_PURE _Pragma("FUNC_IS_PURE;")
+#else
+#  define JSON_HEDLEY_PURE
+#endif
+
+#if defined(JSON_HEDLEY_CONST)
+    #undef JSON_HEDLEY_CONST
+#endif
+#if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(const) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(2,5,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    JSON_HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+    JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    (JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    (JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+    (JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+    (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+    JSON_HEDLEY_PGI_VERSION_CHECK(17,10,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_CONST __attribute__((__const__))
+#elif \
+    JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,10,0)
+    #define JSON_HEDLEY_CONST _Pragma("no_side_effect")
+#else
+    #define JSON_HEDLEY_CONST JSON_HEDLEY_PURE
+#endif
+
+#if defined(JSON_HEDLEY_RESTRICT)
+    #undef JSON_HEDLEY_RESTRICT
+#endif
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && !defined(__cplusplus)
+    #define JSON_HEDLEY_RESTRICT restrict
+#elif \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+    JSON_HEDLEY_MSVC_VERSION_CHECK(14,0,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    JSON_HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+    JSON_HEDLEY_PGI_VERSION_CHECK(17,10,0) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,2,4) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(8,1,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    (JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,14,0) && defined(__cplusplus)) || \
+    JSON_HEDLEY_IAR_VERSION_CHECK(8,0,0) || \
+    defined(__clang__) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_RESTRICT __restrict
+#elif JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,3,0) && !defined(__cplusplus)
+    #define JSON_HEDLEY_RESTRICT _Restrict
+#else
+    #define JSON_HEDLEY_RESTRICT
+#endif
+
+#if defined(JSON_HEDLEY_INLINE)
+    #undef JSON_HEDLEY_INLINE
+#endif
+#if \
+    (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) || \
+    (defined(__cplusplus) && (__cplusplus >= 199711L))
+    #define JSON_HEDLEY_INLINE inline
+#elif \
+    defined(JSON_HEDLEY_GCC_VERSION) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(6,2,0)
+    #define JSON_HEDLEY_INLINE __inline__
+#elif \
+    JSON_HEDLEY_MSVC_VERSION_CHECK(12,0,0) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,1,0) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(3,1,0) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,2,0) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(8,0,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_INLINE __inline
+#else
+    #define JSON_HEDLEY_INLINE
+#endif
+
+#if defined(JSON_HEDLEY_ALWAYS_INLINE)
+    #undef JSON_HEDLEY_ALWAYS_INLINE
+#endif
+#if \
+  JSON_HEDLEY_HAS_ATTRIBUTE(always_inline) || \
+  JSON_HEDLEY_GCC_VERSION_CHECK(4,0,0) || \
+  JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  JSON_HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+  JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10) || \
+  JSON_HEDLEY_IAR_VERSION_CHECK(8,10,0)
+#  define JSON_HEDLEY_ALWAYS_INLINE __attribute__((__always_inline__)) JSON_HEDLEY_INLINE
+#elif \
+  JSON_HEDLEY_MSVC_VERSION_CHECK(12,0,0) || \
+  JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define JSON_HEDLEY_ALWAYS_INLINE __forceinline
+#elif defined(__cplusplus) && \
+    ( \
+      JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+      JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+      JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+      JSON_HEDLEY_TI_CL6X_VERSION_CHECK(6,1,0) || \
+      JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+      JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) \
+    )
+#  define JSON_HEDLEY_ALWAYS_INLINE _Pragma("FUNC_ALWAYS_INLINE;")
+#elif JSON_HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define JSON_HEDLEY_ALWAYS_INLINE _Pragma("inline=forced")
+#else
+#  define JSON_HEDLEY_ALWAYS_INLINE JSON_HEDLEY_INLINE
+#endif
+
+#if defined(JSON_HEDLEY_NEVER_INLINE)
+    #undef JSON_HEDLEY_NEVER_INLINE
+#endif
+#if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(noinline) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(4,0,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    JSON_HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+    JSON_HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    (JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    (JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+    (JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+    (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+    JSON_HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    JSON_HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10) || \
+    JSON_HEDLEY_IAR_VERSION_CHECK(8,10,0)
+    #define JSON_HEDLEY_NEVER_INLINE __attribute__((__noinline__))
+#elif \
+    JSON_HEDLEY_MSVC_VERSION_CHECK(13,10,0) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_NEVER_INLINE __declspec(noinline)
+#elif JSON_HEDLEY_PGI_VERSION_CHECK(10,2,0)
+    #define JSON_HEDLEY_NEVER_INLINE _Pragma("noinline")
+#elif JSON_HEDLEY_TI_CL6X_VERSION_CHECK(6,0,0) && defined(__cplusplus)
+    #define JSON_HEDLEY_NEVER_INLINE _Pragma("FUNC_CANNOT_INLINE;")
+#elif JSON_HEDLEY_IAR_VERSION_CHECK(8,0,0)
+    #define JSON_HEDLEY_NEVER_INLINE _Pragma("inline=never")
+#elif JSON_HEDLEY_COMPCERT_VERSION_CHECK(3,2,0)
+    #define JSON_HEDLEY_NEVER_INLINE __attribute((noinline))
+#elif JSON_HEDLEY_PELLES_VERSION_CHECK(9,0,0)
+    #define JSON_HEDLEY_NEVER_INLINE __declspec(noinline)
+#else
+    #define JSON_HEDLEY_NEVER_INLINE
+#endif
+
+#if defined(JSON_HEDLEY_PRIVATE)
+    #undef JSON_HEDLEY_PRIVATE
+#endif
+#if defined(JSON_HEDLEY_PUBLIC)
+    #undef JSON_HEDLEY_PUBLIC
+#endif
+#if defined(JSON_HEDLEY_IMPORT)
+    #undef JSON_HEDLEY_IMPORT
+#endif
+#if defined(_WIN32) || defined(__CYGWIN__)
+#  define JSON_HEDLEY_PRIVATE
+#  define JSON_HEDLEY_PUBLIC   __declspec(dllexport)
+#  define JSON_HEDLEY_IMPORT   __declspec(dllimport)
+#else
+#  if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(visibility) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+    JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    JSON_HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+    ( \
+      defined(__TI_EABI__) && \
+      ( \
+        (JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+        JSON_HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) \
+      ) \
+    ) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+#    define JSON_HEDLEY_PRIVATE __attribute__((__visibility__("hidden")))
+#    define JSON_HEDLEY_PUBLIC  __attribute__((__visibility__("default")))
+#  else
+#    define JSON_HEDLEY_PRIVATE
+#    define JSON_HEDLEY_PUBLIC
+#  endif
+#  define JSON_HEDLEY_IMPORT    extern
+#endif
+
+#if defined(JSON_HEDLEY_NO_THROW)
+    #undef JSON_HEDLEY_NO_THROW
+#endif
+#if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(nothrow) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_NO_THROW __attribute__((__nothrow__))
+#elif \
+    JSON_HEDLEY_MSVC_VERSION_CHECK(13,1,0) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0)
+    #define JSON_HEDLEY_NO_THROW __declspec(nothrow)
+#else
+    #define JSON_HEDLEY_NO_THROW
+#endif
+
+#if defined(JSON_HEDLEY_FALL_THROUGH)
+    #undef JSON_HEDLEY_FALL_THROUGH
+#endif
+#if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(fallthrough) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(7,0,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_FALL_THROUGH __attribute__((__fallthrough__))
+#elif JSON_HEDLEY_HAS_CPP_ATTRIBUTE_NS(clang,fallthrough)
+    #define JSON_HEDLEY_FALL_THROUGH JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[clang::fallthrough]])
+#elif JSON_HEDLEY_HAS_CPP_ATTRIBUTE(fallthrough)
+    #define JSON_HEDLEY_FALL_THROUGH JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[fallthrough]])
+#elif defined(__fallthrough) /* SAL */
+    #define JSON_HEDLEY_FALL_THROUGH __fallthrough
+#else
+    #define JSON_HEDLEY_FALL_THROUGH
+#endif
+
+#if defined(JSON_HEDLEY_RETURNS_NON_NULL)
+    #undef JSON_HEDLEY_RETURNS_NON_NULL
+#endif
+#if \
+    JSON_HEDLEY_HAS_ATTRIBUTE(returns_nonnull) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(4,9,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_RETURNS_NON_NULL __attribute__((__returns_nonnull__))
+#elif defined(_Ret_notnull_) /* SAL */
+    #define JSON_HEDLEY_RETURNS_NON_NULL _Ret_notnull_
+#else
+    #define JSON_HEDLEY_RETURNS_NON_NULL
+#endif
+
+#if defined(JSON_HEDLEY_ARRAY_PARAM)
+    #undef JSON_HEDLEY_ARRAY_PARAM
+#endif
+#if \
+    defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+    !defined(__STDC_NO_VLA__) && \
+    !defined(__cplusplus) && \
+    !defined(JSON_HEDLEY_PGI_VERSION) && \
+    !defined(JSON_HEDLEY_TINYC_VERSION)
+    #define JSON_HEDLEY_ARRAY_PARAM(name) (name)
+#else
+    #define JSON_HEDLEY_ARRAY_PARAM(name)
+#endif
+
+#if defined(JSON_HEDLEY_IS_CONSTANT)
+    #undef JSON_HEDLEY_IS_CONSTANT
+#endif
+#if defined(JSON_HEDLEY_REQUIRE_CONSTEXPR)
+    #undef JSON_HEDLEY_REQUIRE_CONSTEXPR
+#endif
+/* JSON_HEDLEY_IS_CONSTEXPR_ is for
+   HEDLEY INTERNAL USE ONLY.  API subject to change without notice. */
+#if defined(JSON_HEDLEY_IS_CONSTEXPR_)
+    #undef JSON_HEDLEY_IS_CONSTEXPR_
+#endif
+#if \
+    JSON_HEDLEY_HAS_BUILTIN(__builtin_constant_p) || \
+    JSON_HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+    JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    JSON_HEDLEY_TINYC_VERSION_CHECK(0,9,19) || \
+    JSON_HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    JSON_HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+    JSON_HEDLEY_TI_CL6X_VERSION_CHECK(6,1,0) || \
+    (JSON_HEDLEY_SUNPRO_VERSION_CHECK(5,10,0) && !defined(__cplusplus)) || \
+    JSON_HEDLEY_CRAY_VERSION_CHECK(8,1,0) || \
+    JSON_HEDLEY_MCST_LCC_VERSION_CHECK(1,25,10)
+    #define JSON_HEDLEY_IS_CONSTANT(expr) __builtin_constant_p(expr)
+#endif
+#if !defined(__cplusplus)
+#  if \
+       JSON_HEDLEY_HAS_BUILTIN(__builtin_types_compatible_p) || \
+       JSON_HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+       JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+       JSON_HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+       JSON_HEDLEY_CRAY_VERSION_CHECK(8,1,0) || \
+       JSON_HEDLEY_ARM_VERSION_CHECK(5,4,0) || \
+       JSON_HEDLEY_TINYC_VERSION_CHECK(0,9,24)
+#if defined(__INTPTR_TYPE__)
+    #define JSON_HEDLEY_IS_CONSTEXPR_(expr) __builtin_types_compatible_p(__typeof__((1 ? (void*) ((__INTPTR_TYPE__) ((expr) * 0)) : (int*) 0)), int*)
+#else
+    #include <stdint.h>
+    #define JSON_HEDLEY_IS_CONSTEXPR_(expr) __builtin_types_compatible_p(__typeof__((1 ? (void*) ((intptr_t) ((expr) * 0)) : (int*) 0)), int*)
+#endif
+#  elif \
+       ( \
+          defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && \
+          !defined(JSON_HEDLEY_SUNPRO_VERSION) && \
+          !defined(JSON_HEDLEY_PGI_VERSION) && \
+          !defined(JSON_HEDLEY_IAR_VERSION)) || \
+       (JSON_HEDLEY_HAS_EXTENSION(c_generic_selections) && !defined(JSON_HEDLEY_IAR_VERSION)) || \
+       JSON_HEDLEY_GCC_VERSION_CHECK(4,9,0) || \
+       JSON_HEDLEY_INTEL_VERSION_CHECK(17,0,0) || \
+       JSON_HEDLEY_IBM_VERSION_CHECK(12,1,0) || \
+       JSON_HEDLEY_ARM_VERSION_CHECK(5,3,0)
+#if defined(__INTPTR_TYPE__)
+    #define JSON_HEDLEY_IS_CONSTEXPR_(expr) _Generic((1 ? (void*) ((__INTPTR_TYPE__) ((expr) * 0)) : (int*) 0), int*: 1, void*: 0)
+#else
+    #include <stdint.h>
+    #define JSON_HEDLEY_IS_CONSTEXPR_(expr) _Generic((1 ? (void*) ((intptr_t) * 0) : (int*) 0), int*: 1, void*: 0)
+#endif
+#  elif \
+       defined(JSON_HEDLEY_GCC_VERSION) || \
+       defined(JSON_HEDLEY_INTEL_VERSION) || \
+       defined(JSON_HEDLEY_TINYC_VERSION) || \
+       defined(JSON_HEDLEY_TI_ARMCL_VERSION) || \
+       JSON_HEDLEY_TI_CL430_VERSION_CHECK(18,12,0) || \
+       defined(JSON_HEDLEY_TI_CL2000_VERSION) || \
+       defined(JSON_HEDLEY_TI_CL6X_VERSION) || \
+       defined(JSON_HEDLEY_TI_CL7X_VERSION) || \
+       defined(JSON_HEDLEY_TI_CLPRU_VERSION) || \
+       defined(__clang__)
+#    define JSON_HEDLEY_IS_CONSTEXPR_(expr) ( \
+        sizeof(void) != \
+        sizeof(*( \
+                  1 ? \
+                  ((void*) ((expr) * 0L) ) : \
+((struct { char v[sizeof(void) * 2]; } *) 1) \
+                ) \
+              ) \
+                                            )
+#  endif
+#endif
+#if defined(JSON_HEDLEY_IS_CONSTEXPR_)
+    #if !defined(JSON_HEDLEY_IS_CONSTANT)
+        #define JSON_HEDLEY_IS_CONSTANT(expr) JSON_HEDLEY_IS_CONSTEXPR_(expr)
+    #endif
+    #define JSON_HEDLEY_REQUIRE_CONSTEXPR(expr) (JSON_HEDLEY_IS_CONSTEXPR_(expr) ? (expr) : (-1))
+#else
+    #if !defined(JSON_HEDLEY_IS_CONSTANT)
+        #define JSON_HEDLEY_IS_CONSTANT(expr) (0)
+    #endif
+    #define JSON_HEDLEY_REQUIRE_CONSTEXPR(expr) (expr)
+#endif
+
+#if defined(JSON_HEDLEY_BEGIN_C_DECLS)
+    #undef JSON_HEDLEY_BEGIN_C_DECLS
+#endif
+#if defined(JSON_HEDLEY_END_C_DECLS)
+    #undef JSON_HEDLEY_END_C_DECLS
+#endif
+#if defined(JSON_HEDLEY_C_DECL)
+    #undef JSON_HEDLEY_C_DECL
+#endif
+#if defined(__cplusplus)
+    #define JSON_HEDLEY_BEGIN_C_DECLS extern "C" {
+    #define JSON_HEDLEY_END_C_DECLS }
+    #define JSON_HEDLEY_C_DECL extern "C"
+#else
+    #define JSON_HEDLEY_BEGIN_C_DECLS
+    #define JSON_HEDLEY_END_C_DECLS
+    #define JSON_HEDLEY_C_DECL
+#endif
+
+#if defined(JSON_HEDLEY_STATIC_ASSERT)
+    #undef JSON_HEDLEY_STATIC_ASSERT
+#endif
+#if \
+  !defined(__cplusplus) && ( \
+      (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)) || \
+      (JSON_HEDLEY_HAS_FEATURE(c_static_assert) && !defined(JSON_HEDLEY_INTEL_CL_VERSION)) || \
+      JSON_HEDLEY_GCC_VERSION_CHECK(6,0,0) || \
+      JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      defined(_Static_assert) \
+    )
+#  define JSON_HEDLEY_STATIC_ASSERT(expr, message) _Static_assert(expr, message)
+#elif \
+  (defined(__cplusplus) && (__cplusplus >= 201103L)) || \
+  JSON_HEDLEY_MSVC_VERSION_CHECK(16,0,0) || \
+  JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define JSON_HEDLEY_STATIC_ASSERT(expr, message) JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(static_assert(expr, message))
+#else
+#  define JSON_HEDLEY_STATIC_ASSERT(expr, message)
+#endif
+
+#if defined(JSON_HEDLEY_NULL)
+    #undef JSON_HEDLEY_NULL
+#endif
+#if defined(__cplusplus)
+    #if __cplusplus >= 201103L
+        #define JSON_HEDLEY_NULL JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(nullptr)
+    #elif defined(NULL)
+        #define JSON_HEDLEY_NULL NULL
+    #else
+        #define JSON_HEDLEY_NULL JSON_HEDLEY_STATIC_CAST(void*, 0)
+    #endif
+#elif defined(NULL)
+    #define JSON_HEDLEY_NULL NULL
+#else
+    #define JSON_HEDLEY_NULL ((void*) 0)
+#endif
+
+#if defined(JSON_HEDLEY_MESSAGE)
+    #undef JSON_HEDLEY_MESSAGE
+#endif
+#if JSON_HEDLEY_HAS_WARNING("-Wunknown-pragmas")
+#  define JSON_HEDLEY_MESSAGE(msg) \
+    JSON_HEDLEY_DIAGNOSTIC_PUSH \
+    JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS \
+    JSON_HEDLEY_PRAGMA(message msg) \
+    JSON_HEDLEY_DIAGNOSTIC_POP
+#elif \
+  JSON_HEDLEY_GCC_VERSION_CHECK(4,4,0) || \
+  JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define JSON_HEDLEY_MESSAGE(msg) JSON_HEDLEY_PRAGMA(message msg)
+#elif JSON_HEDLEY_CRAY_VERSION_CHECK(5,0,0)
+#  define JSON_HEDLEY_MESSAGE(msg) JSON_HEDLEY_PRAGMA(_CRI message msg)
+#elif JSON_HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define JSON_HEDLEY_MESSAGE(msg) JSON_HEDLEY_PRAGMA(message(msg))
+#elif JSON_HEDLEY_PELLES_VERSION_CHECK(2,0,0)
+#  define JSON_HEDLEY_MESSAGE(msg) JSON_HEDLEY_PRAGMA(message(msg))
+#else
+#  define JSON_HEDLEY_MESSAGE(msg)
+#endif
+
+#if defined(JSON_HEDLEY_WARNING)
+    #undef JSON_HEDLEY_WARNING
+#endif
+#if JSON_HEDLEY_HAS_WARNING("-Wunknown-pragmas")
+#  define JSON_HEDLEY_WARNING(msg) \
+    JSON_HEDLEY_DIAGNOSTIC_PUSH \
+    JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS \
+    JSON_HEDLEY_PRAGMA(clang warning msg) \
+    JSON_HEDLEY_DIAGNOSTIC_POP
+#elif \
+  JSON_HEDLEY_GCC_VERSION_CHECK(4,8,0) || \
+  JSON_HEDLEY_PGI_VERSION_CHECK(18,4,0) || \
+  JSON_HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define JSON_HEDLEY_WARNING(msg) JSON_HEDLEY_PRAGMA(GCC warning msg)
+#elif \
+  JSON_HEDLEY_MSVC_VERSION_CHECK(15,0,0) || \
+  JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define JSON_HEDLEY_WARNING(msg) JSON_HEDLEY_PRAGMA(message(msg))
+#else
+#  define JSON_HEDLEY_WARNING(msg) JSON_HEDLEY_MESSAGE(msg)
+#endif
+
+#if defined(JSON_HEDLEY_REQUIRE)
+    #undef JSON_HEDLEY_REQUIRE
+#endif
+#if defined(JSON_HEDLEY_REQUIRE_MSG)
+    #undef JSON_HEDLEY_REQUIRE_MSG
+#endif
+#if JSON_HEDLEY_HAS_ATTRIBUTE(diagnose_if)
+#  if JSON_HEDLEY_HAS_WARNING("-Wgcc-compat")
+#    define JSON_HEDLEY_REQUIRE(expr) \
+    JSON_HEDLEY_DIAGNOSTIC_PUSH \
+    _Pragma("clang diagnostic ignored \"-Wgcc-compat\"") \
+    __attribute__((diagnose_if(!(expr), #expr, "error"))) \
+    JSON_HEDLEY_DIAGNOSTIC_POP
+#    define JSON_HEDLEY_REQUIRE_MSG(expr,msg) \
+    JSON_HEDLEY_DIAGNOSTIC_PUSH \
+    _Pragma("clang diagnostic ignored \"-Wgcc-compat\"") \
+    __attribute__((diagnose_if(!(expr), msg, "error"))) \
+    JSON_HEDLEY_DIAGNOSTIC_POP
+#  else
+#    define JSON_HEDLEY_REQUIRE(expr) __attribute__((diagnose_if(!(expr), #expr, "error")))
+#    define JSON_HEDLEY_REQUIRE_MSG(expr,msg) __attribute__((diagnose_if(!(expr), msg, "error")))
+#  endif
+#else
+#  define JSON_HEDLEY_REQUIRE(expr)
+#  define JSON_HEDLEY_REQUIRE_MSG(expr,msg)
+#endif
+
+#if defined(JSON_HEDLEY_FLAGS)
+    #undef JSON_HEDLEY_FLAGS
+#endif
+#if JSON_HEDLEY_HAS_ATTRIBUTE(flag_enum) && (!defined(__cplusplus) || JSON_HEDLEY_HAS_WARNING("-Wbitfield-enum-conversion"))
+    #define JSON_HEDLEY_FLAGS __attribute__((__flag_enum__))
+#else
+    #define JSON_HEDLEY_FLAGS
+#endif
+
+#if defined(JSON_HEDLEY_FLAGS_CAST)
+    #undef JSON_HEDLEY_FLAGS_CAST
+#endif
+#if JSON_HEDLEY_INTEL_VERSION_CHECK(19,0,0)
+#  define JSON_HEDLEY_FLAGS_CAST(T, expr) (__extension__ ({ \
+        JSON_HEDLEY_DIAGNOSTIC_PUSH \
+        _Pragma("warning(disable:188)") \
+        ((T) (expr)); \
+        JSON_HEDLEY_DIAGNOSTIC_POP \
+    }))
+#else
+#  define JSON_HEDLEY_FLAGS_CAST(T, expr) JSON_HEDLEY_STATIC_CAST(T, expr)
+#endif
+
+#if defined(JSON_HEDLEY_EMPTY_BASES)
+    #undef JSON_HEDLEY_EMPTY_BASES
+#endif
+#if \
+    (JSON_HEDLEY_MSVC_VERSION_CHECK(19,0,23918) && !JSON_HEDLEY_MSVC_VERSION_CHECK(20,0,0)) || \
+    JSON_HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+    #define JSON_HEDLEY_EMPTY_BASES __declspec(empty_bases)
+#else
+    #define JSON_HEDLEY_EMPTY_BASES
+#endif
+
+/* Remaining macros are deprecated. */
+
+#if defined(JSON_HEDLEY_GCC_NOT_CLANG_VERSION_CHECK)
+    #undef JSON_HEDLEY_GCC_NOT_CLANG_VERSION_CHECK
+#endif
+#if defined(__clang__)
+    #define JSON_HEDLEY_GCC_NOT_CLANG_VERSION_CHECK(major,minor,patch) (0)
+#else
+    #define JSON_HEDLEY_GCC_NOT_CLANG_VERSION_CHECK(major,minor,patch) JSON_HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(JSON_HEDLEY_CLANG_HAS_ATTRIBUTE)
+    #undef JSON_HEDLEY_CLANG_HAS_ATTRIBUTE
+#endif
+#define JSON_HEDLEY_CLANG_HAS_ATTRIBUTE(attribute) JSON_HEDLEY_HAS_ATTRIBUTE(attribute)
+
+#if defined(JSON_HEDLEY_CLANG_HAS_CPP_ATTRIBUTE)
+    #undef JSON_HEDLEY_CLANG_HAS_CPP_ATTRIBUTE
+#endif
+#define JSON_HEDLEY_CLANG_HAS_CPP_ATTRIBUTE(attribute) JSON_HEDLEY_HAS_CPP_ATTRIBUTE(attribute)
+
+#if defined(JSON_HEDLEY_CLANG_HAS_BUILTIN)
+    #undef JSON_HEDLEY_CLANG_HAS_BUILTIN
+#endif
+#define JSON_HEDLEY_CLANG_HAS_BUILTIN(builtin) JSON_HEDLEY_HAS_BUILTIN(builtin)
+
+#if defined(JSON_HEDLEY_CLANG_HAS_FEATURE)
+    #undef JSON_HEDLEY_CLANG_HAS_FEATURE
+#endif
+#define JSON_HEDLEY_CLANG_HAS_FEATURE(feature) JSON_HEDLEY_HAS_FEATURE(feature)
+
+#if defined(JSON_HEDLEY_CLANG_HAS_EXTENSION)
+    #undef JSON_HEDLEY_CLANG_HAS_EXTENSION
+#endif
+#define JSON_HEDLEY_CLANG_HAS_EXTENSION(extension) JSON_HEDLEY_HAS_EXTENSION(extension)
+
+#if defined(JSON_HEDLEY_CLANG_HAS_DECLSPEC_DECLSPEC_ATTRIBUTE)
+    #undef JSON_HEDLEY_CLANG_HAS_DECLSPEC_DECLSPEC_ATTRIBUTE
+#endif
+#define JSON_HEDLEY_CLANG_HAS_DECLSPEC_ATTRIBUTE(attribute) JSON_HEDLEY_HAS_DECLSPEC_ATTRIBUTE(attribute)
+
+#if defined(JSON_HEDLEY_CLANG_HAS_WARNING)
+    #undef JSON_HEDLEY_CLANG_HAS_WARNING
+#endif
+#define JSON_HEDLEY_CLANG_HAS_WARNING(warning) JSON_HEDLEY_HAS_WARNING(warning)
+
+#endif /* !defined(JSON_HEDLEY_VERSION) || (JSON_HEDLEY_VERSION < X) */
+
+
+// This file contains all internal macro definitions (except those affecting ABI)
+// You MUST include macro_unscope.hpp at the end of json.hpp to undef all of them
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+
+// exclude unsupported compilers
+#if !defined(JSON_SKIP_UNSUPPORTED_COMPILER_CHECK)
+    #if defined(__clang__)
+        #if (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) < 30400
+            #error "unsupported Clang version - see https://github.com/nlohmann/json#supported-compilers"
+        #endif
+    #elif defined(__GNUC__) && !(defined(__ICC) || defined(__INTEL_COMPILER))
+        #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40800
+            #error "unsupported GCC version - see https://github.com/nlohmann/json#supported-compilers"
+        #endif
+    #endif
+#endif
+
+// C++ language standard detection
+// if the user manually specified the used c++ version this is skipped
+#if !defined(JSON_HAS_CPP_20) && !defined(JSON_HAS_CPP_17) && !defined(JSON_HAS_CPP_14) && !defined(JSON_HAS_CPP_11)
+    #if (defined(__cplusplus) && __cplusplus >= 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+        #define JSON_HAS_CPP_20
+        #define JSON_HAS_CPP_17
+        #define JSON_HAS_CPP_14
+    #elif (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_HAS_CXX17) && _HAS_CXX17 == 1) // fix for issue #464
+        #define JSON_HAS_CPP_17
+        #define JSON_HAS_CPP_14
+    #elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_HAS_CXX14) && _HAS_CXX14 == 1)
+        #define JSON_HAS_CPP_14
+    #endif
+    // the cpp 11 flag is always specified because it is the minimal required version
+    #define JSON_HAS_CPP_11
+#endif
+
+#ifdef __has_include
+    #if __has_include(<version>)
+        #include <version>
+    #endif
+#endif
+
+#if !defined(JSON_HAS_FILESYSTEM) && !defined(JSON_HAS_EXPERIMENTAL_FILESYSTEM)
+    #ifdef JSON_HAS_CPP_17
+        #if defined(__cpp_lib_filesystem)
+            #define JSON_HAS_FILESYSTEM 1
+        #elif defined(__cpp_lib_experimental_filesystem)
+            #define JSON_HAS_EXPERIMENTAL_FILESYSTEM 1
+        #elif !defined(__has_include)
+            #define JSON_HAS_EXPERIMENTAL_FILESYSTEM 1
+        #elif __has_include(<filesystem>)
+            #define JSON_HAS_FILESYSTEM 1
+        #elif __has_include(<experimental/filesystem>)
+            #define JSON_HAS_EXPERIMENTAL_FILESYSTEM 1
+        #endif
+
+        // std::filesystem does not work on MinGW GCC 8: https://sourceforge.net/p/mingw-w64/bugs/737/
+        #if defined(__MINGW32__) && defined(__GNUC__) && __GNUC__ == 8
+            #undef JSON_HAS_FILESYSTEM
+            #undef JSON_HAS_EXPERIMENTAL_FILESYSTEM
+        #endif
+
+        // no filesystem support before GCC 8: https://en.cppreference.com/w/cpp/compiler_support
+        #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
+            #undef JSON_HAS_FILESYSTEM
+            #undef JSON_HAS_EXPERIMENTAL_FILESYSTEM
+        #endif
+
+        // no filesystem support before Clang 7: https://en.cppreference.com/w/cpp/compiler_support
+        #if defined(__clang_major__) && __clang_major__ < 7
+            #undef JSON_HAS_FILESYSTEM
+            #undef JSON_HAS_EXPERIMENTAL_FILESYSTEM
+        #endif
+
+        // no filesystem support before MSVC 19.14: https://en.cppreference.com/w/cpp/compiler_support
+        #if defined(_MSC_VER) && _MSC_VER < 1914
+            #undef JSON_HAS_FILESYSTEM
+            #undef JSON_HAS_EXPERIMENTAL_FILESYSTEM
+        #endif
+
+        // no filesystem support before iOS 13
+        #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 130000
+            #undef JSON_HAS_FILESYSTEM
+            #undef JSON_HAS_EXPERIMENTAL_FILESYSTEM
+        #endif
+
+        // no filesystem support before macOS Catalina
+        #if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101500
+            #undef JSON_HAS_FILESYSTEM
+            #undef JSON_HAS_EXPERIMENTAL_FILESYSTEM
+        #endif
+    #endif
+#endif
+
+#ifndef JSON_HAS_EXPERIMENTAL_FILESYSTEM
+    #define JSON_HAS_EXPERIMENTAL_FILESYSTEM 0
+#endif
+
+#ifndef JSON_HAS_FILESYSTEM
+    #define JSON_HAS_FILESYSTEM 0
+#endif
+
+#ifndef JSON_HAS_THREE_WAY_COMPARISON
+    #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L \
+        && defined(__cpp_lib_three_way_comparison) && __cpp_lib_three_way_comparison >= 201907L
+        #define JSON_HAS_THREE_WAY_COMPARISON 1
+    #else
+        #define JSON_HAS_THREE_WAY_COMPARISON 0
+    #endif
+#endif
+
+#ifndef JSON_HAS_RANGES
+    // ranges header shipping in GCC 11.1.0 (released 2021-04-27) has syntax error
+    #if defined(__GLIBCXX__) && __GLIBCXX__ == 20210427
+        #define JSON_HAS_RANGES 0
+    #elif defined(__cpp_lib_ranges)
+        #define JSON_HAS_RANGES 1
+    #else
+        #define JSON_HAS_RANGES 0
+    #endif
+#endif
+
+#ifndef JSON_HAS_STATIC_RTTI
+    #if !defined(_HAS_STATIC_RTTI) || _HAS_STATIC_RTTI != 0
+        #define JSON_HAS_STATIC_RTTI 1
+    #else
+        #define JSON_HAS_STATIC_RTTI 0
+    #endif
+#endif
+
+#ifdef JSON_HAS_CPP_17
+    #define JSON_INLINE_VARIABLE inline
+#else
+    #define JSON_INLINE_VARIABLE
+#endif
+
+#if JSON_HEDLEY_HAS_ATTRIBUTE(no_unique_address)
+    #define JSON_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+    #define JSON_NO_UNIQUE_ADDRESS
+#endif
+
+// disable documentation warnings on clang
+#if defined(__clang__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdocumentation"
+    #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#endif
+
+// allow disabling exceptions
+#if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)) && !defined(JSON_NOEXCEPTION)
+    #define JSON_THROW(exception) throw exception
+    #define JSON_TRY try
+    #define JSON_CATCH(exception) catch(exception)
+    #define JSON_INTERNAL_CATCH(exception) catch(exception)
+#else
+    #include <cstdlib>
+    #define JSON_THROW(exception) std::abort()
+    #define JSON_TRY if(true)
+    #define JSON_CATCH(exception) if(false)
+    #define JSON_INTERNAL_CATCH(exception) if(false)
+#endif
+
+// override exception macros
+#if defined(JSON_THROW_USER)
+    #undef JSON_THROW
+    #define JSON_THROW JSON_THROW_USER
+#endif
+#if defined(JSON_TRY_USER)
+    #undef JSON_TRY
+    #define JSON_TRY JSON_TRY_USER
+#endif
+#if defined(JSON_CATCH_USER)
+    #undef JSON_CATCH
+    #define JSON_CATCH JSON_CATCH_USER
+    #undef JSON_INTERNAL_CATCH
+    #define JSON_INTERNAL_CATCH JSON_CATCH_USER
+#endif
+#if defined(JSON_INTERNAL_CATCH_USER)
+    #undef JSON_INTERNAL_CATCH
+    #define JSON_INTERNAL_CATCH JSON_INTERNAL_CATCH_USER
+#endif
+
+// allow overriding assert
+#if !defined(JSON_ASSERT)
+    #include <cassert> // assert
+    #define JSON_ASSERT(x) assert(x)
+#endif
+
+// allow to access some private functions (needed by the test suite)
+#if defined(JSON_TESTS_PRIVATE)
+    #define JSON_PRIVATE_UNLESS_TESTED public
+#else
+    #define JSON_PRIVATE_UNLESS_TESTED private
+#endif
+
+/*!
+@brief macro to briefly define a mapping between an enum and JSON
+@def NLOHMANN_JSON_SERIALIZE_ENUM
+@since version 3.4.0
+*/
+#define NLOHMANN_JSON_SERIALIZE_ENUM(ENUM_TYPE, ...)                                            \
+    template<typename BasicJsonType>                                                            \
+    inline void to_json(BasicJsonType& j, const ENUM_TYPE& e)                                   \
+    {                                                                                           \
+        static_assert(std::is_enum<ENUM_TYPE>::value, #ENUM_TYPE " must be an enum!");          \
+        static const std::pair<ENUM_TYPE, BasicJsonType> m[] = __VA_ARGS__;                     \
+        auto it = std::find_if(std::begin(m), std::end(m),                                      \
+                               [e](const std::pair<ENUM_TYPE, BasicJsonType>& ej_pair) -> bool  \
+        {                                                                                       \
+            return ej_pair.first == e;                                                          \
+        });                                                                                     \
+        j = ((it != std::end(m)) ? it : std::begin(m))->second;                                 \
+    }                                                                                           \
+    template<typename BasicJsonType>                                                            \
+    inline void from_json(const BasicJsonType& j, ENUM_TYPE& e)                                 \
+    {                                                                                           \
+        static_assert(std::is_enum<ENUM_TYPE>::value, #ENUM_TYPE " must be an enum!");          \
+        static const std::pair<ENUM_TYPE, BasicJsonType> m[] = __VA_ARGS__;                     \
+        auto it = std::find_if(std::begin(m), std::end(m),                                      \
+                               [&j](const std::pair<ENUM_TYPE, BasicJsonType>& ej_pair) -> bool \
+        {                                                                                       \
+            return ej_pair.second == j;                                                         \
+        });                                                                                     \
+        e = ((it != std::end(m)) ? it : std::begin(m))->first;                                  \
+    }
+
+// Ugly macros to avoid uglier copy-paste when specializing basic_json. They
+// may be removed in the future once the class is split.
+
+#define NLOHMANN_BASIC_JSON_TPL_DECLARATION                                \
+    template<template<typename, typename, typename...> class ObjectType,   \
+             template<typename, typename...> class ArrayType,              \
+             class StringType, class BooleanType, class NumberIntegerType, \
+             class NumberUnsignedType, class NumberFloatType,              \
+             template<typename> class AllocatorType,                       \
+             template<typename, typename = void> class JSONSerializer,     \
+             class BinaryType,                                             \
+             class CustomBaseClass>
+
+#define NLOHMANN_BASIC_JSON_TPL                                            \
+    basic_json<ObjectType, ArrayType, StringType, BooleanType,             \
+    NumberIntegerType, NumberUnsignedType, NumberFloatType,                \
+    AllocatorType, JSONSerializer, BinaryType, CustomBaseClass>
+
+// Macros to simplify conversion from/to types
+
+#define NLOHMANN_JSON_EXPAND( x ) x
+#define NLOHMANN_JSON_GET_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63, _64, NAME,...) NAME
+#define NLOHMANN_JSON_PASTE(...) NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_GET_MACRO(__VA_ARGS__, \
+        NLOHMANN_JSON_PASTE64, \
+        NLOHMANN_JSON_PASTE63, \
+        NLOHMANN_JSON_PASTE62, \
+        NLOHMANN_JSON_PASTE61, \
+        NLOHMANN_JSON_PASTE60, \
+        NLOHMANN_JSON_PASTE59, \
+        NLOHMANN_JSON_PASTE58, \
+        NLOHMANN_JSON_PASTE57, \
+        NLOHMANN_JSON_PASTE56, \
+        NLOHMANN_JSON_PASTE55, \
+        NLOHMANN_JSON_PASTE54, \
+        NLOHMANN_JSON_PASTE53, \
+        NLOHMANN_JSON_PASTE52, \
+        NLOHMANN_JSON_PASTE51, \
+        NLOHMANN_JSON_PASTE50, \
+        NLOHMANN_JSON_PASTE49, \
+        NLOHMANN_JSON_PASTE48, \
+        NLOHMANN_JSON_PASTE47, \
+        NLOHMANN_JSON_PASTE46, \
+        NLOHMANN_JSON_PASTE45, \
+        NLOHMANN_JSON_PASTE44, \
+        NLOHMANN_JSON_PASTE43, \
+        NLOHMANN_JSON_PASTE42, \
+        NLOHMANN_JSON_PASTE41, \
+        NLOHMANN_JSON_PASTE40, \
+        NLOHMANN_JSON_PASTE39, \
+        NLOHMANN_JSON_PASTE38, \
+        NLOHMANN_JSON_PASTE37, \
+        NLOHMANN_JSON_PASTE36, \
+        NLOHMANN_JSON_PASTE35, \
+        NLOHMANN_JSON_PASTE34, \
+        NLOHMANN_JSON_PASTE33, \
+        NLOHMANN_JSON_PASTE32, \
+        NLOHMANN_JSON_PASTE31, \
+        NLOHMANN_JSON_PASTE30, \
+        NLOHMANN_JSON_PASTE29, \
+        NLOHMANN_JSON_PASTE28, \
+        NLOHMANN_JSON_PASTE27, \
+        NLOHMANN_JSON_PASTE26, \
+        NLOHMANN_JSON_PASTE25, \
+        NLOHMANN_JSON_PASTE24, \
+        NLOHMANN_JSON_PASTE23, \
+        NLOHMANN_JSON_PASTE22, \
+        NLOHMANN_JSON_PASTE21, \
+        NLOHMANN_JSON_PASTE20, \
+        NLOHMANN_JSON_PASTE19, \
+        NLOHMANN_JSON_PASTE18, \
+        NLOHMANN_JSON_PASTE17, \
+        NLOHMANN_JSON_PASTE16, \
+        NLOHMANN_JSON_PASTE15, \
+        NLOHMANN_JSON_PASTE14, \
+        NLOHMANN_JSON_PASTE13, \
+        NLOHMANN_JSON_PASTE12, \
+        NLOHMANN_JSON_PASTE11, \
+        NLOHMANN_JSON_PASTE10, \
+        NLOHMANN_JSON_PASTE9, \
+        NLOHMANN_JSON_PASTE8, \
+        NLOHMANN_JSON_PASTE7, \
+        NLOHMANN_JSON_PASTE6, \
+        NLOHMANN_JSON_PASTE5, \
+        NLOHMANN_JSON_PASTE4, \
+        NLOHMANN_JSON_PASTE3, \
+        NLOHMANN_JSON_PASTE2, \
+        NLOHMANN_JSON_PASTE1)(__VA_ARGS__))
+#define NLOHMANN_JSON_PASTE2(func, v1) func(v1)
+#define NLOHMANN_JSON_PASTE3(func, v1, v2) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE2(func, v2)
+#define NLOHMANN_JSON_PASTE4(func, v1, v2, v3) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE3(func, v2, v3)
+#define NLOHMANN_JSON_PASTE5(func, v1, v2, v3, v4) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE4(func, v2, v3, v4)
+#define NLOHMANN_JSON_PASTE6(func, v1, v2, v3, v4, v5) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE5(func, v2, v3, v4, v5)
+#define NLOHMANN_JSON_PASTE7(func, v1, v2, v3, v4, v5, v6) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE6(func, v2, v3, v4, v5, v6)
+#define NLOHMANN_JSON_PASTE8(func, v1, v2, v3, v4, v5, v6, v7) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE7(func, v2, v3, v4, v5, v6, v7)
+#define NLOHMANN_JSON_PASTE9(func, v1, v2, v3, v4, v5, v6, v7, v8) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE8(func, v2, v3, v4, v5, v6, v7, v8)
+#define NLOHMANN_JSON_PASTE10(func, v1, v2, v3, v4, v5, v6, v7, v8, v9) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE9(func, v2, v3, v4, v5, v6, v7, v8, v9)
+#define NLOHMANN_JSON_PASTE11(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE10(func, v2, v3, v4, v5, v6, v7, v8, v9, v10)
+#define NLOHMANN_JSON_PASTE12(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE11(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
+#define NLOHMANN_JSON_PASTE13(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE12(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12)
+#define NLOHMANN_JSON_PASTE14(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE13(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13)
+#define NLOHMANN_JSON_PASTE15(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE14(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14)
+#define NLOHMANN_JSON_PASTE16(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE15(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15)
+#define NLOHMANN_JSON_PASTE17(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE16(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16)
+#define NLOHMANN_JSON_PASTE18(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE17(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17)
+#define NLOHMANN_JSON_PASTE19(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE18(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18)
+#define NLOHMANN_JSON_PASTE20(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE19(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19)
+#define NLOHMANN_JSON_PASTE21(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE20(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20)
+#define NLOHMANN_JSON_PASTE22(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE21(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21)
+#define NLOHMANN_JSON_PASTE23(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE22(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22)
+#define NLOHMANN_JSON_PASTE24(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE23(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23)
+#define NLOHMANN_JSON_PASTE25(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE24(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24)
+#define NLOHMANN_JSON_PASTE26(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE25(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25)
+#define NLOHMANN_JSON_PASTE27(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE26(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26)
+#define NLOHMANN_JSON_PASTE28(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE27(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27)
+#define NLOHMANN_JSON_PASTE29(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE28(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28)
+#define NLOHMANN_JSON_PASTE30(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE29(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29)
+#define NLOHMANN_JSON_PASTE31(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE30(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30)
+#define NLOHMANN_JSON_PASTE32(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE31(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31)
+#define NLOHMANN_JSON_PASTE33(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE32(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32)
+#define NLOHMANN_JSON_PASTE34(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE33(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33)
+#define NLOHMANN_JSON_PASTE35(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE34(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34)
+#define NLOHMANN_JSON_PASTE36(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE35(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35)
+#define NLOHMANN_JSON_PASTE37(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE36(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36)
+#define NLOHMANN_JSON_PASTE38(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE37(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37)
+#define NLOHMANN_JSON_PASTE39(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE38(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38)
+#define NLOHMANN_JSON_PASTE40(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE39(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39)
+#define NLOHMANN_JSON_PASTE41(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE40(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40)
+#define NLOHMANN_JSON_PASTE42(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE41(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41)
+#define NLOHMANN_JSON_PASTE43(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE42(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42)
+#define NLOHMANN_JSON_PASTE44(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE43(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43)
+#define NLOHMANN_JSON_PASTE45(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE44(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44)
+#define NLOHMANN_JSON_PASTE46(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE45(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45)
+#define NLOHMANN_JSON_PASTE47(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE46(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46)
+#define NLOHMANN_JSON_PASTE48(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE47(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47)
+#define NLOHMANN_JSON_PASTE49(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE48(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48)
+#define NLOHMANN_JSON_PASTE50(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE49(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49)
+#define NLOHMANN_JSON_PASTE51(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE50(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50)
+#define NLOHMANN_JSON_PASTE52(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE51(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51)
+#define NLOHMANN_JSON_PASTE53(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE52(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52)
+#define NLOHMANN_JSON_PASTE54(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE53(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53)
+#define NLOHMANN_JSON_PASTE55(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE54(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54)
+#define NLOHMANN_JSON_PASTE56(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE55(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55)
+#define NLOHMANN_JSON_PASTE57(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE56(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56)
+#define NLOHMANN_JSON_PASTE58(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE57(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57)
+#define NLOHMANN_JSON_PASTE59(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE58(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58)
+#define NLOHMANN_JSON_PASTE60(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE59(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59)
+#define NLOHMANN_JSON_PASTE61(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE60(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60)
+#define NLOHMANN_JSON_PASTE62(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60, v61) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE61(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60, v61)
+#define NLOHMANN_JSON_PASTE63(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60, v61, v62) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE62(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60, v61, v62)
+#define NLOHMANN_JSON_PASTE64(func, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60, v61, v62, v63) NLOHMANN_JSON_PASTE2(func, v1) NLOHMANN_JSON_PASTE63(func, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60, v61, v62, v63)
+
+#define NLOHMANN_JSON_TO(v1) nlohmann_json_j[#v1] = nlohmann_json_t.v1;
+#define NLOHMANN_JSON_FROM(v1) nlohmann_json_j.at(#v1).get_to(nlohmann_json_t.v1);
+#define NLOHMANN_JSON_FROM_WITH_DEFAULT(v1) nlohmann_json_t.v1 = nlohmann_json_j.value(#v1, nlohmann_json_default_obj.v1);
+
+/*!
+@brief macro
+@def NLOHMANN_DEFINE_TYPE_INTRUSIVE
+@since version 3.9.0
+*/
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE(Type, ...)  \
+    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
+    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
+    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
+    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { const Type nlohmann_json_default_obj{}; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE(Type, ...)  \
+    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) }
+
+/*!
+@brief macro
+@def NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE
+@since version 3.9.0
+*/
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Type, ...)  \
+    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
+    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM, __VA_ARGS__)) }
+
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE(Type, ...)  \
+    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) }
+
+#define NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Type, ...)  \
+    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) } \
+    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { const Type nlohmann_json_default_obj{}; NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__)) }
+
+// inspired from https://stackoverflow.com/a/26745591
+// allows to call any std function as if (e.g. with begin):
+// using std::begin; begin(x);
+//
+// it allows using the detected idiom to retrieve the return type
+// of such an expression
+#define NLOHMANN_CAN_CALL_STD_FUNC_IMPL(std_name)                                 \
+    namespace detail {                                                            \
+    using std::std_name;                                                          \
+    \
+    template<typename... T>                                                       \
+    using result_of_##std_name = decltype(std_name(std::declval<T>()...));        \
+    }                                                                             \
+    \
+    namespace detail2 {                                                           \
+    struct std_name##_tag                                                         \
+    {                                                                             \
+    };                                                                            \
+    \
+    template<typename... T>                                                       \
+    std_name##_tag std_name(T&&...);                                              \
+    \
+    template<typename... T>                                                       \
+    using result_of_##std_name = decltype(std_name(std::declval<T>()...));        \
+    \
+    template<typename... T>                                                       \
+    struct would_call_std_##std_name                                              \
+    {                                                                             \
+        static constexpr auto const value = ::nlohmann::detail::                  \
+                                            is_detected_exact<std_name##_tag, result_of_##std_name, T...>::value; \
+    };                                                                            \
+    } /* namespace detail2 */ \
+    \
+    template<typename... T>                                                       \
+    struct would_call_std_##std_name : detail2::would_call_std_##std_name<T...>   \
+    {                                                                             \
+    }
+
+#ifndef JSON_USE_IMPLICIT_CONVERSIONS
+    #define JSON_USE_IMPLICIT_CONVERSIONS 1
+#endif
+
+#if JSON_USE_IMPLICIT_CONVERSIONS
+    #define JSON_EXPLICIT
+#else
+    #define JSON_EXPLICIT explicit
+#endif
+
+#ifndef JSON_DISABLE_ENUM_SERIALIZATION
+    #define JSON_DISABLE_ENUM_SERIALIZATION 0
+#endif
+
+#ifndef JSON_USE_GLOBAL_UDLS
+    #define JSON_USE_GLOBAL_UDLS 1
+#endif
+
+#if JSON_HAS_THREE_WAY_COMPARISON
+    #include <compare> // partial_ordering
+#endif
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+///////////////////////////
+// JSON type enumeration //
+///////////////////////////
+
+/*!
+@brief the JSON type enumeration
+
+This enumeration collects the different JSON types. It is internally used to
+distinguish the stored values, and the functions @ref basic_json::is_null(),
+@ref basic_json::is_object(), @ref basic_json::is_array(),
+@ref basic_json::is_string(), @ref basic_json::is_boolean(),
+@ref basic_json::is_number() (with @ref basic_json::is_number_integer(),
+@ref basic_json::is_number_unsigned(), and @ref basic_json::is_number_float()),
+@ref basic_json::is_discarded(), @ref basic_json::is_primitive(), and
+@ref basic_json::is_structured() rely on it.
+
+@note There are three enumeration entries (number_integer, number_unsigned, and
+number_float), because the library distinguishes these three types for numbers:
+@ref basic_json::number_unsigned_t is used for unsigned integers,
+@ref basic_json::number_integer_t is used for signed integers, and
+@ref basic_json::number_float_t is used for floating-point numbers or to
+approximate integers which do not fit in the limits of their respective type.
+
+@sa see @ref basic_json::basic_json(const value_t value_type) -- create a JSON
+value with the default value for a given type
+
+@since version 1.0.0
+*/
+enum class value_t : std::uint8_t
+{
+    null,             ///< null value
+    object,           ///< object (unordered set of name/value pairs)
+    array,            ///< array (ordered collection of values)
+    string,           ///< string value
+    boolean,          ///< boolean value
+    number_integer,   ///< number value (signed integer)
+    number_unsigned,  ///< number value (unsigned integer)
+    number_float,     ///< number value (floating-point)
+    binary,           ///< binary array (ordered collection of bytes)
+    discarded         ///< discarded by the parser callback function
+};
+
+/*!
+@brief comparison operator for JSON types
+
+Returns an ordering that is similar to Python:
+- order: null < boolean < number < object < array < string < binary
+- furthermore, each type is not smaller than itself
+- discarded values are not comparable
+- binary is represented as a b"" string in python and directly comparable to a
+  string; however, making a binary array directly comparable with a string would
+  be surprising behavior in a JSON file.
+
+@since version 1.0.0
+*/
+#if JSON_HAS_THREE_WAY_COMPARISON
+    inline std::partial_ordering operator<=>(const value_t lhs, const value_t rhs) noexcept // *NOPAD*
+#else
+    inline bool operator<(const value_t lhs, const value_t rhs) noexcept
+#endif
+{
+    static constexpr std::array<std::uint8_t, 9> order = {{
+            0 /* null */, 3 /* object */, 4 /* array */, 5 /* string */,
+            1 /* boolean */, 2 /* integer */, 2 /* unsigned */, 2 /* float */,
+            6 /* binary */
+        }
+    };
+
+    const auto l_index = static_cast<std::size_t>(lhs);
+    const auto r_index = static_cast<std::size_t>(rhs);
+#if JSON_HAS_THREE_WAY_COMPARISON
+    if (l_index < order.size() && r_index < order.size())
+    {
+        return order[l_index] <=> order[r_index]; // *NOPAD*
+    }
+    return std::partial_ordering::unordered;
+#else
+    return l_index < order.size() && r_index < order.size() && order[l_index] < order[r_index];
+#endif
+}
+
+// GCC selects the built-in operator< over an operator rewritten from
+// a user-defined spaceship operator
+// Clang, MSVC, and ICC select the rewritten candidate
+// (see GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105200)
+#if JSON_HAS_THREE_WAY_COMPARISON && defined(__GNUC__)
+inline bool operator<(const value_t lhs, const value_t rhs) noexcept
+{
+    return std::is_lt(lhs <=> rhs); // *NOPAD*
+}
+#endif
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/string_escape.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+/*!
+@brief replace all occurrences of a substring by another string
+
+@param[in,out] s  the string to manipulate; changed so that all
+               occurrences of @a f are replaced with @a t
+@param[in]     f  the substring to replace with @a t
+@param[in]     t  the string to replace @a f
+
+@pre The search string @a f must not be empty. **This precondition is
+enforced with an assertion.**
+
+@since version 2.0.0
+*/
+template<typename StringType>
+inline void replace_substring(StringType& s, const StringType& f,
+                              const StringType& t)
+{
+    JSON_ASSERT(!f.empty());
+    for (auto pos = s.find(f);                // find first occurrence of f
+            pos != StringType::npos;          // make sure f was found
+            s.replace(pos, f.size(), t),      // replace with t, and
+            pos = s.find(f, pos + t.size()))  // find next occurrence of f
+    {}
+}
+
+/*!
+ * @brief string escaping as described in RFC 6901 (Sect. 4)
+ * @param[in] s string to escape
+ * @return    escaped string
+ *
+ * Note the order of escaping "~" to "~0" and "/" to "~1" is important.
+ */
+template<typename StringType>
+inline StringType escape(StringType s)
+{
+    replace_substring(s, StringType{"~"}, StringType{"~0"});
+    replace_substring(s, StringType{"/"}, StringType{"~1"});
+    return s;
+}
+
+/*!
+ * @brief string unescaping as described in RFC 6901 (Sect. 4)
+ * @param[in] s string to unescape
+ * @return    unescaped string
+ *
+ * Note the order of escaping "~1" to "/" and "~0" to "~" is important.
+ */
+template<typename StringType>
+static void unescape(StringType& s)
+{
+    replace_substring(s, StringType{"~1"}, StringType{"/"});
+    replace_substring(s, StringType{"~0"}, StringType{"~"});
+}
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/input/position_t.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cstddef> // size_t
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+/// struct to capture the start position of the current token
+struct position_t
+{
+    /// the total number of characters read
+    std::size_t chars_read_total = 0;
+    /// the number of characters read in the current line
+    std::size_t chars_read_current_line = 0;
+    /// the number of lines read
+    std::size_t lines_read = 0;
+
+    /// conversion to size_t to preserve SAX interface
+    constexpr operator size_t() const
+    {
+        return chars_read_total;
+    }
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/cpp_future.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-FileCopyrightText: 2018 The Abseil Authors
+// SPDX-License-Identifier: MIT
+
+
+
+#include <array> // array
+#include <cstddef> // size_t
+#include <type_traits> // conditional, enable_if, false_type, integral_constant, is_constructible, is_integral, is_same, remove_cv, remove_reference, true_type
+#include <utility> // index_sequence, make_index_sequence, index_sequence_for
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+template<typename T>
+using uncvref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+#ifdef JSON_HAS_CPP_14
+
+// the following utilities are natively available in C++14
+using std::enable_if_t;
+using std::index_sequence;
+using std::make_index_sequence;
+using std::index_sequence_for;
+
+#else
+
+// alias templates to reduce boilerplate
+template<bool B, typename T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+// The following code is taken from https://github.com/abseil/abseil-cpp/blob/10cb35e459f5ecca5b2ff107635da0bfa41011b4/absl/utility/utility.h
+// which is part of Google Abseil (https://github.com/abseil/abseil-cpp), licensed under the Apache License 2.0.
+
+//// START OF CODE FROM GOOGLE ABSEIL
+
+// integer_sequence
+//
+// Class template representing a compile-time integer sequence. An instantiation
+// of `integer_sequence<T, Ints...>` has a sequence of integers encoded in its
+// type through its template arguments (which is a common need when
+// working with C++11 variadic templates). `absl::integer_sequence` is designed
+// to be a drop-in replacement for C++14's `std::integer_sequence`.
+//
+// Example:
+//
+//   template< class T, T... Ints >
+//   void user_function(integer_sequence<T, Ints...>);
+//
+//   int main()
+//   {
+//     // user_function's `T` will be deduced to `int` and `Ints...`
+//     // will be deduced to `0, 1, 2, 3, 4`.
+//     user_function(make_integer_sequence<int, 5>());
+//   }
+template <typename T, T... Ints>
+struct integer_sequence
+{
+    using value_type = T;
+    static constexpr std::size_t size() noexcept
+    {
+        return sizeof...(Ints);
+    }
+};
+
+// index_sequence
+//
+// A helper template for an `integer_sequence` of `size_t`,
+// `absl::index_sequence` is designed to be a drop-in replacement for C++14's
+// `std::index_sequence`.
+template <size_t... Ints>
+using index_sequence = integer_sequence<size_t, Ints...>;
+
+namespace utility_internal
+{
+
+template <typename Seq, size_t SeqSize, size_t Rem>
+struct Extend;
+
+// Note that SeqSize == sizeof...(Ints). It's passed explicitly for efficiency.
+template <typename T, T... Ints, size_t SeqSize>
+struct Extend<integer_sequence<T, Ints...>, SeqSize, 0>
+{
+    using type = integer_sequence < T, Ints..., (Ints + SeqSize)... >;
+};
+
+template <typename T, T... Ints, size_t SeqSize>
+struct Extend<integer_sequence<T, Ints...>, SeqSize, 1>
+{
+    using type = integer_sequence < T, Ints..., (Ints + SeqSize)..., 2 * SeqSize >;
+};
+
+// Recursion helper for 'make_integer_sequence<T, N>'.
+// 'Gen<T, N>::type' is an alias for 'integer_sequence<T, 0, 1, ... N-1>'.
+template <typename T, size_t N>
+struct Gen
+{
+    using type =
+        typename Extend < typename Gen < T, N / 2 >::type, N / 2, N % 2 >::type;
+};
+
+template <typename T>
+struct Gen<T, 0>
+{
+    using type = integer_sequence<T>;
+};
+
+}  // namespace utility_internal
+
+// Compile-time sequences of integers
+
+// make_integer_sequence
+//
+// This template alias is equivalent to
+// `integer_sequence<int, 0, 1, ..., N-1>`, and is designed to be a drop-in
+// replacement for C++14's `std::make_integer_sequence`.
+template <typename T, T N>
+using make_integer_sequence = typename utility_internal::Gen<T, N>::type;
+
+// make_index_sequence
+//
+// This template alias is equivalent to `index_sequence<0, 1, ..., N-1>`,
+// and is designed to be a drop-in replacement for C++14's
+// `std::make_index_sequence`.
+template <size_t N>
+using make_index_sequence = make_integer_sequence<size_t, N>;
+
+// index_sequence_for
+//
+// Converts a typename pack into an index sequence of the same length, and
+// is designed to be a drop-in replacement for C++14's
+// `std::index_sequence_for()`
+template <typename... Ts>
+using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+
+//// END OF CODE FROM GOOGLE ABSEIL
+
+#endif
+
+// dispatch utility (taken from ranges-v3)
+template<unsigned N> struct priority_tag : priority_tag < N - 1 > {};
+template<> struct priority_tag<0> {};
+
+// taken from ranges-v3
+template<typename T>
+struct static_const
+{
+    static JSON_INLINE_VARIABLE constexpr T value{};
+};
+
+#ifndef JSON_HAS_CPP_17
+    template<typename T>
+    constexpr T static_const<T>::value;
+#endif
+
+template<typename T, typename... Args>
+inline constexpr std::array<T, sizeof...(Args)> make_array(Args&& ... args)
+{
+    return std::array<T, sizeof...(Args)> {{static_cast<T>(std::forward<Args>(args))...}};
+}
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <limits> // numeric_limits
+#include <type_traits> // false_type, is_constructible, is_integral, is_same, true_type
+#include <utility> // declval
+#include <tuple> // tuple
+#include <string> // char_traits
+
+// #include <nlohmann/detail/iterators/iterator_traits.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <iterator> // random_access_iterator_tag
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+// #include <nlohmann/detail/meta/void_t.hpp>
+
+// #include <nlohmann/detail/meta/cpp_future.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+template<typename It, typename = void>
+struct iterator_types {};
+
+template<typename It>
+struct iterator_types <
+    It,
+    void_t<typename It::difference_type, typename It::value_type, typename It::pointer,
+    typename It::reference, typename It::iterator_category >>
+{
+    using difference_type = typename It::difference_type;
+    using value_type = typename It::value_type;
+    using pointer = typename It::pointer;
+    using reference = typename It::reference;
+    using iterator_category = typename It::iterator_category;
+};
+
+// This is required as some compilers implement std::iterator_traits in a way that
+// doesn't work with SFINAE. See https://github.com/nlohmann/json/issues/1341.
+template<typename T, typename = void>
+struct iterator_traits
+{
+};
+
+template<typename T>
+struct iterator_traits < T, enable_if_t < !std::is_pointer<T>::value >>
+            : iterator_types<T>
+{
+};
+
+template<typename T>
+struct iterator_traits<T*, enable_if_t<std::is_object<T>::value>>
+{
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = T;
+    using difference_type = ptrdiff_t;
+    using pointer = T*;
+    using reference = T&;
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/call_std/begin.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+
+NLOHMANN_CAN_CALL_STD_FUNC_IMPL(begin);
+
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/meta/call_std/end.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+
+NLOHMANN_CAN_CALL_STD_FUNC_IMPL(end);
+
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/meta/cpp_future.hpp>
+
+// #include <nlohmann/detail/meta/detected.hpp>
+
+// #include <nlohmann/json_fwd.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+#ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
+    #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+
+    #include <cstdint> // int64_t, uint64_t
+    #include <map> // map
+    #include <memory> // allocator
+    #include <string> // string
+    #include <vector> // vector
+
+    // #include <nlohmann/detail/abi_macros.hpp>
+
+
+    /*!
+    @brief namespace for Niels Lohmann
+    @see https://github.com/nlohmann
+    @since version 1.0.0
+    */
+    NLOHMANN_JSON_NAMESPACE_BEGIN
+
+    /*!
+    @brief default JSONSerializer template argument
+
+    This serializer ignores the template arguments and uses ADL
+    ([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+    for serialization.
+    */
+    template<typename T = void, typename SFINAE = void>
+    struct adl_serializer;
+
+    /// a class to store JSON values
+    /// @sa https://json.nlohmann.me/api/basic_json/
+    template<template<typename U, typename V, typename... Args> class ObjectType =
+    std::map,
+    template<typename U, typename... Args> class ArrayType = std::vector,
+    class StringType = std::string, class BooleanType = bool,
+    class NumberIntegerType = std::int64_t,
+    class NumberUnsignedType = std::uint64_t,
+    class NumberFloatType = double,
+    template<typename U> class AllocatorType = std::allocator,
+    template<typename T, typename SFINAE = void> class JSONSerializer =
+    adl_serializer,
+    class BinaryType = std::vector<std::uint8_t>, // cppcheck-suppress syntaxError
+    class CustomBaseClass = void>
+    class basic_json;
+
+    /// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+    /// @sa https://json.nlohmann.me/api/json_pointer/
+    template<typename RefStringType>
+    class json_pointer;
+
+    /*!
+    @brief default specialization
+    @sa https://json.nlohmann.me/api/json/
+    */
+    using json = basic_json<>;
+
+    /// @brief a minimal map-like container that preserves insertion order
+    /// @sa https://json.nlohmann.me/api/ordered_map/
+    template<class Key, class T, class IgnoredLess, class Allocator>
+    struct ordered_map;
+
+    /// @brief specialization that maintains the insertion order of object keys
+    /// @sa https://json.nlohmann.me/api/ordered_json/
+    using ordered_json = basic_json<nlohmann::ordered_map>;
+
+    NLOHMANN_JSON_NAMESPACE_END
+
+#endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+/*!
+@brief detail namespace with internal helper functions
+
+This namespace collects functions that should not be exposed,
+implementations of some @ref basic_json methods, and meta-programming helpers.
+
+@since version 2.1.0
+*/
+namespace detail
+{
+
+/////////////
+// helpers //
+/////////////
+
+// Note to maintainers:
+//
+// Every trait in this file expects a non CV-qualified type.
+// The only exceptions are in the 'aliases for detected' section
+// (i.e. those of the form: decltype(T::member_function(std::declval<T>())))
+//
+// In this case, T has to be properly CV-qualified to constraint the function arguments
+// (e.g. to_json(BasicJsonType&, const T&))
+
+template<typename> struct is_basic_json : std::false_type {};
+
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+struct is_basic_json<NLOHMANN_BASIC_JSON_TPL> : std::true_type {};
+
+// used by exceptions create() member functions
+// true_type for pointer to possibly cv-qualified basic_json or std::nullptr_t
+// false_type otherwise
+template<typename BasicJsonContext>
+struct is_basic_json_context :
+    std::integral_constant < bool,
+    is_basic_json<typename std::remove_cv<typename std::remove_pointer<BasicJsonContext>::type>::type>::value
+    || std::is_same<BasicJsonContext, std::nullptr_t>::value >
+{};
+
+//////////////////////
+// json_ref helpers //
+//////////////////////
+
+template<typename>
+class json_ref;
+
+template<typename>
+struct is_json_ref : std::false_type {};
+
+template<typename T>
+struct is_json_ref<json_ref<T>> : std::true_type {};
+
+//////////////////////////
+// aliases for detected //
+//////////////////////////
+
+template<typename T>
+using mapped_type_t = typename T::mapped_type;
+
+template<typename T>
+using key_type_t = typename T::key_type;
+
+template<typename T>
+using value_type_t = typename T::value_type;
+
+template<typename T>
+using difference_type_t = typename T::difference_type;
+
+template<typename T>
+using pointer_t = typename T::pointer;
+
+template<typename T>
+using reference_t = typename T::reference;
+
+template<typename T>
+using iterator_category_t = typename T::iterator_category;
+
+template<typename T, typename... Args>
+using to_json_function = decltype(T::to_json(std::declval<Args>()...));
+
+template<typename T, typename... Args>
+using from_json_function = decltype(T::from_json(std::declval<Args>()...));
+
+template<typename T, typename U>
+using get_template_function = decltype(std::declval<T>().template get<U>());
+
+// trait checking if JSONSerializer<T>::from_json(json const&, udt&) exists
+template<typename BasicJsonType, typename T, typename = void>
+struct has_from_json : std::false_type {};
+
+// trait checking if j.get<T> is valid
+// use this trait instead of std::is_constructible or std::is_convertible,
+// both rely on, or make use of implicit conversions, and thus fail when T
+// has several constructors/operator= (see https://github.com/nlohmann/json/issues/958)
+template <typename BasicJsonType, typename T>
+struct is_getable
+{
+    static constexpr bool value = is_detected<get_template_function, const BasicJsonType&, T>::value;
+};
+
+template<typename BasicJsonType, typename T>
+struct has_from_json < BasicJsonType, T, enable_if_t < !is_basic_json<T>::value >>
+{
+    using serializer = typename BasicJsonType::template json_serializer<T, void>;
+
+    static constexpr bool value =
+        is_detected_exact<void, from_json_function, serializer,
+        const BasicJsonType&, T&>::value;
+};
+
+// This trait checks if JSONSerializer<T>::from_json(json const&) exists
+// this overload is used for non-default-constructible user-defined-types
+template<typename BasicJsonType, typename T, typename = void>
+struct has_non_default_from_json : std::false_type {};
+
+template<typename BasicJsonType, typename T>
+struct has_non_default_from_json < BasicJsonType, T, enable_if_t < !is_basic_json<T>::value >>
+{
+    using serializer = typename BasicJsonType::template json_serializer<T, void>;
+
+    static constexpr bool value =
+        is_detected_exact<T, from_json_function, serializer,
+        const BasicJsonType&>::value;
+};
+
+// This trait checks if BasicJsonType::json_serializer<T>::to_json exists
+// Do not evaluate the trait when T is a basic_json type, to avoid template instantiation infinite recursion.
+template<typename BasicJsonType, typename T, typename = void>
+struct has_to_json : std::false_type {};
+
+template<typename BasicJsonType, typename T>
+struct has_to_json < BasicJsonType, T, enable_if_t < !is_basic_json<T>::value >>
+{
+    using serializer = typename BasicJsonType::template json_serializer<T, void>;
+
+    static constexpr bool value =
+        is_detected_exact<void, to_json_function, serializer, BasicJsonType&,
+        T>::value;
+};
+
+template<typename T>
+using detect_key_compare = typename T::key_compare;
+
+template<typename T>
+struct has_key_compare : std::integral_constant<bool, is_detected<detect_key_compare, T>::value> {};
+
+// obtains the actual object key comparator
+template<typename BasicJsonType>
+struct actual_object_comparator
+{
+    using object_t = typename BasicJsonType::object_t;
+    using object_comparator_t = typename BasicJsonType::default_object_comparator_t;
+    using type = typename std::conditional < has_key_compare<object_t>::value,
+          typename object_t::key_compare, object_comparator_t>::type;
+};
+
+template<typename BasicJsonType>
+using actual_object_comparator_t = typename actual_object_comparator<BasicJsonType>::type;
+
+/////////////////
+// char_traits //
+/////////////////
+
+// Primary template of char_traits calls std char_traits
+template<typename T>
+struct char_traits : std::char_traits<T>
+{};
+
+// Explicitly define char traits for unsigned char since it is not standard
+template<>
+struct char_traits<unsigned char> : std::char_traits<char>
+{
+    using char_type = unsigned char;
+    using int_type = uint64_t;
+
+    // Redefine to_int_type function
+    static int_type to_int_type(char_type c) noexcept
+    {
+        return static_cast<int_type>(c);
+    }
+
+    static char_type to_char_type(int_type i) noexcept
+    {
+        return static_cast<char_type>(i);
+    }
+
+    static constexpr int_type eof() noexcept
+    {
+        return static_cast<int_type>(EOF);
+    }
+};
+
+// Explicitly define char traits for signed char since it is not standard
+template<>
+struct char_traits<signed char> : std::char_traits<char>
+{
+    using char_type = signed char;
+    using int_type = uint64_t;
+
+    // Redefine to_int_type function
+    static int_type to_int_type(char_type c) noexcept
+    {
+        return static_cast<int_type>(c);
+    }
+
+    static char_type to_char_type(int_type i) noexcept
+    {
+        return static_cast<char_type>(i);
+    }
+
+    static constexpr int_type eof() noexcept
+    {
+        return static_cast<int_type>(EOF);
+    }
+};
+
+///////////////////
+// is_ functions //
+///////////////////
+
+// https://en.cppreference.com/w/cpp/types/conjunction
+template<class...> struct conjunction : std::true_type { };
+template<class B> struct conjunction<B> : B { };
+template<class B, class... Bn>
+struct conjunction<B, Bn...>
+: std::conditional<static_cast<bool>(B::value), conjunction<Bn...>, B>::type {};
+
+// https://en.cppreference.com/w/cpp/types/negation
+template<class B> struct negation : std::integral_constant < bool, !B::value > { };
+
+// Reimplementation of is_constructible and is_default_constructible, due to them being broken for
+// std::pair and std::tuple until LWG 2367 fix (see https://cplusplus.github.io/LWG/lwg-defects.html#2367).
+// This causes compile errors in e.g. clang 3.5 or gcc 4.9.
+template <typename T>
+struct is_default_constructible : std::is_default_constructible<T> {};
+
+template <typename T1, typename T2>
+struct is_default_constructible<std::pair<T1, T2>>
+            : conjunction<is_default_constructible<T1>, is_default_constructible<T2>> {};
+
+template <typename T1, typename T2>
+struct is_default_constructible<const std::pair<T1, T2>>
+            : conjunction<is_default_constructible<T1>, is_default_constructible<T2>> {};
+
+template <typename... Ts>
+struct is_default_constructible<std::tuple<Ts...>>
+            : conjunction<is_default_constructible<Ts>...> {};
+
+template <typename... Ts>
+struct is_default_constructible<const std::tuple<Ts...>>
+            : conjunction<is_default_constructible<Ts>...> {};
+
+template <typename T, typename... Args>
+struct is_constructible : std::is_constructible<T, Args...> {};
+
+template <typename T1, typename T2>
+struct is_constructible<std::pair<T1, T2>> : is_default_constructible<std::pair<T1, T2>> {};
+
+template <typename T1, typename T2>
+struct is_constructible<const std::pair<T1, T2>> : is_default_constructible<const std::pair<T1, T2>> {};
+
+template <typename... Ts>
+struct is_constructible<std::tuple<Ts...>> : is_default_constructible<std::tuple<Ts...>> {};
+
+template <typename... Ts>
+struct is_constructible<const std::tuple<Ts...>> : is_default_constructible<const std::tuple<Ts...>> {};
+
+template<typename T, typename = void>
+struct is_iterator_traits : std::false_type {};
+
+template<typename T>
+struct is_iterator_traits<iterator_traits<T>>
+{
+  private:
+    using traits = iterator_traits<T>;
+
+  public:
+    static constexpr auto value =
+        is_detected<value_type_t, traits>::value &&
+        is_detected<difference_type_t, traits>::value &&
+        is_detected<pointer_t, traits>::value &&
+        is_detected<iterator_category_t, traits>::value &&
+        is_detected<reference_t, traits>::value;
+};
+
+template<typename T>
+struct is_range
+{
+  private:
+    using t_ref = typename std::add_lvalue_reference<T>::type;
+
+    using iterator = detected_t<result_of_begin, t_ref>;
+    using sentinel = detected_t<result_of_end, t_ref>;
+
+    // to be 100% correct, it should use https://en.cppreference.com/w/cpp/iterator/input_or_output_iterator
+    // and https://en.cppreference.com/w/cpp/iterator/sentinel_for
+    // but reimplementing these would be too much work, as a lot of other concepts are used underneath
+    static constexpr auto is_iterator_begin =
+        is_iterator_traits<iterator_traits<iterator>>::value;
+
+  public:
+    static constexpr bool value = !std::is_same<iterator, nonesuch>::value && !std::is_same<sentinel, nonesuch>::value && is_iterator_begin;
+};
+
+template<typename R>
+using iterator_t = enable_if_t<is_range<R>::value, result_of_begin<decltype(std::declval<R&>())>>;
+
+template<typename T>
+using range_value_t = value_type_t<iterator_traits<iterator_t<T>>>;
+
+// The following implementation of is_complete_type is taken from
+// https://blogs.msdn.microsoft.com/vcblog/2015/12/02/partial-support-for-expression-sfinae-in-vs-2015-update-1/
+// and is written by Xiang Fan who agreed to using it in this library.
+
+template<typename T, typename = void>
+struct is_complete_type : std::false_type {};
+
+template<typename T>
+struct is_complete_type<T, decltype(void(sizeof(T)))> : std::true_type {};
+
+template<typename BasicJsonType, typename CompatibleObjectType,
+         typename = void>
+struct is_compatible_object_type_impl : std::false_type {};
+
+template<typename BasicJsonType, typename CompatibleObjectType>
+struct is_compatible_object_type_impl <
+    BasicJsonType, CompatibleObjectType,
+    enable_if_t < is_detected<mapped_type_t, CompatibleObjectType>::value&&
+    is_detected<key_type_t, CompatibleObjectType>::value >>
+{
+    using object_t = typename BasicJsonType::object_t;
+
+    // macOS's is_constructible does not play well with nonesuch...
+    static constexpr bool value =
+        is_constructible<typename object_t::key_type,
+        typename CompatibleObjectType::key_type>::value &&
+        is_constructible<typename object_t::mapped_type,
+        typename CompatibleObjectType::mapped_type>::value;
+};
+
+template<typename BasicJsonType, typename CompatibleObjectType>
+struct is_compatible_object_type
+    : is_compatible_object_type_impl<BasicJsonType, CompatibleObjectType> {};
+
+template<typename BasicJsonType, typename ConstructibleObjectType,
+         typename = void>
+struct is_constructible_object_type_impl : std::false_type {};
+
+template<typename BasicJsonType, typename ConstructibleObjectType>
+struct is_constructible_object_type_impl <
+    BasicJsonType, ConstructibleObjectType,
+    enable_if_t < is_detected<mapped_type_t, ConstructibleObjectType>::value&&
+    is_detected<key_type_t, ConstructibleObjectType>::value >>
+{
+    using object_t = typename BasicJsonType::object_t;
+
+    static constexpr bool value =
+        (is_default_constructible<ConstructibleObjectType>::value &&
+         (std::is_move_assignable<ConstructibleObjectType>::value ||
+          std::is_copy_assignable<ConstructibleObjectType>::value) &&
+         (is_constructible<typename ConstructibleObjectType::key_type,
+          typename object_t::key_type>::value &&
+          std::is_same <
+          typename object_t::mapped_type,
+          typename ConstructibleObjectType::mapped_type >::value)) ||
+        (has_from_json<BasicJsonType,
+         typename ConstructibleObjectType::mapped_type>::value ||
+         has_non_default_from_json <
+         BasicJsonType,
+         typename ConstructibleObjectType::mapped_type >::value);
+};
+
+template<typename BasicJsonType, typename ConstructibleObjectType>
+struct is_constructible_object_type
+    : is_constructible_object_type_impl<BasicJsonType,
+      ConstructibleObjectType> {};
+
+template<typename BasicJsonType, typename CompatibleStringType>
+struct is_compatible_string_type
+{
+    static constexpr auto value =
+        is_constructible<typename BasicJsonType::string_t, CompatibleStringType>::value;
+};
+
+template<typename BasicJsonType, typename ConstructibleStringType>
+struct is_constructible_string_type
+{
+    // launder type through decltype() to fix compilation failure on ICPC
+#ifdef __INTEL_COMPILER
+    using laundered_type = decltype(std::declval<ConstructibleStringType>());
+#else
+    using laundered_type = ConstructibleStringType;
+#endif
+
+    static constexpr auto value =
+        conjunction <
+        is_constructible<laundered_type, typename BasicJsonType::string_t>,
+        is_detected_exact<typename BasicJsonType::string_t::value_type,
+        value_type_t, laundered_type >>::value;
+};
+
+template<typename BasicJsonType, typename CompatibleArrayType, typename = void>
+struct is_compatible_array_type_impl : std::false_type {};
+
+template<typename BasicJsonType, typename CompatibleArrayType>
+struct is_compatible_array_type_impl <
+    BasicJsonType, CompatibleArrayType,
+    enable_if_t <
+    is_detected<iterator_t, CompatibleArrayType>::value&&
+    is_iterator_traits<iterator_traits<detected_t<iterator_t, CompatibleArrayType>>>::value&&
+// special case for types like std::filesystem::path whose iterator's value_type are themselves
+// c.f. https://github.com/nlohmann/json/pull/3073
+    !std::is_same<CompatibleArrayType, detected_t<range_value_t, CompatibleArrayType>>::value >>
+{
+    static constexpr bool value =
+        is_constructible<BasicJsonType,
+        range_value_t<CompatibleArrayType>>::value;
+};
+
+template<typename BasicJsonType, typename CompatibleArrayType>
+struct is_compatible_array_type
+    : is_compatible_array_type_impl<BasicJsonType, CompatibleArrayType> {};
+
+template<typename BasicJsonType, typename ConstructibleArrayType, typename = void>
+struct is_constructible_array_type_impl : std::false_type {};
+
+template<typename BasicJsonType, typename ConstructibleArrayType>
+struct is_constructible_array_type_impl <
+    BasicJsonType, ConstructibleArrayType,
+    enable_if_t<std::is_same<ConstructibleArrayType,
+    typename BasicJsonType::value_type>::value >>
+            : std::true_type {};
+
+template<typename BasicJsonType, typename ConstructibleArrayType>
+struct is_constructible_array_type_impl <
+    BasicJsonType, ConstructibleArrayType,
+    enable_if_t < !std::is_same<ConstructibleArrayType,
+    typename BasicJsonType::value_type>::value&&
+    !is_compatible_string_type<BasicJsonType, ConstructibleArrayType>::value&&
+    is_default_constructible<ConstructibleArrayType>::value&&
+(std::is_move_assignable<ConstructibleArrayType>::value ||
+ std::is_copy_assignable<ConstructibleArrayType>::value)&&
+is_detected<iterator_t, ConstructibleArrayType>::value&&
+is_iterator_traits<iterator_traits<detected_t<iterator_t, ConstructibleArrayType>>>::value&&
+is_detected<range_value_t, ConstructibleArrayType>::value&&
+// special case for types like std::filesystem::path whose iterator's value_type are themselves
+// c.f. https://github.com/nlohmann/json/pull/3073
+!std::is_same<ConstructibleArrayType, detected_t<range_value_t, ConstructibleArrayType>>::value&&
+        is_complete_type <
+        detected_t<range_value_t, ConstructibleArrayType >>::value >>
+{
+    using value_type = range_value_t<ConstructibleArrayType>;
+
+    static constexpr bool value =
+        std::is_same<value_type,
+        typename BasicJsonType::array_t::value_type>::value ||
+        has_from_json<BasicJsonType,
+        value_type>::value ||
+        has_non_default_from_json <
+        BasicJsonType,
+        value_type >::value;
+};
+
+template<typename BasicJsonType, typename ConstructibleArrayType>
+struct is_constructible_array_type
+    : is_constructible_array_type_impl<BasicJsonType, ConstructibleArrayType> {};
+
+template<typename RealIntegerType, typename CompatibleNumberIntegerType,
+         typename = void>
+struct is_compatible_integer_type_impl : std::false_type {};
+
+template<typename RealIntegerType, typename CompatibleNumberIntegerType>
+struct is_compatible_integer_type_impl <
+    RealIntegerType, CompatibleNumberIntegerType,
+    enable_if_t < std::is_integral<RealIntegerType>::value&&
+    std::is_integral<CompatibleNumberIntegerType>::value&&
+    !std::is_same<bool, CompatibleNumberIntegerType>::value >>
+{
+    // is there an assert somewhere on overflows?
+    using RealLimits = std::numeric_limits<RealIntegerType>;
+    using CompatibleLimits = std::numeric_limits<CompatibleNumberIntegerType>;
+
+    static constexpr auto value =
+        is_constructible<RealIntegerType,
+        CompatibleNumberIntegerType>::value &&
+        CompatibleLimits::is_integer &&
+        RealLimits::is_signed == CompatibleLimits::is_signed;
+};
+
+template<typename RealIntegerType, typename CompatibleNumberIntegerType>
+struct is_compatible_integer_type
+    : is_compatible_integer_type_impl<RealIntegerType,
+      CompatibleNumberIntegerType> {};
+
+template<typename BasicJsonType, typename CompatibleType, typename = void>
+struct is_compatible_type_impl: std::false_type {};
+
+template<typename BasicJsonType, typename CompatibleType>
+struct is_compatible_type_impl <
+    BasicJsonType, CompatibleType,
+    enable_if_t<is_complete_type<CompatibleType>::value >>
+{
+    static constexpr bool value =
+        has_to_json<BasicJsonType, CompatibleType>::value;
+};
+
+template<typename BasicJsonType, typename CompatibleType>
+struct is_compatible_type
+    : is_compatible_type_impl<BasicJsonType, CompatibleType> {};
+
+template<typename T1, typename T2>
+struct is_constructible_tuple : std::false_type {};
+
+template<typename T1, typename... Args>
+struct is_constructible_tuple<T1, std::tuple<Args...>> : conjunction<is_constructible<T1, Args>...> {};
+
+template<typename BasicJsonType, typename T>
+struct is_json_iterator_of : std::false_type {};
+
+template<typename BasicJsonType>
+struct is_json_iterator_of<BasicJsonType, typename BasicJsonType::iterator> : std::true_type {};
+
+template<typename BasicJsonType>
+struct is_json_iterator_of<BasicJsonType, typename BasicJsonType::const_iterator> : std::true_type
+{};
+
+// checks if a given type T is a template specialization of Primary
+template<template <typename...> class Primary, typename T>
+struct is_specialization_of : std::false_type {};
+
+template<template <typename...> class Primary, typename... Args>
+struct is_specialization_of<Primary, Primary<Args...>> : std::true_type {};
+
+template<typename T>
+using is_json_pointer = is_specialization_of<::nlohmann::json_pointer, uncvref_t<T>>;
+
+// checks if A and B are comparable using Compare functor
+template<typename Compare, typename A, typename B, typename = void>
+struct is_comparable : std::false_type {};
+
+template<typename Compare, typename A, typename B>
+struct is_comparable<Compare, A, B, void_t<
+decltype(std::declval<Compare>()(std::declval<A>(), std::declval<B>())),
+decltype(std::declval<Compare>()(std::declval<B>(), std::declval<A>()))
+>> : std::true_type {};
+
+template<typename T>
+using detect_is_transparent = typename T::is_transparent;
+
+// type trait to check if KeyType can be used as object key (without a BasicJsonType)
+// see is_usable_as_basic_json_key_type below
+template<typename Comparator, typename ObjectKeyType, typename KeyTypeCVRef, bool RequireTransparentComparator = true,
+         bool ExcludeObjectKeyType = RequireTransparentComparator, typename KeyType = uncvref_t<KeyTypeCVRef>>
+using is_usable_as_key_type = typename std::conditional <
+                              is_comparable<Comparator, ObjectKeyType, KeyTypeCVRef>::value
+                              && !(ExcludeObjectKeyType && std::is_same<KeyType,
+                                   ObjectKeyType>::value)
+                              && (!RequireTransparentComparator
+                                  || is_detected <detect_is_transparent, Comparator>::value)
+                              && !is_json_pointer<KeyType>::value,
+                              std::true_type,
+                              std::false_type >::type;
+
+// type trait to check if KeyType can be used as object key
+// true if:
+//   - KeyType is comparable with BasicJsonType::object_t::key_type
+//   - if ExcludeObjectKeyType is true, KeyType is not BasicJsonType::object_t::key_type
+//   - the comparator is transparent or RequireTransparentComparator is false
+//   - KeyType is not a JSON iterator or json_pointer
+template<typename BasicJsonType, typename KeyTypeCVRef, bool RequireTransparentComparator = true,
+         bool ExcludeObjectKeyType = RequireTransparentComparator, typename KeyType = uncvref_t<KeyTypeCVRef>>
+using is_usable_as_basic_json_key_type = typename std::conditional <
+        is_usable_as_key_type<typename BasicJsonType::object_comparator_t,
+        typename BasicJsonType::object_t::key_type, KeyTypeCVRef,
+        RequireTransparentComparator, ExcludeObjectKeyType>::value
+        && !is_json_iterator_of<BasicJsonType, KeyType>::value,
+        std::true_type,
+        std::false_type >::type;
+
+template<typename ObjectType, typename KeyType>
+using detect_erase_with_key_type = decltype(std::declval<ObjectType&>().erase(std::declval<KeyType>()));
+
+// type trait to check if object_t has an erase() member functions accepting KeyType
+template<typename BasicJsonType, typename KeyType>
+using has_erase_with_key_type = typename std::conditional <
+                                is_detected <
+                                detect_erase_with_key_type,
+                                typename BasicJsonType::object_t, KeyType >::value,
+                                std::true_type,
+                                std::false_type >::type;
+
+// a naive helper to check if a type is an ordered_map (exploits the fact that
+// ordered_map inherits capacity() from std::vector)
+template <typename T>
+struct is_ordered_map
+{
+    using one = char;
+
+    struct two
+    {
+        char x[2]; // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+    };
+
+    template <typename C> static one test( decltype(&C::capacity) ) ;
+    template <typename C> static two test(...);
+
+    enum { value = sizeof(test<T>(nullptr)) == sizeof(char) }; // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+};
+
+// to avoid useless casts (see https://github.com/nlohmann/json/issues/2893#issuecomment-889152324)
+template < typename T, typename U, enable_if_t < !std::is_same<T, U>::value, int > = 0 >
+T conditional_static_cast(U value)
+{
+    return static_cast<T>(value);
+}
+
+template<typename T, typename U, enable_if_t<std::is_same<T, U>::value, int> = 0>
+T conditional_static_cast(U value)
+{
+    return value;
+}
+
+template<typename... Types>
+using all_integral = conjunction<std::is_integral<Types>...>;
+
+template<typename... Types>
+using all_signed = conjunction<std::is_signed<Types>...>;
+
+template<typename... Types>
+using all_unsigned = conjunction<std::is_unsigned<Types>...>;
+
+// there's a disjunction trait in another PR; replace when merged
+template<typename... Types>
+using same_sign = std::integral_constant < bool,
+      all_signed<Types...>::value || all_unsigned<Types...>::value >;
+
+template<typename OfType, typename T>
+using never_out_of_range = std::integral_constant < bool,
+      (std::is_signed<OfType>::value && (sizeof(T) < sizeof(OfType)))
+      || (same_sign<OfType, T>::value && sizeof(OfType) == sizeof(T)) >;
+
+template<typename OfType, typename T,
+         bool OfTypeSigned = std::is_signed<OfType>::value,
+         bool TSigned = std::is_signed<T>::value>
+struct value_in_range_of_impl2;
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, false, false>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return static_cast<CommonType>(val) <= static_cast<CommonType>((std::numeric_limits<OfType>::max)());
+    }
+};
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, true, false>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return static_cast<CommonType>(val) <= static_cast<CommonType>((std::numeric_limits<OfType>::max)());
+    }
+};
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, false, true>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return val >= 0 && static_cast<CommonType>(val) <= static_cast<CommonType>((std::numeric_limits<OfType>::max)());
+    }
+};
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl2<OfType, T, true, true>
+{
+    static constexpr bool test(T val)
+    {
+        using CommonType = typename std::common_type<OfType, T>::type;
+        return static_cast<CommonType>(val) >= static_cast<CommonType>((std::numeric_limits<OfType>::min)())
+               && static_cast<CommonType>(val) <= static_cast<CommonType>((std::numeric_limits<OfType>::max)());
+    }
+};
+
+template<typename OfType, typename T,
+         bool NeverOutOfRange = never_out_of_range<OfType, T>::value,
+         typename = detail::enable_if_t<all_integral<OfType, T>::value>>
+struct value_in_range_of_impl1;
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl1<OfType, T, false>
+{
+    static constexpr bool test(T val)
+    {
+        return value_in_range_of_impl2<OfType, T>::test(val);
+    }
+};
+
+template<typename OfType, typename T>
+struct value_in_range_of_impl1<OfType, T, true>
+{
+    static constexpr bool test(T /*val*/)
+    {
+        return true;
+    }
+};
+
+template<typename OfType, typename T>
+inline constexpr bool value_in_range_of(T val)
+{
+    return value_in_range_of_impl1<OfType, T>::test(val);
+}
+
+template<bool Value>
+using bool_constant = std::integral_constant<bool, Value>;
+
+///////////////////////////////////////////////////////////////////////////////
+// is_c_string
+///////////////////////////////////////////////////////////////////////////////
+
+namespace impl
+{
+
+template<typename T>
+inline constexpr bool is_c_string()
+{
+    using TUnExt = typename std::remove_extent<T>::type;
+    using TUnCVExt = typename std::remove_cv<TUnExt>::type;
+    using TUnPtr = typename std::remove_pointer<T>::type;
+    using TUnCVPtr = typename std::remove_cv<TUnPtr>::type;
+    return
+        (std::is_array<T>::value && std::is_same<TUnCVExt, char>::value)
+        || (std::is_pointer<T>::value && std::is_same<TUnCVPtr, char>::value);
+}
+
+}  // namespace impl
+
+// checks whether T is a [cv] char */[cv] char[] C string
+template<typename T>
+struct is_c_string : bool_constant<impl::is_c_string<T>()> {};
+
+template<typename T>
+using is_c_string_uncvref = is_c_string<uncvref_t<T>>;
+
+///////////////////////////////////////////////////////////////////////////////
+// is_transparent
+///////////////////////////////////////////////////////////////////////////////
+
+namespace impl
+{
+
+template<typename T>
+inline constexpr bool is_transparent()
+{
+    return is_detected<detect_is_transparent, T>::value;
+}
+
+}  // namespace impl
+
+// checks whether T has a member named is_transparent
+template<typename T>
+struct is_transparent : bool_constant<impl::is_transparent<T>()> {};
+
+///////////////////////////////////////////////////////////////////////////////
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/string_concat.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cstring> // strlen
+#include <string> // string
+#include <utility> // forward
+
+// #include <nlohmann/detail/meta/cpp_future.hpp>
+
+// #include <nlohmann/detail/meta/detected.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+inline std::size_t concat_length()
+{
+    return 0;
+}
+
+template<typename... Args>
+inline std::size_t concat_length(const char* cstr, const Args& ... rest);
+
+template<typename StringType, typename... Args>
+inline std::size_t concat_length(const StringType& str, const Args& ... rest);
+
+template<typename... Args>
+inline std::size_t concat_length(const char /*c*/, const Args& ... rest)
+{
+    return 1 + concat_length(rest...);
+}
+
+template<typename... Args>
+inline std::size_t concat_length(const char* cstr, const Args& ... rest)
+{
+    // cppcheck-suppress ignoredReturnValue
+    return ::strlen(cstr) + concat_length(rest...);
+}
+
+template<typename StringType, typename... Args>
+inline std::size_t concat_length(const StringType& str, const Args& ... rest)
+{
+    return str.size() + concat_length(rest...);
+}
+
+template<typename OutStringType>
+inline void concat_into(OutStringType& /*out*/)
+{}
+
+template<typename StringType, typename Arg>
+using string_can_append = decltype(std::declval<StringType&>().append(std::declval < Arg && > ()));
+
+template<typename StringType, typename Arg>
+using detect_string_can_append = is_detected<string_can_append, StringType, Arg>;
+
+template<typename StringType, typename Arg>
+using string_can_append_op = decltype(std::declval<StringType&>() += std::declval < Arg && > ());
+
+template<typename StringType, typename Arg>
+using detect_string_can_append_op = is_detected<string_can_append_op, StringType, Arg>;
+
+template<typename StringType, typename Arg>
+using string_can_append_iter = decltype(std::declval<StringType&>().append(std::declval<const Arg&>().begin(), std::declval<const Arg&>().end()));
+
+template<typename StringType, typename Arg>
+using detect_string_can_append_iter = is_detected<string_can_append_iter, StringType, Arg>;
+
+template<typename StringType, typename Arg>
+using string_can_append_data = decltype(std::declval<StringType&>().append(std::declval<const Arg&>().data(), std::declval<const Arg&>().size()));
+
+template<typename StringType, typename Arg>
+using detect_string_can_append_data = is_detected<string_can_append_data, StringType, Arg>;
+
+template < typename OutStringType, typename Arg, typename... Args,
+           enable_if_t < !detect_string_can_append<OutStringType, Arg>::value
+                         && detect_string_can_append_op<OutStringType, Arg>::value, int > = 0 >
+inline void concat_into(OutStringType& out, Arg && arg, Args && ... rest);
+
+template < typename OutStringType, typename Arg, typename... Args,
+           enable_if_t < !detect_string_can_append<OutStringType, Arg>::value
+                         && !detect_string_can_append_op<OutStringType, Arg>::value
+                         && detect_string_can_append_iter<OutStringType, Arg>::value, int > = 0 >
+inline void concat_into(OutStringType& out, const Arg& arg, Args && ... rest);
+
+template < typename OutStringType, typename Arg, typename... Args,
+           enable_if_t < !detect_string_can_append<OutStringType, Arg>::value
+                         && !detect_string_can_append_op<OutStringType, Arg>::value
+                         && !detect_string_can_append_iter<OutStringType, Arg>::value
+                         && detect_string_can_append_data<OutStringType, Arg>::value, int > = 0 >
+inline void concat_into(OutStringType& out, const Arg& arg, Args && ... rest);
+
+template<typename OutStringType, typename Arg, typename... Args,
+         enable_if_t<detect_string_can_append<OutStringType, Arg>::value, int> = 0>
+inline void concat_into(OutStringType& out, Arg && arg, Args && ... rest)
+{
+    out.append(std::forward<Arg>(arg));
+    concat_into(out, std::forward<Args>(rest)...);
+}
+
+template < typename OutStringType, typename Arg, typename... Args,
+           enable_if_t < !detect_string_can_append<OutStringType, Arg>::value
+                         && detect_string_can_append_op<OutStringType, Arg>::value, int > >
+inline void concat_into(OutStringType& out, Arg&& arg, Args&& ... rest)
+{
+    out += std::forward<Arg>(arg);
+    concat_into(out, std::forward<Args>(rest)...);
+}
+
+template < typename OutStringType, typename Arg, typename... Args,
+           enable_if_t < !detect_string_can_append<OutStringType, Arg>::value
+                         && !detect_string_can_append_op<OutStringType, Arg>::value
+                         && detect_string_can_append_iter<OutStringType, Arg>::value, int > >
+inline void concat_into(OutStringType& out, const Arg& arg, Args&& ... rest)
+{
+    out.append(arg.begin(), arg.end());
+    concat_into(out, std::forward<Args>(rest)...);
+}
+
+template < typename OutStringType, typename Arg, typename... Args,
+           enable_if_t < !detect_string_can_append<OutStringType, Arg>::value
+                         && !detect_string_can_append_op<OutStringType, Arg>::value
+                         && !detect_string_can_append_iter<OutStringType, Arg>::value
+                         && detect_string_can_append_data<OutStringType, Arg>::value, int > >
+inline void concat_into(OutStringType& out, const Arg& arg, Args&& ... rest)
+{
+    out.append(arg.data(), arg.size());
+    concat_into(out, std::forward<Args>(rest)...);
+}
+
+template<typename OutStringType = std::string, typename... Args>
+inline OutStringType concat(Args && ... args)
+{
+    OutStringType str;
+    str.reserve(concat_length(args...));
+    concat_into(str, std::forward<Args>(args)...);
+    return str;
+}
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+////////////////
+// exceptions //
+////////////////
+
+/// @brief general exception of the @ref basic_json class
+/// @sa https://json.nlohmann.me/api/basic_json/exception/
+class exception : public std::exception
+{
+  public:
+    /// returns the explanatory string
+    const char* what() const noexcept override
+    {
+        return m.what();
+    }
+
+    /// the id of the exception
+    const int id; // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+
+  protected:
+    JSON_HEDLEY_NON_NULL(3)
+    exception(int id_, const char* what_arg) : id(id_), m(what_arg) {} // NOLINT(bugprone-throw-keyword-missing)
+
+    static std::string name(const std::string& ename, int id_)
+    {
+        return concat("[json.exception.", ename, '.', std::to_string(id_), "] ");
+    }
+
+    static std::string diagnostics(std::nullptr_t /*leaf_element*/)
+    {
+        return "";
+    }
+
+    template<typename BasicJsonType>
+    static std::string diagnostics(const BasicJsonType* leaf_element)
+    {
+#if JSON_DIAGNOSTICS
+        std::vector<std::string> tokens;
+        for (const auto* current = leaf_element; current != nullptr && current->m_parent != nullptr; current = current->m_parent)
+        {
+            switch (current->m_parent->type())
+            {
+                case value_t::array:
+                {
+                    for (std::size_t i = 0; i < current->m_parent->m_data.m_value.array->size(); ++i)
+                    {
+                        if (&current->m_parent->m_data.m_value.array->operator[](i) == current)
+                        {
+                            tokens.emplace_back(std::to_string(i));
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                case value_t::object:
+                {
+                    for (const auto& element : *current->m_parent->m_data.m_value.object)
+                    {
+                        if (&element.second == current)
+                        {
+                            tokens.emplace_back(element.first.c_str());
+                            break;
+                        }
+                    }
+                    break;
+                }
+
+                case value_t::null: // LCOV_EXCL_LINE
+                case value_t::string: // LCOV_EXCL_LINE
+                case value_t::boolean: // LCOV_EXCL_LINE
+                case value_t::number_integer: // LCOV_EXCL_LINE
+                case value_t::number_unsigned: // LCOV_EXCL_LINE
+                case value_t::number_float: // LCOV_EXCL_LINE
+                case value_t::binary: // LCOV_EXCL_LINE
+                case value_t::discarded: // LCOV_EXCL_LINE
+                default:   // LCOV_EXCL_LINE
+                    break; // LCOV_EXCL_LINE
+            }
+        }
+
+        if (tokens.empty())
+        {
+            return "";
+        }
+
+        auto str = std::accumulate(tokens.rbegin(), tokens.rend(), std::string{},
+                                   [](const std::string & a, const std::string & b)
+        {
+            return concat(a, '/', detail::escape(b));
+        });
+        return concat('(', str, ") ");
+#else
+        static_cast<void>(leaf_element);
+        return "";
+#endif
+    }
+
+  private:
+    /// an exception object as storage for error messages
+    std::runtime_error m;
+};
+
+/// @brief exception indicating a parse error
+/// @sa https://json.nlohmann.me/api/basic_json/parse_error/
+class parse_error : public exception
+{
+  public:
+    /*!
+    @brief create a parse error exception
+    @param[in] id_       the id of the exception
+    @param[in] pos       the position where the error occurred (or with
+                         chars_read_total=0 if the position cannot be
+                         determined)
+    @param[in] what_arg  the explanatory string
+    @return parse_error object
+    */
+    template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
+    static parse_error create(int id_, const position_t& pos, const std::string& what_arg, BasicJsonContext context)
+    {
+        const std::string w = concat(exception::name("parse_error", id_), "parse error",
+                                     position_string(pos), ": ", exception::diagnostics(context), what_arg);
+        return {id_, pos.chars_read_total, w.c_str()};
+    }
+
+    template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
+    static parse_error create(int id_, std::size_t byte_, const std::string& what_arg, BasicJsonContext context)
+    {
+        const std::string w = concat(exception::name("parse_error", id_), "parse error",
+                                     (byte_ != 0 ? (concat(" at byte ", std::to_string(byte_))) : ""),
+                                     ": ", exception::diagnostics(context), what_arg);
+        return {id_, byte_, w.c_str()};
+    }
+
+    /*!
+    @brief byte index of the parse error
+
+    The byte index of the last read character in the input file.
+
+    @note For an input with n bytes, 1 is the index of the first character and
+          n+1 is the index of the terminating null byte or the end of file.
+          This also holds true when reading a byte vector (CBOR or MessagePack).
+    */
+    const std::size_t byte;
+
+  private:
+    parse_error(int id_, std::size_t byte_, const char* what_arg)
+        : exception(id_, what_arg), byte(byte_) {}
+
+    static std::string position_string(const position_t& pos)
+    {
+        return concat(" at line ", std::to_string(pos.lines_read + 1),
+                      ", column ", std::to_string(pos.chars_read_current_line));
+    }
+};
+
+/// @brief exception indicating errors with iterators
+/// @sa https://json.nlohmann.me/api/basic_json/invalid_iterator/
+class invalid_iterator : public exception
+{
+  public:
+    template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
+    static invalid_iterator create(int id_, const std::string& what_arg, BasicJsonContext context)
+    {
+        const std::string w = concat(exception::name("invalid_iterator", id_), exception::diagnostics(context), what_arg);
+        return {id_, w.c_str()};
+    }
+
+  private:
+    JSON_HEDLEY_NON_NULL(3)
+    invalid_iterator(int id_, const char* what_arg)
+        : exception(id_, what_arg) {}
+};
+
+/// @brief exception indicating executing a member function with a wrong type
+/// @sa https://json.nlohmann.me/api/basic_json/type_error/
+class type_error : public exception
+{
+  public:
+    template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
+    static type_error create(int id_, const std::string& what_arg, BasicJsonContext context)
+    {
+        const std::string w = concat(exception::name("type_error", id_), exception::diagnostics(context), what_arg);
+        return {id_, w.c_str()};
+    }
+
+  private:
+    JSON_HEDLEY_NON_NULL(3)
+    type_error(int id_, const char* what_arg) : exception(id_, what_arg) {}
+};
+
+/// @brief exception indicating access out of the defined range
+/// @sa https://json.nlohmann.me/api/basic_json/out_of_range/
+class out_of_range : public exception
+{
+  public:
+    template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
+    static out_of_range create(int id_, const std::string& what_arg, BasicJsonContext context)
+    {
+        const std::string w = concat(exception::name("out_of_range", id_), exception::diagnostics(context), what_arg);
+        return {id_, w.c_str()};
+    }
+
+  private:
+    JSON_HEDLEY_NON_NULL(3)
+    out_of_range(int id_, const char* what_arg) : exception(id_, what_arg) {}
+};
+
+/// @brief exception indicating other library errors
+/// @sa https://json.nlohmann.me/api/basic_json/other_error/
+class other_error : public exception
+{
+  public:
+    template<typename BasicJsonContext, enable_if_t<is_basic_json_context<BasicJsonContext>::value, int> = 0>
+    static other_error create(int id_, const std::string& what_arg, BasicJsonContext context)
+    {
+        const std::string w = concat(exception::name("other_error", id_), exception::diagnostics(context), what_arg);
+        return {id_, w.c_str()};
+    }
+
+  private:
+    JSON_HEDLEY_NON_NULL(3)
+    other_error(int id_, const char* what_arg) : exception(id_, what_arg) {}
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/cpp_future.hpp>
+
+// #include <nlohmann/detail/meta/identity_tag.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+// dispatching helper struct
+template <class T> struct identity_tag {};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/meta/std_fs.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+
+#if JSON_HAS_EXPERIMENTAL_FILESYSTEM
+#include <experimental/filesystem>
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+namespace std_fs = std::experimental::filesystem;
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+#elif JSON_HAS_FILESYSTEM
+#include <filesystem>
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+namespace std_fs = std::filesystem;
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+#endif
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+// #include <nlohmann/detail/string_concat.hpp>
+
+// #include <nlohmann/detail/value_t.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+template<typename BasicJsonType>
+inline void from_json(const BasicJsonType& j, typename std::nullptr_t& n)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_null()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be null, but is ", j.type_name()), &j));
+    }
+    n = nullptr;
+}
+
+// overloads for basic_json template parameters
+template < typename BasicJsonType, typename ArithmeticType,
+           enable_if_t < std::is_arithmetic<ArithmeticType>::value&&
+                         !std::is_same<ArithmeticType, typename BasicJsonType::boolean_t>::value,
+                         int > = 0 >
+void get_arithmetic_value(const BasicJsonType& j, ArithmeticType& val)
+{
+    switch (static_cast<value_t>(j))
+    {
+        case value_t::number_unsigned:
+        {
+            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>());
+            break;
+        }
+        case value_t::number_integer:
+        {
+            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t*>());
+            break;
+        }
+        case value_t::number_float:
+        {
+            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
+            break;
+        }
+
+        case value_t::null:
+        case value_t::object:
+        case value_t::array:
+        case value_t::string:
+        case value_t::boolean:
+        case value_t::binary:
+        case value_t::discarded:
+        default:
+            JSON_THROW(type_error::create(302, concat("type must be number, but is ", j.type_name()), &j));
+    }
+}
+
+template<typename BasicJsonType>
+inline void from_json(const BasicJsonType& j, typename BasicJsonType::boolean_t& b)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_boolean()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be boolean, but is ", j.type_name()), &j));
+    }
+    b = *j.template get_ptr<const typename BasicJsonType::boolean_t*>();
+}
+
+template<typename BasicJsonType>
+inline void from_json(const BasicJsonType& j, typename BasicJsonType::string_t& s)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_string()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be string, but is ", j.type_name()), &j));
+    }
+    s = *j.template get_ptr<const typename BasicJsonType::string_t*>();
+}
+
+template <
+    typename BasicJsonType, typename StringType,
+    enable_if_t <
+        std::is_assignable<StringType&, const typename BasicJsonType::string_t>::value
+        && is_detected_exact<typename BasicJsonType::string_t::value_type, value_type_t, StringType>::value
+        && !std::is_same<typename BasicJsonType::string_t, StringType>::value
+        && !is_json_ref<StringType>::value, int > = 0 >
+inline void from_json(const BasicJsonType& j, StringType& s)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_string()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be string, but is ", j.type_name()), &j));
+    }
+
+    s = *j.template get_ptr<const typename BasicJsonType::string_t*>();
+}
+
+template<typename BasicJsonType>
+inline void from_json(const BasicJsonType& j, typename BasicJsonType::number_float_t& val)
+{
+    get_arithmetic_value(j, val);
+}
+
+template<typename BasicJsonType>
+inline void from_json(const BasicJsonType& j, typename BasicJsonType::number_unsigned_t& val)
+{
+    get_arithmetic_value(j, val);
+}
+
+template<typename BasicJsonType>
+inline void from_json(const BasicJsonType& j, typename BasicJsonType::number_integer_t& val)
+{
+    get_arithmetic_value(j, val);
+}
+
+#if !JSON_DISABLE_ENUM_SERIALIZATION
+template<typename BasicJsonType, typename EnumType,
+         enable_if_t<std::is_enum<EnumType>::value, int> = 0>
+inline void from_json(const BasicJsonType& j, EnumType& e)
+{
+    typename std::underlying_type<EnumType>::type val;
+    get_arithmetic_value(j, val);
+    e = static_cast<EnumType>(val);
+}
+#endif  // JSON_DISABLE_ENUM_SERIALIZATION
+
+// forward_list doesn't have an insert method
+template<typename BasicJsonType, typename T, typename Allocator,
+         enable_if_t<is_getable<BasicJsonType, T>::value, int> = 0>
+inline void from_json(const BasicJsonType& j, std::forward_list<T, Allocator>& l)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_array()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be array, but is ", j.type_name()), &j));
+    }
+    l.clear();
+    std::transform(j.rbegin(), j.rend(),
+                   std::front_inserter(l), [](const BasicJsonType & i)
+    {
+        return i.template get<T>();
+    });
+}
+
+// valarray doesn't have an insert method
+template<typename BasicJsonType, typename T,
+         enable_if_t<is_getable<BasicJsonType, T>::value, int> = 0>
+inline void from_json(const BasicJsonType& j, std::valarray<T>& l)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_array()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be array, but is ", j.type_name()), &j));
+    }
+    l.resize(j.size());
+    std::transform(j.begin(), j.end(), std::begin(l),
+                   [](const BasicJsonType & elem)
+    {
+        return elem.template get<T>();
+    });
+}
+
+template<typename BasicJsonType, typename T, std::size_t N>
+auto from_json(const BasicJsonType& j, T (&arr)[N])  // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+-> decltype(j.template get<T>(), void())
+{
+    for (std::size_t i = 0; i < N; ++i)
+    {
+        arr[i] = j.at(i).template get<T>();
+    }
+}
+
+template<typename BasicJsonType>
+inline void from_json_array_impl(const BasicJsonType& j, typename BasicJsonType::array_t& arr, priority_tag<3> /*unused*/)
+{
+    arr = *j.template get_ptr<const typename BasicJsonType::array_t*>();
+}
+
+template<typename BasicJsonType, typename T, std::size_t N>
+auto from_json_array_impl(const BasicJsonType& j, std::array<T, N>& arr,
+                          priority_tag<2> /*unused*/)
+-> decltype(j.template get<T>(), void())
+{
+    for (std::size_t i = 0; i < N; ++i)
+    {
+        arr[i] = j.at(i).template get<T>();
+    }
+}
+
+template<typename BasicJsonType, typename ConstructibleArrayType,
+         enable_if_t<
+             std::is_assignable<ConstructibleArrayType&, ConstructibleArrayType>::value,
+             int> = 0>
+auto from_json_array_impl(const BasicJsonType& j, ConstructibleArrayType& arr, priority_tag<1> /*unused*/)
+-> decltype(
+    arr.reserve(std::declval<typename ConstructibleArrayType::size_type>()),
+    j.template get<typename ConstructibleArrayType::value_type>(),
+    void())
+{
+    using std::end;
+
+    ConstructibleArrayType ret;
+    ret.reserve(j.size());
+    std::transform(j.begin(), j.end(),
+                   std::inserter(ret, end(ret)), [](const BasicJsonType & i)
+    {
+        // get<BasicJsonType>() returns *this, this won't call a from_json
+        // method when value_type is BasicJsonType
+        return i.template get<typename ConstructibleArrayType::value_type>();
+    });
+    arr = std::move(ret);
+}
+
+template<typename BasicJsonType, typename ConstructibleArrayType,
+         enable_if_t<
+             std::is_assignable<ConstructibleArrayType&, ConstructibleArrayType>::value,
+             int> = 0>
+inline void from_json_array_impl(const BasicJsonType& j, ConstructibleArrayType& arr,
+                                 priority_tag<0> /*unused*/)
+{
+    using std::end;
+
+    ConstructibleArrayType ret;
+    std::transform(
+        j.begin(), j.end(), std::inserter(ret, end(ret)),
+        [](const BasicJsonType & i)
+    {
+        // get<BasicJsonType>() returns *this, this won't call a from_json
+        // method when value_type is BasicJsonType
+        return i.template get<typename ConstructibleArrayType::value_type>();
+    });
+    arr = std::move(ret);
+}
+
+template < typename BasicJsonType, typename ConstructibleArrayType,
+           enable_if_t <
+               is_constructible_array_type<BasicJsonType, ConstructibleArrayType>::value&&
+               !is_constructible_object_type<BasicJsonType, ConstructibleArrayType>::value&&
+               !is_constructible_string_type<BasicJsonType, ConstructibleArrayType>::value&&
+               !std::is_same<ConstructibleArrayType, typename BasicJsonType::binary_t>::value&&
+               !is_basic_json<ConstructibleArrayType>::value,
+               int > = 0 >
+auto from_json(const BasicJsonType& j, ConstructibleArrayType& arr)
+-> decltype(from_json_array_impl(j, arr, priority_tag<3> {}),
+j.template get<typename ConstructibleArrayType::value_type>(),
+void())
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_array()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be array, but is ", j.type_name()), &j));
+    }
+
+    from_json_array_impl(j, arr, priority_tag<3> {});
+}
+
+template < typename BasicJsonType, typename T, std::size_t... Idx >
+std::array<T, sizeof...(Idx)> from_json_inplace_array_impl(BasicJsonType&& j,
+        identity_tag<std::array<T, sizeof...(Idx)>> /*unused*/, index_sequence<Idx...> /*unused*/)
+{
+    return { { std::forward<BasicJsonType>(j).at(Idx).template get<T>()... } };
+}
+
+template < typename BasicJsonType, typename T, std::size_t N >
+auto from_json(BasicJsonType&& j, identity_tag<std::array<T, N>> tag)
+-> decltype(from_json_inplace_array_impl(std::forward<BasicJsonType>(j), tag, make_index_sequence<N> {}))
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_array()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be array, but is ", j.type_name()), &j));
+    }
+
+    return from_json_inplace_array_impl(std::forward<BasicJsonType>(j), tag, make_index_sequence<N> {});
+}
+
+template<typename BasicJsonType>
+inline void from_json(const BasicJsonType& j, typename BasicJsonType::binary_t& bin)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_binary()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be binary, but is ", j.type_name()), &j));
+    }
+
+    bin = *j.template get_ptr<const typename BasicJsonType::binary_t*>();
+}
+
+template<typename BasicJsonType, typename ConstructibleObjectType,
+         enable_if_t<is_constructible_object_type<BasicJsonType, ConstructibleObjectType>::value, int> = 0>
+inline void from_json(const BasicJsonType& j, ConstructibleObjectType& obj)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_object()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be object, but is ", j.type_name()), &j));
+    }
+
+    ConstructibleObjectType ret;
+    const auto* inner_object = j.template get_ptr<const typename BasicJsonType::object_t*>();
+    using value_type = typename ConstructibleObjectType::value_type;
+    std::transform(
+        inner_object->begin(), inner_object->end(),
+        std::inserter(ret, ret.begin()),
+        [](typename BasicJsonType::object_t::value_type const & p)
+    {
+        return value_type(p.first, p.second.template get<typename ConstructibleObjectType::mapped_type>());
+    });
+    obj = std::move(ret);
+}
+
+// overload for arithmetic types, not chosen for basic_json template arguments
+// (BooleanType, etc..); note: Is it really necessary to provide explicit
+// overloads for boolean_t etc. in case of a custom BooleanType which is not
+// an arithmetic type?
+template < typename BasicJsonType, typename ArithmeticType,
+           enable_if_t <
+               std::is_arithmetic<ArithmeticType>::value&&
+               !std::is_same<ArithmeticType, typename BasicJsonType::number_unsigned_t>::value&&
+               !std::is_same<ArithmeticType, typename BasicJsonType::number_integer_t>::value&&
+               !std::is_same<ArithmeticType, typename BasicJsonType::number_float_t>::value&&
+               !std::is_same<ArithmeticType, typename BasicJsonType::boolean_t>::value,
+               int > = 0 >
+inline void from_json(const BasicJsonType& j, ArithmeticType& val)
+{
+    switch (static_cast<value_t>(j))
+    {
+        case value_t::number_unsigned:
+        {
+            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_unsigned_t*>());
+            break;
+        }
+        case value_t::number_integer:
+        {
+            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_integer_t*>());
+            break;
+        }
+        case value_t::number_float:
+        {
+            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::number_float_t*>());
+            break;
+        }
+        case value_t::boolean:
+        {
+            val = static_cast<ArithmeticType>(*j.template get_ptr<const typename BasicJsonType::boolean_t*>());
+            break;
+        }
+
+        case value_t::null:
+        case value_t::object:
+        case value_t::array:
+        case value_t::string:
+        case value_t::binary:
+        case value_t::discarded:
+        default:
+            JSON_THROW(type_error::create(302, concat("type must be number, but is ", j.type_name()), &j));
+    }
+}
+
+template<typename BasicJsonType, typename... Args, std::size_t... Idx>
+std::tuple<Args...> from_json_tuple_impl_base(BasicJsonType&& j, index_sequence<Idx...> /*unused*/)
+{
+    return std::make_tuple(std::forward<BasicJsonType>(j).at(Idx).template get<Args>()...);
+}
+
+template < typename BasicJsonType, class A1, class A2 >
+std::pair<A1, A2> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::pair<A1, A2>> /*unused*/, priority_tag<0> /*unused*/)
+{
+    return {std::forward<BasicJsonType>(j).at(0).template get<A1>(),
+            std::forward<BasicJsonType>(j).at(1).template get<A2>()};
+}
+
+template<typename BasicJsonType, typename A1, typename A2>
+inline void from_json_tuple_impl(BasicJsonType&& j, std::pair<A1, A2>& p, priority_tag<1> /*unused*/)
+{
+    p = from_json_tuple_impl(std::forward<BasicJsonType>(j), identity_tag<std::pair<A1, A2>> {}, priority_tag<0> {});
+}
+
+template<typename BasicJsonType, typename... Args>
+std::tuple<Args...> from_json_tuple_impl(BasicJsonType&& j, identity_tag<std::tuple<Args...>> /*unused*/, priority_tag<2> /*unused*/)
+{
+    return from_json_tuple_impl_base<BasicJsonType, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+}
+
+template<typename BasicJsonType, typename... Args>
+inline void from_json_tuple_impl(BasicJsonType&& j, std::tuple<Args...>& t, priority_tag<3> /*unused*/)
+{
+    t = from_json_tuple_impl_base<BasicJsonType, Args...>(std::forward<BasicJsonType>(j), index_sequence_for<Args...> {});
+}
+
+template<typename BasicJsonType, typename TupleRelated>
+auto from_json(BasicJsonType&& j, TupleRelated&& t)
+-> decltype(from_json_tuple_impl(std::forward<BasicJsonType>(j), std::forward<TupleRelated>(t), priority_tag<3> {}))
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_array()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be array, but is ", j.type_name()), &j));
+    }
+
+    return from_json_tuple_impl(std::forward<BasicJsonType>(j), std::forward<TupleRelated>(t), priority_tag<3> {});
+}
+
+template < typename BasicJsonType, typename Key, typename Value, typename Compare, typename Allocator,
+           typename = enable_if_t < !std::is_constructible <
+                                        typename BasicJsonType::string_t, Key >::value >>
+inline void from_json(const BasicJsonType& j, std::map<Key, Value, Compare, Allocator>& m)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_array()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be array, but is ", j.type_name()), &j));
+    }
+    m.clear();
+    for (const auto& p : j)
+    {
+        if (JSON_HEDLEY_UNLIKELY(!p.is_array()))
+        {
+            JSON_THROW(type_error::create(302, concat("type must be array, but is ", p.type_name()), &j));
+        }
+        m.emplace(p.at(0).template get<Key>(), p.at(1).template get<Value>());
+    }
+}
+
+template < typename BasicJsonType, typename Key, typename Value, typename Hash, typename KeyEqual, typename Allocator,
+           typename = enable_if_t < !std::is_constructible <
+                                        typename BasicJsonType::string_t, Key >::value >>
+inline void from_json(const BasicJsonType& j, std::unordered_map<Key, Value, Hash, KeyEqual, Allocator>& m)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_array()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be array, but is ", j.type_name()), &j));
+    }
+    m.clear();
+    for (const auto& p : j)
+    {
+        if (JSON_HEDLEY_UNLIKELY(!p.is_array()))
+        {
+            JSON_THROW(type_error::create(302, concat("type must be array, but is ", p.type_name()), &j));
+        }
+        m.emplace(p.at(0).template get<Key>(), p.at(1).template get<Value>());
+    }
+}
+
+#if JSON_HAS_FILESYSTEM || JSON_HAS_EXPERIMENTAL_FILESYSTEM
+template<typename BasicJsonType>
+inline void from_json(const BasicJsonType& j, std_fs::path& p)
+{
+    if (JSON_HEDLEY_UNLIKELY(!j.is_string()))
+    {
+        JSON_THROW(type_error::create(302, concat("type must be string, but is ", j.type_name()), &j));
+    }
+    p = *j.template get_ptr<const typename BasicJsonType::string_t*>();
+}
+#endif
+
+struct from_json_fn
+{
+    template<typename BasicJsonType, typename T>
+    auto operator()(const BasicJsonType& j, T&& val) const
+    noexcept(noexcept(from_json(j, std::forward<T>(val))))
+    -> decltype(from_json(j, std::forward<T>(val)))
+    {
+        return from_json(j, std::forward<T>(val));
+    }
+};
+
+}  // namespace detail
+
+#ifndef JSON_HAS_CPP_17
+/// namespace to hold default `from_json` function
+/// to see why this is required:
+/// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4381.html
+namespace // NOLINT(cert-dcl59-cpp,fuchsia-header-anon-namespaces,google-build-namespaces)
+{
+#endif
+JSON_INLINE_VARIABLE constexpr const auto& from_json = // NOLINT(misc-definitions-in-headers)
+    detail::static_const<detail::from_json_fn>::value;
+#ifndef JSON_HAS_CPP_17
+}  // namespace
+#endif
+
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/conversions/to_json.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <algorithm> // copy
+#include <iterator> // begin, end
+#include <string> // string
+#include <tuple> // tuple, get
+#include <type_traits> // is_same, is_constructible, is_floating_point, is_enum, underlying_type
+#include <utility> // move, forward, declval, pair
+#include <valarray> // valarray
+#include <vector> // vector
+
+// #include <nlohmann/detail/iterators/iteration_proxy.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cstddef> // size_t
+#include <iterator> // input_iterator_tag
+#include <string> // string, to_string
+#include <tuple> // tuple_size, get, tuple_element
+#include <utility> // move
+
+#if JSON_HAS_RANGES
+    #include <ranges> // enable_borrowed_range
+#endif
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+// #include <nlohmann/detail/value_t.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+template<typename string_type>
+void int_to_string( string_type& target, std::size_t value )
+{
+    // For ADL
+    using std::to_string;
+    target = to_string(value);
+}
+template<typename IteratorType> class iteration_proxy_value
+{
+  public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = iteration_proxy_value;
+    using pointer = value_type *;
+    using reference = value_type &;
+    using iterator_category = std::input_iterator_tag;
+    using string_type = typename std::remove_cv< typename std::remove_reference<decltype( std::declval<IteratorType>().key() ) >::type >::type;
+
+  private:
+    /// the iterator
+    IteratorType anchor{};
+    /// an index for arrays (used to create key names)
+    std::size_t array_index = 0;
+    /// last stringified array index
+    mutable std::size_t array_index_last = 0;
+    /// a string representation of the array index
+    mutable string_type array_index_str = "0";
+    /// an empty string (to return a reference for primitive values)
+    string_type empty_str{};
+
+  public:
+    explicit iteration_proxy_value() = default;
+    explicit iteration_proxy_value(IteratorType it, std::size_t array_index_ = 0)
+    noexcept(std::is_nothrow_move_constructible<IteratorType>::value
+             && std::is_nothrow_default_constructible<string_type>::value)
+        : anchor(std::move(it))
+        , array_index(array_index_)
+    {}
+
+    iteration_proxy_value(iteration_proxy_value const&) = default;
+    iteration_proxy_value& operator=(iteration_proxy_value const&) = default;
+    // older GCCs are a bit fussy and require explicit noexcept specifiers on defaulted functions
+    iteration_proxy_value(iteration_proxy_value&&)
+    noexcept(std::is_nothrow_move_constructible<IteratorType>::value
+             && std::is_nothrow_move_constructible<string_type>::value) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor,cppcoreguidelines-noexcept-move-operations)
+    iteration_proxy_value& operator=(iteration_proxy_value&&)
+    noexcept(std::is_nothrow_move_assignable<IteratorType>::value
+             && std::is_nothrow_move_assignable<string_type>::value) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor,cppcoreguidelines-noexcept-move-operations)
+    ~iteration_proxy_value() = default;
+
+    /// dereference operator (needed for range-based for)
+    const iteration_proxy_value& operator*() const
+    {
+        return *this;
+    }
+
+    /// increment operator (needed for range-based for)
+    iteration_proxy_value& operator++()
+    {
+        ++anchor;
+        ++array_index;
+
+        return *this;
+    }
+
+    iteration_proxy_value operator++(int)& // NOLINT(cert-dcl21-cpp)
+    {
+        auto tmp = iteration_proxy_value(anchor, array_index);
+        ++anchor;
+        ++array_index;
+        return tmp;
+    }
+
+    /// equality operator (needed for InputIterator)
+    bool operator==(const iteration_proxy_value& o) const
+    {
+        return anchor == o.anchor;
+    }
+
+    /// inequality operator (needed for range-based for)
+    bool operator!=(const iteration_proxy_value& o) const
+    {
+        return anchor != o.anchor;
+    }
+
+    /// return key of the iterator
+    const string_type& key() const
+    {
+        JSON_ASSERT(anchor.m_object != nullptr);
+
+        switch (anchor.m_object->type())
+        {
+            // use integer array index as key
+            case value_t::array:
+            {
+                if (array_index != array_index_last)
+                {
+                    int_to_string( array_index_str, array_index );
+                    array_index_last = array_index;
+                }
+                return array_index_str;
+            }
+
+            // use key from the object
+            case value_t::object:
+                return anchor.key();
+
+            // use an empty key for all primitive types
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+                return empty_str;
+        }
+    }
+
+    /// return value of the iterator
+    typename IteratorType::reference value() const
+    {
+        return anchor.value();
+    }
+};
+
+/// proxy class for the items() function
+template<typename IteratorType> class iteration_proxy
+{
+  private:
+    /// the container to iterate
+    typename IteratorType::pointer container = nullptr;
+
+  public:
+    explicit iteration_proxy() = default;
+
+    /// construct iteration proxy from a container
+    explicit iteration_proxy(typename IteratorType::reference cont) noexcept
+        : container(&cont) {}
+
+    iteration_proxy(iteration_proxy const&) = default;
+    iteration_proxy& operator=(iteration_proxy const&) = default;
+    iteration_proxy(iteration_proxy&&) noexcept = default;
+    iteration_proxy& operator=(iteration_proxy&&) noexcept = default;
+    ~iteration_proxy() = default;
+
+    /// return iterator begin (needed for range-based for)
+    iteration_proxy_value<IteratorType> begin() const noexcept
+    {
+        return iteration_proxy_value<IteratorType>(container->begin());
+    }
+
+    /// return iterator end (needed for range-based for)
+    iteration_proxy_value<IteratorType> end() const noexcept
+    {
+        return iteration_proxy_value<IteratorType>(container->end());
+    }
+};
+
+// Structured Bindings Support
+// For further reference see https://blog.tartanllama.xyz/structured-bindings/
+// And see https://github.com/nlohmann/json/pull/1391
+template<std::size_t N, typename IteratorType, enable_if_t<N == 0, int> = 0>
+auto get(const nlohmann::detail::iteration_proxy_value<IteratorType>& i) -> decltype(i.key())
+{
+    return i.key();
+}
+// Structured Bindings Support
+// For further reference see https://blog.tartanllama.xyz/structured-bindings/
+// And see https://github.com/nlohmann/json/pull/1391
+template<std::size_t N, typename IteratorType, enable_if_t<N == 1, int> = 0>
+auto get(const nlohmann::detail::iteration_proxy_value<IteratorType>& i) -> decltype(i.value())
+{
+    return i.value();
+}
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// The Addition to the STD Namespace is required to add
+// Structured Bindings Support to the iteration_proxy_value class
+// For further reference see https://blog.tartanllama.xyz/structured-bindings/
+// And see https://github.com/nlohmann/json/pull/1391
+namespace std
+{
+
+#if defined(__clang__)
+    // Fix: https://github.com/nlohmann/json/issues/1401
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wmismatched-tags"
+#endif
+template<typename IteratorType>
+class tuple_size<::nlohmann::detail::iteration_proxy_value<IteratorType>> // NOLINT(cert-dcl58-cpp)
+            : public std::integral_constant<std::size_t, 2> {};
+
+template<std::size_t N, typename IteratorType>
+class tuple_element<N, ::nlohmann::detail::iteration_proxy_value<IteratorType >> // NOLINT(cert-dcl58-cpp)
+{
+  public:
+    using type = decltype(
+                     get<N>(std::declval <
+                            ::nlohmann::detail::iteration_proxy_value<IteratorType >> ()));
+};
+#if defined(__clang__)
+    #pragma clang diagnostic pop
+#endif
+
+}  // namespace std
+
+#if JSON_HAS_RANGES
+    template <typename IteratorType>
+    inline constexpr bool ::std::ranges::enable_borrowed_range<::nlohmann::detail::iteration_proxy<IteratorType>> = true;
+#endif
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/cpp_future.hpp>
+
+// #include <nlohmann/detail/meta/std_fs.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+// #include <nlohmann/detail/value_t.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+//////////////////
+// constructors //
+//////////////////
+
+/*
+ * Note all external_constructor<>::construct functions need to call
+ * j.m_data.m_value.destroy(j.m_data.m_type) to avoid a memory leak in case j contains an
+ * allocated value (e.g., a string). See bug issue
+ * https://github.com/nlohmann/json/issues/2865 for more information.
+ */
+
+template<value_t> struct external_constructor;
+
+template<>
+struct external_constructor<value_t::boolean>
+{
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, typename BasicJsonType::boolean_t b) noexcept
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::boolean;
+        j.m_data.m_value = b;
+        j.assert_invariant();
+    }
+};
+
+template<>
+struct external_constructor<value_t::string>
+{
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, const typename BasicJsonType::string_t& s)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::string;
+        j.m_data.m_value = s;
+        j.assert_invariant();
+    }
+
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, typename BasicJsonType::string_t&& s)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::string;
+        j.m_data.m_value = std::move(s);
+        j.assert_invariant();
+    }
+
+    template < typename BasicJsonType, typename CompatibleStringType,
+               enable_if_t < !std::is_same<CompatibleStringType, typename BasicJsonType::string_t>::value,
+                             int > = 0 >
+    static void construct(BasicJsonType& j, const CompatibleStringType& str)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::string;
+        j.m_data.m_value.string = j.template create<typename BasicJsonType::string_t>(str);
+        j.assert_invariant();
+    }
+};
+
+template<>
+struct external_constructor<value_t::binary>
+{
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, const typename BasicJsonType::binary_t& b)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::binary;
+        j.m_data.m_value = typename BasicJsonType::binary_t(b);
+        j.assert_invariant();
+    }
+
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, typename BasicJsonType::binary_t&& b)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::binary;
+        j.m_data.m_value = typename BasicJsonType::binary_t(std::move(b));
+        j.assert_invariant();
+    }
+};
+
+template<>
+struct external_constructor<value_t::number_float>
+{
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, typename BasicJsonType::number_float_t val) noexcept
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::number_float;
+        j.m_data.m_value = val;
+        j.assert_invariant();
+    }
+};
+
+template<>
+struct external_constructor<value_t::number_unsigned>
+{
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, typename BasicJsonType::number_unsigned_t val) noexcept
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::number_unsigned;
+        j.m_data.m_value = val;
+        j.assert_invariant();
+    }
+};
+
+template<>
+struct external_constructor<value_t::number_integer>
+{
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, typename BasicJsonType::number_integer_t val) noexcept
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::number_integer;
+        j.m_data.m_value = val;
+        j.assert_invariant();
+    }
+};
+
+template<>
+struct external_constructor<value_t::array>
+{
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, const typename BasicJsonType::array_t& arr)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value = arr;
+        j.set_parents();
+        j.assert_invariant();
+    }
+
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, typename BasicJsonType::array_t&& arr)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value = std::move(arr);
+        j.set_parents();
+        j.assert_invariant();
+    }
+
+    template < typename BasicJsonType, typename CompatibleArrayType,
+               enable_if_t < !std::is_same<CompatibleArrayType, typename BasicJsonType::array_t>::value,
+                             int > = 0 >
+    static void construct(BasicJsonType& j, const CompatibleArrayType& arr)
+    {
+        using std::begin;
+        using std::end;
+
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value.array = j.template create<typename BasicJsonType::array_t>(begin(arr), end(arr));
+        j.set_parents();
+        j.assert_invariant();
+    }
+
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, const std::vector<bool>& arr)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value = value_t::array;
+        j.m_data.m_value.array->reserve(arr.size());
+        for (const bool x : arr)
+        {
+            j.m_data.m_value.array->push_back(x);
+            j.set_parent(j.m_data.m_value.array->back());
+        }
+        j.assert_invariant();
+    }
+
+    template<typename BasicJsonType, typename T,
+             enable_if_t<std::is_convertible<T, BasicJsonType>::value, int> = 0>
+    static void construct(BasicJsonType& j, const std::valarray<T>& arr)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::array;
+        j.m_data.m_value = value_t::array;
+        j.m_data.m_value.array->resize(arr.size());
+        if (arr.size() > 0)
+        {
+            std::copy(std::begin(arr), std::end(arr), j.m_data.m_value.array->begin());
+        }
+        j.set_parents();
+        j.assert_invariant();
+    }
+};
+
+template<>
+struct external_constructor<value_t::object>
+{
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, const typename BasicJsonType::object_t& obj)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::object;
+        j.m_data.m_value = obj;
+        j.set_parents();
+        j.assert_invariant();
+    }
+
+    template<typename BasicJsonType>
+    static void construct(BasicJsonType& j, typename BasicJsonType::object_t&& obj)
+    {
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::object;
+        j.m_data.m_value = std::move(obj);
+        j.set_parents();
+        j.assert_invariant();
+    }
+
+    template < typename BasicJsonType, typename CompatibleObjectType,
+               enable_if_t < !std::is_same<CompatibleObjectType, typename BasicJsonType::object_t>::value, int > = 0 >
+    static void construct(BasicJsonType& j, const CompatibleObjectType& obj)
+    {
+        using std::begin;
+        using std::end;
+
+        j.m_data.m_value.destroy(j.m_data.m_type);
+        j.m_data.m_type = value_t::object;
+        j.m_data.m_value.object = j.template create<typename BasicJsonType::object_t>(begin(obj), end(obj));
+        j.set_parents();
+        j.assert_invariant();
+    }
+};
+
+/////////////
+// to_json //
+/////////////
+
+template<typename BasicJsonType, typename T,
+         enable_if_t<std::is_same<T, typename BasicJsonType::boolean_t>::value, int> = 0>
+inline void to_json(BasicJsonType& j, T b) noexcept
+{
+    external_constructor<value_t::boolean>::construct(j, b);
+}
+
+template < typename BasicJsonType, typename BoolRef,
+           enable_if_t <
+               ((std::is_same<std::vector<bool>::reference, BoolRef>::value
+                 && !std::is_same <std::vector<bool>::reference, typename BasicJsonType::boolean_t&>::value)
+                || (std::is_same<std::vector<bool>::const_reference, BoolRef>::value
+                    && !std::is_same <detail::uncvref_t<std::vector<bool>::const_reference>,
+                                      typename BasicJsonType::boolean_t >::value))
+               && std::is_convertible<const BoolRef&, typename BasicJsonType::boolean_t>::value, int > = 0 >
+inline void to_json(BasicJsonType& j, const BoolRef& b) noexcept
+{
+    external_constructor<value_t::boolean>::construct(j, static_cast<typename BasicJsonType::boolean_t>(b));
+}
+
+template<typename BasicJsonType, typename CompatibleString,
+         enable_if_t<std::is_constructible<typename BasicJsonType::string_t, CompatibleString>::value, int> = 0>
+inline void to_json(BasicJsonType& j, const CompatibleString& s)
+{
+    external_constructor<value_t::string>::construct(j, s);
+}
+
+template<typename BasicJsonType>
+inline void to_json(BasicJsonType& j, typename BasicJsonType::string_t&& s)
+{
+    external_constructor<value_t::string>::construct(j, std::move(s));
+}
+
+template<typename BasicJsonType, typename FloatType,
+         enable_if_t<std::is_floating_point<FloatType>::value, int> = 0>
+inline void to_json(BasicJsonType& j, FloatType val) noexcept
+{
+    external_constructor<value_t::number_float>::construct(j, static_cast<typename BasicJsonType::number_float_t>(val));
+}
+
+template<typename BasicJsonType, typename CompatibleNumberUnsignedType,
+         enable_if_t<is_compatible_integer_type<typename BasicJsonType::number_unsigned_t, CompatibleNumberUnsignedType>::value, int> = 0>
+inline void to_json(BasicJsonType& j, CompatibleNumberUnsignedType val) noexcept
+{
+    external_constructor<value_t::number_unsigned>::construct(j, static_cast<typename BasicJsonType::number_unsigned_t>(val));
+}
+
+template<typename BasicJsonType, typename CompatibleNumberIntegerType,
+         enable_if_t<is_compatible_integer_type<typename BasicJsonType::number_integer_t, CompatibleNumberIntegerType>::value, int> = 0>
+inline void to_json(BasicJsonType& j, CompatibleNumberIntegerType val) noexcept
+{
+    external_constructor<value_t::number_integer>::construct(j, static_cast<typename BasicJsonType::number_integer_t>(val));
+}
+
+#if !JSON_DISABLE_ENUM_SERIALIZATION
+template<typename BasicJsonType, typename EnumType,
+         enable_if_t<std::is_enum<EnumType>::value, int> = 0>
+inline void to_json(BasicJsonType& j, EnumType e) noexcept
+{
+    using underlying_type = typename std::underlying_type<EnumType>::type;
+    external_constructor<value_t::number_integer>::construct(j, static_cast<underlying_type>(e));
+}
+#endif  // JSON_DISABLE_ENUM_SERIALIZATION
+
+template<typename BasicJsonType>
+inline void to_json(BasicJsonType& j, const std::vector<bool>& e)
+{
+    external_constructor<value_t::array>::construct(j, e);
+}
+
+template < typename BasicJsonType, typename CompatibleArrayType,
+           enable_if_t < is_compatible_array_type<BasicJsonType,
+                         CompatibleArrayType>::value&&
+                         !is_compatible_object_type<BasicJsonType, CompatibleArrayType>::value&&
+                         !is_compatible_string_type<BasicJsonType, CompatibleArrayType>::value&&
+                         !std::is_same<typename BasicJsonType::binary_t, CompatibleArrayType>::value&&
+                         !is_basic_json<CompatibleArrayType>::value,
+                         int > = 0 >
+inline void to_json(BasicJsonType& j, const CompatibleArrayType& arr)
+{
+    external_constructor<value_t::array>::construct(j, arr);
+}
+
+template<typename BasicJsonType>
+inline void to_json(BasicJsonType& j, const typename BasicJsonType::binary_t& bin)
+{
+    external_constructor<value_t::binary>::construct(j, bin);
+}
+
+template<typename BasicJsonType, typename T,
+         enable_if_t<std::is_convertible<T, BasicJsonType>::value, int> = 0>
+inline void to_json(BasicJsonType& j, const std::valarray<T>& arr)
+{
+    external_constructor<value_t::array>::construct(j, std::move(arr));
+}
+
+template<typename BasicJsonType>
+inline void to_json(BasicJsonType& j, typename BasicJsonType::array_t&& arr)
+{
+    external_constructor<value_t::array>::construct(j, std::move(arr));
+}
+
+template < typename BasicJsonType, typename CompatibleObjectType,
+           enable_if_t < is_compatible_object_type<BasicJsonType, CompatibleObjectType>::value&& !is_basic_json<CompatibleObjectType>::value, int > = 0 >
+inline void to_json(BasicJsonType& j, const CompatibleObjectType& obj)
+{
+    external_constructor<value_t::object>::construct(j, obj);
+}
+
+template<typename BasicJsonType>
+inline void to_json(BasicJsonType& j, typename BasicJsonType::object_t&& obj)
+{
+    external_constructor<value_t::object>::construct(j, std::move(obj));
+}
+
+template <
+    typename BasicJsonType, typename T, std::size_t N,
+    enable_if_t < !std::is_constructible<typename BasicJsonType::string_t,
+                  const T(&)[N]>::value, // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+                  int > = 0 >
+inline void to_json(BasicJsonType& j, const T(&arr)[N]) // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+{
+    external_constructor<value_t::array>::construct(j, arr);
+}
+
+template < typename BasicJsonType, typename T1, typename T2, enable_if_t < std::is_constructible<BasicJsonType, T1>::value&& std::is_constructible<BasicJsonType, T2>::value, int > = 0 >
+inline void to_json(BasicJsonType& j, const std::pair<T1, T2>& p)
+{
+    j = { p.first, p.second };
+}
+
+// for https://github.com/nlohmann/json/pull/1134
+template<typename BasicJsonType, typename T,
+         enable_if_t<std::is_same<T, iteration_proxy_value<typename BasicJsonType::iterator>>::value, int> = 0>
+inline void to_json(BasicJsonType& j, const T& b)
+{
+    j = { {b.key(), b.value()} };
+}
+
+template<typename BasicJsonType, typename Tuple, std::size_t... Idx>
+inline void to_json_tuple_impl(BasicJsonType& j, const Tuple& t, index_sequence<Idx...> /*unused*/)
+{
+    j = { std::get<Idx>(t)... };
+}
+
+template<typename BasicJsonType, typename T, enable_if_t<is_constructible_tuple<BasicJsonType, T>::value, int > = 0>
+inline void to_json(BasicJsonType& j, const T& t)
+{
+    to_json_tuple_impl(j, t, make_index_sequence<std::tuple_size<T>::value> {});
+}
+
+#if JSON_HAS_FILESYSTEM || JSON_HAS_EXPERIMENTAL_FILESYSTEM
+template<typename BasicJsonType>
+inline void to_json(BasicJsonType& j, const std_fs::path& p)
+{
+    j = p.string();
+}
+#endif
+
+struct to_json_fn
+{
+    template<typename BasicJsonType, typename T>
+    auto operator()(BasicJsonType& j, T&& val) const noexcept(noexcept(to_json(j, std::forward<T>(val))))
+    -> decltype(to_json(j, std::forward<T>(val)), void())
+    {
+        return to_json(j, std::forward<T>(val));
+    }
+};
+}  // namespace detail
+
+#ifndef JSON_HAS_CPP_17
+/// namespace to hold default `to_json` function
+/// to see why this is required:
+/// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4381.html
+namespace // NOLINT(cert-dcl59-cpp,fuchsia-header-anon-namespaces,google-build-namespaces)
+{
+#endif
+JSON_INLINE_VARIABLE constexpr const auto& to_json = // NOLINT(misc-definitions-in-headers)
+    detail::static_const<detail::to_json_fn>::value;
+#ifndef JSON_HAS_CPP_17
+}  // namespace
+#endif
+
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/meta/identity_tag.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+
+/// @sa https://json.nlohmann.me/api/adl_serializer/
+template<typename ValueType, typename>
+struct adl_serializer
+{
+    /// @brief convert a JSON value to any value type
+    /// @sa https://json.nlohmann.me/api/adl_serializer/from_json/
+    template<typename BasicJsonType, typename TargetType = ValueType>
+    static auto from_json(BasicJsonType && j, TargetType& val) noexcept(
+        noexcept(::nlohmann::from_json(std::forward<BasicJsonType>(j), val)))
+    -> decltype(::nlohmann::from_json(std::forward<BasicJsonType>(j), val), void())
+    {
+        ::nlohmann::from_json(std::forward<BasicJsonType>(j), val);
+    }
+
+    /// @brief convert a JSON value to any value type
+    /// @sa https://json.nlohmann.me/api/adl_serializer/from_json/
+    template<typename BasicJsonType, typename TargetType = ValueType>
+    static auto from_json(BasicJsonType && j) noexcept(
+    noexcept(::nlohmann::from_json(std::forward<BasicJsonType>(j), detail::identity_tag<TargetType> {})))
+    -> decltype(::nlohmann::from_json(std::forward<BasicJsonType>(j), detail::identity_tag<TargetType> {}))
+    {
+        return ::nlohmann::from_json(std::forward<BasicJsonType>(j), detail::identity_tag<TargetType> {});
+    }
+
+    /// @brief convert any value type to a JSON value
+    /// @sa https://json.nlohmann.me/api/adl_serializer/to_json/
+    template<typename BasicJsonType, typename TargetType = ValueType>
+    static auto to_json(BasicJsonType& j, TargetType && val) noexcept(
+        noexcept(::nlohmann::to_json(j, std::forward<TargetType>(val))))
+    -> decltype(::nlohmann::to_json(j, std::forward<TargetType>(val)), void())
+    {
+        ::nlohmann::to_json(j, std::forward<TargetType>(val));
+    }
+};
+
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/byte_container_with_subtype.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cstdint> // uint8_t, uint64_t
+#include <tuple> // tie
+#include <utility> // move
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+
+/// @brief an internal type for a backed binary type
+/// @sa https://json.nlohmann.me/api/byte_container_with_subtype/
+template<typename BinaryType>
+class byte_container_with_subtype : public BinaryType
+{
+  public:
+    using container_type = BinaryType;
+    using subtype_type = std::uint64_t;
+
+    /// @sa https://json.nlohmann.me/api/byte_container_with_subtype/byte_container_with_subtype/
+    byte_container_with_subtype() noexcept(noexcept(container_type()))
+        : container_type()
+    {}
+
+    /// @sa https://json.nlohmann.me/api/byte_container_with_subtype/byte_container_with_subtype/
+    byte_container_with_subtype(const container_type& b) noexcept(noexcept(container_type(b)))
+        : container_type(b)
+    {}
+
+    /// @sa https://json.nlohmann.me/api/byte_container_with_subtype/byte_container_with_subtype/
+    byte_container_with_subtype(container_type&& b) noexcept(noexcept(container_type(std::move(b))))
+        : container_type(std::move(b))
+    {}
+
+    /// @sa https://json.nlohmann.me/api/byte_container_with_subtype/byte_container_with_subtype/
+    byte_container_with_subtype(const container_type& b, subtype_type subtype_) noexcept(noexcept(container_type(b)))
+        : container_type(b)
+        , m_subtype(subtype_)
+        , m_has_subtype(true)
+    {}
+
+    /// @sa https://json.nlohmann.me/api/byte_container_with_subtype/byte_container_with_subtype/
+    byte_container_with_subtype(container_type&& b, subtype_type subtype_) noexcept(noexcept(container_type(std::move(b))))
+        : container_type(std::move(b))
+        , m_subtype(subtype_)
+        , m_has_subtype(true)
+    {}
+
+    bool operator==(const byte_container_with_subtype& rhs) const
+    {
+        return std::tie(static_cast<const BinaryType&>(*this), m_subtype, m_has_subtype) ==
+               std::tie(static_cast<const BinaryType&>(rhs), rhs.m_subtype, rhs.m_has_subtype);
+    }
+
+    bool operator!=(const byte_container_with_subtype& rhs) const
+    {
+        return !(rhs == *this);
+    }
+
+    /// @brief sets the binary subtype
+    /// @sa https://json.nlohmann.me/api/byte_container_with_subtype/set_subtype/
+    void set_subtype(subtype_type subtype_) noexcept
+    {
+        m_subtype = subtype_;
+        m_has_subtype = true;
+    }
+
+    /// @brief return the binary subtype
+    /// @sa https://json.nlohmann.me/api/byte_container_with_subtype/subtype/
+    constexpr subtype_type subtype() const noexcept
+    {
+        return m_has_subtype ? m_subtype : static_cast<subtype_type>(-1);
+    }
+
+    /// @brief return whether the value has a subtype
+    /// @sa https://json.nlohmann.me/api/byte_container_with_subtype/has_subtype/
+    constexpr bool has_subtype() const noexcept
+    {
+        return m_has_subtype;
+    }
+
+    /// @brief clears the binary subtype
+    /// @sa https://json.nlohmann.me/api/byte_container_with_subtype/clear_subtype/
+    void clear_subtype() noexcept
+    {
+        m_subtype = 0;
+        m_has_subtype = false;
+    }
+
+  private:
+    subtype_type m_subtype = 0;
+    bool m_has_subtype = false;
+};
+
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/conversions/from_json.hpp>
+
+// #include <nlohmann/detail/conversions/to_json.hpp>
+
+// #include <nlohmann/detail/exceptions.hpp>
+
+// #include <nlohmann/detail/hash.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cstdint> // uint8_t
+#include <cstddef> // size_t
+#include <functional> // hash
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+// #include <nlohmann/detail/value_t.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+// boost::hash_combine
+inline std::size_t combine(std::size_t seed, std::size_t h) noexcept
+{
+    seed ^= h + 0x9e3779b9 + (seed << 6U) + (seed >> 2U);
+    return seed;
+}
+
+/*!
+@brief hash a JSON value
+
+The hash function tries to rely on std::hash where possible. Furthermore, the
+type of the JSON value is taken into account to have different hash values for
+null, 0, 0U, and false, etc.
+
+@tparam BasicJsonType basic_json specialization
+@param j JSON value to hash
+@return hash value of j
+*/
+template<typename BasicJsonType>
+std::size_t hash(const BasicJsonType& j)
+{
+    using string_t = typename BasicJsonType::string_t;
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+
+    const auto type = static_cast<std::size_t>(j.type());
+    switch (j.type())
+    {
+        case BasicJsonType::value_t::null:
+        case BasicJsonType::value_t::discarded:
+        {
+            return combine(type, 0);
+        }
+
+        case BasicJsonType::value_t::object:
+        {
+            auto seed = combine(type, j.size());
+            for (const auto& element : j.items())
+            {
+                const auto h = std::hash<string_t> {}(element.key());
+                seed = combine(seed, h);
+                seed = combine(seed, hash(element.value()));
+            }
+            return seed;
+        }
+
+        case BasicJsonType::value_t::array:
+        {
+            auto seed = combine(type, j.size());
+            for (const auto& element : j)
+            {
+                seed = combine(seed, hash(element));
+            }
+            return seed;
+        }
+
+        case BasicJsonType::value_t::string:
+        {
+            const auto h = std::hash<string_t> {}(j.template get_ref<const string_t&>());
+            return combine(type, h);
+        }
+
+        case BasicJsonType::value_t::boolean:
+        {
+            const auto h = std::hash<bool> {}(j.template get<bool>());
+            return combine(type, h);
+        }
+
+        case BasicJsonType::value_t::number_integer:
+        {
+            const auto h = std::hash<number_integer_t> {}(j.template get<number_integer_t>());
+            return combine(type, h);
+        }
+
+        case BasicJsonType::value_t::number_unsigned:
+        {
+            const auto h = std::hash<number_unsigned_t> {}(j.template get<number_unsigned_t>());
+            return combine(type, h);
+        }
+
+        case BasicJsonType::value_t::number_float:
+        {
+            const auto h = std::hash<number_float_t> {}(j.template get<number_float_t>());
+            return combine(type, h);
+        }
+
+        case BasicJsonType::value_t::binary:
+        {
+            auto seed = combine(type, j.get_binary().size());
+            const auto h = std::hash<bool> {}(j.get_binary().has_subtype());
+            seed = combine(seed, h);
+            seed = combine(seed, static_cast<std::size_t>(j.get_binary().subtype()));
+            for (const auto byte : j.get_binary())
+            {
+                seed = combine(seed, std::hash<std::uint8_t> {}(byte));
+            }
+            return seed;
+        }
+
+        default:                   // LCOV_EXCL_LINE
+            JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+            return 0;              // LCOV_EXCL_LINE
+    }
+}
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/input/binary_reader.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <algorithm> // generate_n
+#include <array> // array
+#include <cmath> // ldexp
+#include <cstddef> // size_t
+#include <cstdint> // uint8_t, uint16_t, uint32_t, uint64_t
+#include <cstdio> // snprintf
+#include <cstring> // memcpy
+#include <iterator> // back_inserter
+#include <limits> // numeric_limits
+#include <string> // char_traits, string
+#include <utility> // make_pair, move
+#include <vector> // vector
+
+// #include <nlohmann/detail/exceptions.hpp>
+
+// #include <nlohmann/detail/input/input_adapters.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <array> // array
+#include <cstddef> // size_t
+#include <cstring> // strlen
+#include <iterator> // begin, end, iterator_traits, random_access_iterator_tag, distance, next
+#include <memory> // shared_ptr, make_shared, addressof
+#include <numeric> // accumulate
+#include <string> // string, char_traits
+#include <type_traits> // enable_if, is_base_of, is_pointer, is_integral, remove_pointer
+#include <utility> // pair, declval
+
+#ifndef JSON_NO_IO
+    #include <cstdio>   // FILE *
+    #include <istream>  // istream
+#endif                  // JSON_NO_IO
+
+// #include <nlohmann/detail/iterators/iterator_traits.hpp>
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+/// the supported input formats
+enum class input_format_t { json, cbor, msgpack, ubjson, bson, bjdata };
+
+////////////////////
+// input adapters //
+////////////////////
+
+#ifndef JSON_NO_IO
+/*!
+Input adapter for stdio file access. This adapter read only 1 byte and do not use any
+ buffer. This adapter is a very low level adapter.
+*/
+class file_input_adapter
+{
+  public:
+    using char_type = char;
+
+    JSON_HEDLEY_NON_NULL(2)
+    explicit file_input_adapter(std::FILE* f) noexcept
+        : m_file(f)
+    {
+        JSON_ASSERT(m_file != nullptr);
+    }
+
+    // make class move-only
+    file_input_adapter(const file_input_adapter&) = delete;
+    file_input_adapter(file_input_adapter&&) noexcept = default;
+    file_input_adapter& operator=(const file_input_adapter&) = delete;
+    file_input_adapter& operator=(file_input_adapter&&) = delete;
+    ~file_input_adapter() = default;
+
+    std::char_traits<char>::int_type get_character() noexcept
+    {
+        return std::fgetc(m_file);
+    }
+
+  private:
+    /// the file pointer to read from
+    std::FILE* m_file;
+};
+
+/*!
+Input adapter for a (caching) istream. Ignores a UFT Byte Order Mark at
+beginning of input. Does not support changing the underlying std::streambuf
+in mid-input. Maintains underlying std::istream and std::streambuf to support
+subsequent use of standard std::istream operations to process any input
+characters following those used in parsing the JSON input.  Clears the
+std::istream flags; any input errors (e.g., EOF) will be detected by the first
+subsequent call for input from the std::istream.
+*/
+class input_stream_adapter
+{
+  public:
+    using char_type = char;
+
+    ~input_stream_adapter()
+    {
+        // clear stream flags; we use underlying streambuf I/O, do not
+        // maintain ifstream flags, except eof
+        if (is != nullptr)
+        {
+            is->clear(is->rdstate() & std::ios::eofbit);
+        }
+    }
+
+    explicit input_stream_adapter(std::istream& i)
+        : is(&i), sb(i.rdbuf())
+    {}
+
+    // delete because of pointer members
+    input_stream_adapter(const input_stream_adapter&) = delete;
+    input_stream_adapter& operator=(input_stream_adapter&) = delete;
+    input_stream_adapter& operator=(input_stream_adapter&&) = delete;
+
+    input_stream_adapter(input_stream_adapter&& rhs) noexcept
+        : is(rhs.is), sb(rhs.sb)
+    {
+        rhs.is = nullptr;
+        rhs.sb = nullptr;
+    }
+
+    // std::istream/std::streambuf use std::char_traits<char>::to_int_type, to
+    // ensure that std::char_traits<char>::eof() and the character 0xFF do not
+    // end up as the same value, e.g. 0xFFFFFFFF.
+    std::char_traits<char>::int_type get_character()
+    {
+        auto res = sb->sbumpc();
+        // set eof manually, as we don't use the istream interface.
+        if (JSON_HEDLEY_UNLIKELY(res == std::char_traits<char>::eof()))
+        {
+            is->clear(is->rdstate() | std::ios::eofbit);
+        }
+        return res;
+    }
+
+  private:
+    /// the associated input stream
+    std::istream* is = nullptr;
+    std::streambuf* sb = nullptr;
+};
+#endif  // JSON_NO_IO
+
+// General-purpose iterator-based adapter. It might not be as fast as
+// theoretically possible for some containers, but it is extremely versatile.
+template<typename IteratorType>
+class iterator_input_adapter
+{
+  public:
+    using char_type = typename std::iterator_traits<IteratorType>::value_type;
+
+    iterator_input_adapter(IteratorType first, IteratorType last)
+        : current(std::move(first)), end(std::move(last))
+    {}
+
+    typename char_traits<char_type>::int_type get_character()
+    {
+        if (JSON_HEDLEY_LIKELY(current != end))
+        {
+            auto result = char_traits<char_type>::to_int_type(*current);
+            std::advance(current, 1);
+            return result;
+        }
+
+        return char_traits<char_type>::eof();
+    }
+
+  private:
+    IteratorType current;
+    IteratorType end;
+
+    template<typename BaseInputAdapter, size_t T>
+    friend struct wide_string_input_helper;
+
+    bool empty() const
+    {
+        return current == end;
+    }
+};
+
+template<typename BaseInputAdapter, size_t T>
+struct wide_string_input_helper;
+
+template<typename BaseInputAdapter>
+struct wide_string_input_helper<BaseInputAdapter, 4>
+{
+    // UTF-32
+    static void fill_buffer(BaseInputAdapter& input,
+                            std::array<std::char_traits<char>::int_type, 4>& utf8_bytes,
+                            size_t& utf8_bytes_index,
+                            size_t& utf8_bytes_filled)
+    {
+        utf8_bytes_index = 0;
+
+        if (JSON_HEDLEY_UNLIKELY(input.empty()))
+        {
+            utf8_bytes[0] = std::char_traits<char>::eof();
+            utf8_bytes_filled = 1;
+        }
+        else
+        {
+            // get the current character
+            const auto wc = input.get_character();
+
+            // UTF-32 to UTF-8 encoding
+            if (wc < 0x80)
+            {
+                utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(wc);
+                utf8_bytes_filled = 1;
+            }
+            else if (wc <= 0x7FF)
+            {
+                utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(0xC0u | ((static_cast<unsigned int>(wc) >> 6u) & 0x1Fu));
+                utf8_bytes[1] = static_cast<std::char_traits<char>::int_type>(0x80u | (static_cast<unsigned int>(wc) & 0x3Fu));
+                utf8_bytes_filled = 2;
+            }
+            else if (wc <= 0xFFFF)
+            {
+                utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(0xE0u | ((static_cast<unsigned int>(wc) >> 12u) & 0x0Fu));
+                utf8_bytes[1] = static_cast<std::char_traits<char>::int_type>(0x80u | ((static_cast<unsigned int>(wc) >> 6u) & 0x3Fu));
+                utf8_bytes[2] = static_cast<std::char_traits<char>::int_type>(0x80u | (static_cast<unsigned int>(wc) & 0x3Fu));
+                utf8_bytes_filled = 3;
+            }
+            else if (wc <= 0x10FFFF)
+            {
+                utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(0xF0u | ((static_cast<unsigned int>(wc) >> 18u) & 0x07u));
+                utf8_bytes[1] = static_cast<std::char_traits<char>::int_type>(0x80u | ((static_cast<unsigned int>(wc) >> 12u) & 0x3Fu));
+                utf8_bytes[2] = static_cast<std::char_traits<char>::int_type>(0x80u | ((static_cast<unsigned int>(wc) >> 6u) & 0x3Fu));
+                utf8_bytes[3] = static_cast<std::char_traits<char>::int_type>(0x80u | (static_cast<unsigned int>(wc) & 0x3Fu));
+                utf8_bytes_filled = 4;
+            }
+            else
+            {
+                // unknown character
+                utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(wc);
+                utf8_bytes_filled = 1;
+            }
+        }
+    }
+};
+
+template<typename BaseInputAdapter>
+struct wide_string_input_helper<BaseInputAdapter, 2>
+{
+    // UTF-16
+    static void fill_buffer(BaseInputAdapter& input,
+                            std::array<std::char_traits<char>::int_type, 4>& utf8_bytes,
+                            size_t& utf8_bytes_index,
+                            size_t& utf8_bytes_filled)
+    {
+        utf8_bytes_index = 0;
+
+        if (JSON_HEDLEY_UNLIKELY(input.empty()))
+        {
+            utf8_bytes[0] = std::char_traits<char>::eof();
+            utf8_bytes_filled = 1;
+        }
+        else
+        {
+            // get the current character
+            const auto wc = input.get_character();
+
+            // UTF-16 to UTF-8 encoding
+            if (wc < 0x80)
+            {
+                utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(wc);
+                utf8_bytes_filled = 1;
+            }
+            else if (wc <= 0x7FF)
+            {
+                utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(0xC0u | ((static_cast<unsigned int>(wc) >> 6u)));
+                utf8_bytes[1] = static_cast<std::char_traits<char>::int_type>(0x80u | (static_cast<unsigned int>(wc) & 0x3Fu));
+                utf8_bytes_filled = 2;
+            }
+            else if (0xD800 > wc || wc >= 0xE000)
+            {
+                utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(0xE0u | ((static_cast<unsigned int>(wc) >> 12u)));
+                utf8_bytes[1] = static_cast<std::char_traits<char>::int_type>(0x80u | ((static_cast<unsigned int>(wc) >> 6u) & 0x3Fu));
+                utf8_bytes[2] = static_cast<std::char_traits<char>::int_type>(0x80u | (static_cast<unsigned int>(wc) & 0x3Fu));
+                utf8_bytes_filled = 3;
+            }
+            else
+            {
+                if (JSON_HEDLEY_UNLIKELY(!input.empty()))
+                {
+                    const auto wc2 = static_cast<unsigned int>(input.get_character());
+                    const auto charcode = 0x10000u + (((static_cast<unsigned int>(wc) & 0x3FFu) << 10u) | (wc2 & 0x3FFu));
+                    utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(0xF0u | (charcode >> 18u));
+                    utf8_bytes[1] = static_cast<std::char_traits<char>::int_type>(0x80u | ((charcode >> 12u) & 0x3Fu));
+                    utf8_bytes[2] = static_cast<std::char_traits<char>::int_type>(0x80u | ((charcode >> 6u) & 0x3Fu));
+                    utf8_bytes[3] = static_cast<std::char_traits<char>::int_type>(0x80u | (charcode & 0x3Fu));
+                    utf8_bytes_filled = 4;
+                }
+                else
+                {
+                    utf8_bytes[0] = static_cast<std::char_traits<char>::int_type>(wc);
+                    utf8_bytes_filled = 1;
+                }
+            }
+        }
+    }
+};
+
+// Wraps another input adapter to convert wide character types into individual bytes.
+template<typename BaseInputAdapter, typename WideCharType>
+class wide_string_input_adapter
+{
+  public:
+    using char_type = char;
+
+    wide_string_input_adapter(BaseInputAdapter base)
+        : base_adapter(base) {}
+
+    typename std::char_traits<char>::int_type get_character() noexcept
+    {
+        // check if buffer needs to be filled
+        if (utf8_bytes_index == utf8_bytes_filled)
+        {
+            fill_buffer<sizeof(WideCharType)>();
+
+            JSON_ASSERT(utf8_bytes_filled > 0);
+            JSON_ASSERT(utf8_bytes_index == 0);
+        }
+
+        // use buffer
+        JSON_ASSERT(utf8_bytes_filled > 0);
+        JSON_ASSERT(utf8_bytes_index < utf8_bytes_filled);
+        return utf8_bytes[utf8_bytes_index++];
+    }
+
+  private:
+    BaseInputAdapter base_adapter;
+
+    template<size_t T>
+    void fill_buffer()
+    {
+        wide_string_input_helper<BaseInputAdapter, T>::fill_buffer(base_adapter, utf8_bytes, utf8_bytes_index, utf8_bytes_filled);
+    }
+
+    /// a buffer for UTF-8 bytes
+    std::array<std::char_traits<char>::int_type, 4> utf8_bytes = {{0, 0, 0, 0}};
+
+    /// index to the utf8_codes array for the next valid byte
+    std::size_t utf8_bytes_index = 0;
+    /// number of valid bytes in the utf8_codes array
+    std::size_t utf8_bytes_filled = 0;
+};
+
+template<typename IteratorType, typename Enable = void>
+struct iterator_input_adapter_factory
+{
+    using iterator_type = IteratorType;
+    using char_type = typename std::iterator_traits<iterator_type>::value_type;
+    using adapter_type = iterator_input_adapter<iterator_type>;
+
+    static adapter_type create(IteratorType first, IteratorType last)
+    {
+        return adapter_type(std::move(first), std::move(last));
+    }
+};
+
+template<typename T>
+struct is_iterator_of_multibyte
+{
+    using value_type = typename std::iterator_traits<T>::value_type;
+    enum
+    {
+        value = sizeof(value_type) > 1
+    };
+};
+
+template<typename IteratorType>
+struct iterator_input_adapter_factory<IteratorType, enable_if_t<is_iterator_of_multibyte<IteratorType>::value>>
+{
+    using iterator_type = IteratorType;
+    using char_type = typename std::iterator_traits<iterator_type>::value_type;
+    using base_adapter_type = iterator_input_adapter<iterator_type>;
+    using adapter_type = wide_string_input_adapter<base_adapter_type, char_type>;
+
+    static adapter_type create(IteratorType first, IteratorType last)
+    {
+        return adapter_type(base_adapter_type(std::move(first), std::move(last)));
+    }
+};
+
+// General purpose iterator-based input
+template<typename IteratorType>
+typename iterator_input_adapter_factory<IteratorType>::adapter_type input_adapter(IteratorType first, IteratorType last)
+{
+    using factory_type = iterator_input_adapter_factory<IteratorType>;
+    return factory_type::create(first, last);
+}
+
+// Convenience shorthand from container to iterator
+// Enables ADL on begin(container) and end(container)
+// Encloses the using declarations in namespace for not to leak them to outside scope
+
+namespace container_input_adapter_factory_impl
+{
+
+using std::begin;
+using std::end;
+
+template<typename ContainerType, typename Enable = void>
+struct container_input_adapter_factory {};
+
+template<typename ContainerType>
+struct container_input_adapter_factory< ContainerType,
+       void_t<decltype(begin(std::declval<ContainerType>()), end(std::declval<ContainerType>()))>>
+       {
+           using adapter_type = decltype(input_adapter(begin(std::declval<ContainerType>()), end(std::declval<ContainerType>())));
+
+           static adapter_type create(const ContainerType& container)
+{
+    return input_adapter(begin(container), end(container));
+}
+       };
+
+}  // namespace container_input_adapter_factory_impl
+
+template<typename ContainerType>
+typename container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::adapter_type input_adapter(const ContainerType& container)
+{
+    return container_input_adapter_factory_impl::container_input_adapter_factory<ContainerType>::create(container);
+}
+
+#ifndef JSON_NO_IO
+// Special cases with fast paths
+inline file_input_adapter input_adapter(std::FILE* file)
+{
+    return file_input_adapter(file);
+}
+
+inline input_stream_adapter input_adapter(std::istream& stream)
+{
+    return input_stream_adapter(stream);
+}
+
+inline input_stream_adapter input_adapter(std::istream&& stream)
+{
+    return input_stream_adapter(stream);
+}
+#endif  // JSON_NO_IO
+
+using contiguous_bytes_input_adapter = decltype(input_adapter(std::declval<const char*>(), std::declval<const char*>()));
+
+// Null-delimited strings, and the like.
+template < typename CharT,
+           typename std::enable_if <
+               std::is_pointer<CharT>::value&&
+               !std::is_array<CharT>::value&&
+               std::is_integral<typename std::remove_pointer<CharT>::type>::value&&
+               sizeof(typename std::remove_pointer<CharT>::type) == 1,
+               int >::type = 0 >
+contiguous_bytes_input_adapter input_adapter(CharT b)
+{
+    auto length = std::strlen(reinterpret_cast<const char*>(b));
+    const auto* ptr = reinterpret_cast<const char*>(b);
+    return input_adapter(ptr, ptr + length);
+}
+
+template<typename T, std::size_t N>
+auto input_adapter(T (&array)[N]) -> decltype(input_adapter(array, array + N)) // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+{
+    return input_adapter(array, array + N);
+}
+
+// This class only handles inputs of input_buffer_adapter type.
+// It's required so that expressions like {ptr, len} can be implicitly cast
+// to the correct adapter.
+class span_input_adapter
+{
+  public:
+    template < typename CharT,
+               typename std::enable_if <
+                   std::is_pointer<CharT>::value&&
+                   std::is_integral<typename std::remove_pointer<CharT>::type>::value&&
+                   sizeof(typename std::remove_pointer<CharT>::type) == 1,
+                   int >::type = 0 >
+    span_input_adapter(CharT b, std::size_t l)
+        : ia(reinterpret_cast<const char*>(b), reinterpret_cast<const char*>(b) + l) {}
+
+    template<class IteratorType,
+             typename std::enable_if<
+                 std::is_same<typename iterator_traits<IteratorType>::iterator_category, std::random_access_iterator_tag>::value,
+                 int>::type = 0>
+    span_input_adapter(IteratorType first, IteratorType last)
+        : ia(input_adapter(first, last)) {}
+
+    contiguous_bytes_input_adapter&& get()
+    {
+        return std::move(ia); // NOLINT(hicpp-move-const-arg,performance-move-const-arg)
+    }
+
+  private:
+    contiguous_bytes_input_adapter ia;
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/input/json_sax.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cstddef>
+#include <string> // string
+#include <utility> // move
+#include <vector> // vector
+
+// #include <nlohmann/detail/exceptions.hpp>
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/string_concat.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+
+/*!
+@brief SAX interface
+
+This class describes the SAX interface used by @ref nlohmann::json::sax_parse.
+Each function is called in different situations while the input is parsed. The
+boolean return value informs the parser whether to continue processing the
+input.
+*/
+template<typename BasicJsonType>
+struct json_sax
+{
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
+    using binary_t = typename BasicJsonType::binary_t;
+
+    /*!
+    @brief a null value was read
+    @return whether parsing should proceed
+    */
+    virtual bool null() = 0;
+
+    /*!
+    @brief a boolean value was read
+    @param[in] val  boolean value
+    @return whether parsing should proceed
+    */
+    virtual bool boolean(bool val) = 0;
+
+    /*!
+    @brief an integer number was read
+    @param[in] val  integer value
+    @return whether parsing should proceed
+    */
+    virtual bool number_integer(number_integer_t val) = 0;
+
+    /*!
+    @brief an unsigned integer number was read
+    @param[in] val  unsigned integer value
+    @return whether parsing should proceed
+    */
+    virtual bool number_unsigned(number_unsigned_t val) = 0;
+
+    /*!
+    @brief a floating-point number was read
+    @param[in] val  floating-point value
+    @param[in] s    raw token value
+    @return whether parsing should proceed
+    */
+    virtual bool number_float(number_float_t val, const string_t& s) = 0;
+
+    /*!
+    @brief a string value was read
+    @param[in] val  string value
+    @return whether parsing should proceed
+    @note It is safe to move the passed string value.
+    */
+    virtual bool string(string_t& val) = 0;
+
+    /*!
+    @brief a binary value was read
+    @param[in] val  binary value
+    @return whether parsing should proceed
+    @note It is safe to move the passed binary value.
+    */
+    virtual bool binary(binary_t& val) = 0;
+
+    /*!
+    @brief the beginning of an object was read
+    @param[in] elements  number of object elements or -1 if unknown
+    @return whether parsing should proceed
+    @note binary formats may report the number of elements
+    */
+    virtual bool start_object(std::size_t elements) = 0;
+
+    /*!
+    @brief an object key was read
+    @param[in] val  object key
+    @return whether parsing should proceed
+    @note It is safe to move the passed string.
+    */
+    virtual bool key(string_t& val) = 0;
+
+    /*!
+    @brief the end of an object was read
+    @return whether parsing should proceed
+    */
+    virtual bool end_object() = 0;
+
+    /*!
+    @brief the beginning of an array was read
+    @param[in] elements  number of array elements or -1 if unknown
+    @return whether parsing should proceed
+    @note binary formats may report the number of elements
+    */
+    virtual bool start_array(std::size_t elements) = 0;
+
+    /*!
+    @brief the end of an array was read
+    @return whether parsing should proceed
+    */
+    virtual bool end_array() = 0;
+
+    /*!
+    @brief a parse error occurred
+    @param[in] position    the position in the input where the error occurs
+    @param[in] last_token  the last read token
+    @param[in] ex          an exception object describing the error
+    @return whether parsing should proceed (must return false)
+    */
+    virtual bool parse_error(std::size_t position,
+                             const std::string& last_token,
+                             const detail::exception& ex) = 0;
+
+    json_sax() = default;
+    json_sax(const json_sax&) = default;
+    json_sax(json_sax&&) noexcept = default;
+    json_sax& operator=(const json_sax&) = default;
+    json_sax& operator=(json_sax&&) noexcept = default;
+    virtual ~json_sax() = default;
+};
+
+namespace detail
+{
+/*!
+@brief SAX implementation to create a JSON value from SAX events
+
+This class implements the @ref json_sax interface and processes the SAX events
+to create a JSON value which makes it basically a DOM parser. The structure or
+hierarchy of the JSON value is managed by the stack `ref_stack` which contains
+a pointer to the respective array or object for each recursion depth.
+
+After successful parsing, the value that is passed by reference to the
+constructor contains the parsed value.
+
+@tparam BasicJsonType  the JSON type
+*/
+template<typename BasicJsonType>
+class json_sax_dom_parser
+{
+  public:
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
+    using binary_t = typename BasicJsonType::binary_t;
+
+    /*!
+    @param[in,out] r  reference to a JSON value that is manipulated while
+                       parsing
+    @param[in] allow_exceptions_  whether parse errors yield exceptions
+    */
+    explicit json_sax_dom_parser(BasicJsonType& r, const bool allow_exceptions_ = true)
+        : root(r), allow_exceptions(allow_exceptions_)
+    {}
+
+    // make class move-only
+    json_sax_dom_parser(const json_sax_dom_parser&) = delete;
+    json_sax_dom_parser(json_sax_dom_parser&&) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
+    json_sax_dom_parser& operator=(const json_sax_dom_parser&) = delete;
+    json_sax_dom_parser& operator=(json_sax_dom_parser&&) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
+    ~json_sax_dom_parser() = default;
+
+    bool null()
+    {
+        handle_value(nullptr);
+        return true;
+    }
+
+    bool boolean(bool val)
+    {
+        handle_value(val);
+        return true;
+    }
+
+    bool number_integer(number_integer_t val)
+    {
+        handle_value(val);
+        return true;
+    }
+
+    bool number_unsigned(number_unsigned_t val)
+    {
+        handle_value(val);
+        return true;
+    }
+
+    bool number_float(number_float_t val, const string_t& /*unused*/)
+    {
+        handle_value(val);
+        return true;
+    }
+
+    bool string(string_t& val)
+    {
+        handle_value(val);
+        return true;
+    }
+
+    bool binary(binary_t& val)
+    {
+        handle_value(std::move(val));
+        return true;
+    }
+
+    bool start_object(std::size_t len)
+    {
+        ref_stack.push_back(handle_value(BasicJsonType::value_t::object));
+
+        if (JSON_HEDLEY_UNLIKELY(len != static_cast<std::size_t>(-1) && len > ref_stack.back()->max_size()))
+        {
+            JSON_THROW(out_of_range::create(408, concat("excessive object size: ", std::to_string(len)), ref_stack.back()));
+        }
+
+        return true;
+    }
+
+    bool key(string_t& val)
+    {
+        JSON_ASSERT(!ref_stack.empty());
+        JSON_ASSERT(ref_stack.back()->is_object());
+
+        // add null at given key and store the reference for later
+        object_element = &(ref_stack.back()->m_data.m_value.object->operator[](val));
+        return true;
+    }
+
+    bool end_object()
+    {
+        JSON_ASSERT(!ref_stack.empty());
+        JSON_ASSERT(ref_stack.back()->is_object());
+
+        ref_stack.back()->set_parents();
+        ref_stack.pop_back();
+        return true;
+    }
+
+    bool start_array(std::size_t len)
+    {
+        ref_stack.push_back(handle_value(BasicJsonType::value_t::array));
+
+        if (JSON_HEDLEY_UNLIKELY(len != static_cast<std::size_t>(-1) && len > ref_stack.back()->max_size()))
+        {
+            JSON_THROW(out_of_range::create(408, concat("excessive array size: ", std::to_string(len)), ref_stack.back()));
+        }
+
+        return true;
+    }
+
+    bool end_array()
+    {
+        JSON_ASSERT(!ref_stack.empty());
+        JSON_ASSERT(ref_stack.back()->is_array());
+
+        ref_stack.back()->set_parents();
+        ref_stack.pop_back();
+        return true;
+    }
+
+    template<class Exception>
+    bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/,
+                     const Exception& ex)
+    {
+        errored = true;
+        static_cast<void>(ex);
+        if (allow_exceptions)
+        {
+            JSON_THROW(ex);
+        }
+        return false;
+    }
+
+    constexpr bool is_errored() const
+    {
+        return errored;
+    }
+
+  private:
+    /*!
+    @invariant If the ref stack is empty, then the passed value will be the new
+               root.
+    @invariant If the ref stack contains a value, then it is an array or an
+               object to which we can add elements
+    */
+    template<typename Value>
+    JSON_HEDLEY_RETURNS_NON_NULL
+    BasicJsonType* handle_value(Value&& v)
+    {
+        if (ref_stack.empty())
+        {
+            root = BasicJsonType(std::forward<Value>(v));
+            return &root;
+        }
+
+        JSON_ASSERT(ref_stack.back()->is_array() || ref_stack.back()->is_object());
+
+        if (ref_stack.back()->is_array())
+        {
+            ref_stack.back()->m_data.m_value.array->emplace_back(std::forward<Value>(v));
+            return &(ref_stack.back()->m_data.m_value.array->back());
+        }
+
+        JSON_ASSERT(ref_stack.back()->is_object());
+        JSON_ASSERT(object_element);
+        *object_element = BasicJsonType(std::forward<Value>(v));
+        return object_element;
+    }
+
+    /// the parsed JSON value
+    BasicJsonType& root;
+    /// stack to model hierarchy of values
+    std::vector<BasicJsonType*> ref_stack {};
+    /// helper to hold the reference for the next object element
+    BasicJsonType* object_element = nullptr;
+    /// whether a syntax error occurred
+    bool errored = false;
+    /// whether to throw exceptions in case of errors
+    const bool allow_exceptions = true;
+};
+
+template<typename BasicJsonType>
+class json_sax_dom_callback_parser
+{
+  public:
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
+    using binary_t = typename BasicJsonType::binary_t;
+    using parser_callback_t = typename BasicJsonType::parser_callback_t;
+    using parse_event_t = typename BasicJsonType::parse_event_t;
+
+    json_sax_dom_callback_parser(BasicJsonType& r,
+                                 const parser_callback_t cb,
+                                 const bool allow_exceptions_ = true)
+        : root(r), callback(cb), allow_exceptions(allow_exceptions_)
+    {
+        keep_stack.push_back(true);
+    }
+
+    // make class move-only
+    json_sax_dom_callback_parser(const json_sax_dom_callback_parser&) = delete;
+    json_sax_dom_callback_parser(json_sax_dom_callback_parser&&) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
+    json_sax_dom_callback_parser& operator=(const json_sax_dom_callback_parser&) = delete;
+    json_sax_dom_callback_parser& operator=(json_sax_dom_callback_parser&&) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
+    ~json_sax_dom_callback_parser() = default;
+
+    bool null()
+    {
+        handle_value(nullptr);
+        return true;
+    }
+
+    bool boolean(bool val)
+    {
+        handle_value(val);
+        return true;
+    }
+
+    bool number_integer(number_integer_t val)
+    {
+        handle_value(val);
+        return true;
+    }
+
+    bool number_unsigned(number_unsigned_t val)
+    {
+        handle_value(val);
+        return true;
+    }
+
+    bool number_float(number_float_t val, const string_t& /*unused*/)
+    {
+        handle_value(val);
+        return true;
+    }
+
+    bool string(string_t& val)
+    {
+        handle_value(val);
+        return true;
+    }
+
+    bool binary(binary_t& val)
+    {
+        handle_value(std::move(val));
+        return true;
+    }
+
+    bool start_object(std::size_t len)
+    {
+        // check callback for object start
+        const bool keep = callback(static_cast<int>(ref_stack.size()), parse_event_t::object_start, discarded);
+        keep_stack.push_back(keep);
+
+        auto val = handle_value(BasicJsonType::value_t::object, true);
+        ref_stack.push_back(val.second);
+
+        // check object limit
+        if (ref_stack.back() && JSON_HEDLEY_UNLIKELY(len != static_cast<std::size_t>(-1) && len > ref_stack.back()->max_size()))
+        {
+            JSON_THROW(out_of_range::create(408, concat("excessive object size: ", std::to_string(len)), ref_stack.back()));
+        }
+
+        return true;
+    }
+
+    bool key(string_t& val)
+    {
+        BasicJsonType k = BasicJsonType(val);
+
+        // check callback for key
+        const bool keep = callback(static_cast<int>(ref_stack.size()), parse_event_t::key, k);
+        key_keep_stack.push_back(keep);
+
+        // add discarded value at given key and store the reference for later
+        if (keep && ref_stack.back())
+        {
+            object_element = &(ref_stack.back()->m_data.m_value.object->operator[](val) = discarded);
+        }
+
+        return true;
+    }
+
+    bool end_object()
+    {
+        if (ref_stack.back())
+        {
+            if (!callback(static_cast<int>(ref_stack.size()) - 1, parse_event_t::object_end, *ref_stack.back()))
+            {
+                // discard object
+                *ref_stack.back() = discarded;
+            }
+            else
+            {
+                ref_stack.back()->set_parents();
+            }
+        }
+
+        JSON_ASSERT(!ref_stack.empty());
+        JSON_ASSERT(!keep_stack.empty());
+        ref_stack.pop_back();
+        keep_stack.pop_back();
+
+        if (!ref_stack.empty() && ref_stack.back() && ref_stack.back()->is_structured())
+        {
+            // remove discarded value
+            for (auto it = ref_stack.back()->begin(); it != ref_stack.back()->end(); ++it)
+            {
+                if (it->is_discarded())
+                {
+                    ref_stack.back()->erase(it);
+                    break;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    bool start_array(std::size_t len)
+    {
+        const bool keep = callback(static_cast<int>(ref_stack.size()), parse_event_t::array_start, discarded);
+        keep_stack.push_back(keep);
+
+        auto val = handle_value(BasicJsonType::value_t::array, true);
+        ref_stack.push_back(val.second);
+
+        // check array limit
+        if (ref_stack.back() && JSON_HEDLEY_UNLIKELY(len != static_cast<std::size_t>(-1) && len > ref_stack.back()->max_size()))
+        {
+            JSON_THROW(out_of_range::create(408, concat("excessive array size: ", std::to_string(len)), ref_stack.back()));
+        }
+
+        return true;
+    }
+
+    bool end_array()
+    {
+        bool keep = true;
+
+        if (ref_stack.back())
+        {
+            keep = callback(static_cast<int>(ref_stack.size()) - 1, parse_event_t::array_end, *ref_stack.back());
+            if (keep)
+            {
+                ref_stack.back()->set_parents();
+            }
+            else
+            {
+                // discard array
+                *ref_stack.back() = discarded;
+            }
+        }
+
+        JSON_ASSERT(!ref_stack.empty());
+        JSON_ASSERT(!keep_stack.empty());
+        ref_stack.pop_back();
+        keep_stack.pop_back();
+
+        // remove discarded value
+        if (!keep && !ref_stack.empty() && ref_stack.back()->is_array())
+        {
+            ref_stack.back()->m_data.m_value.array->pop_back();
+        }
+
+        return true;
+    }
+
+    template<class Exception>
+    bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/,
+                     const Exception& ex)
+    {
+        errored = true;
+        static_cast<void>(ex);
+        if (allow_exceptions)
+        {
+            JSON_THROW(ex);
+        }
+        return false;
+    }
+
+    constexpr bool is_errored() const
+    {
+        return errored;
+    }
+
+  private:
+    /*!
+    @param[in] v  value to add to the JSON value we build during parsing
+    @param[in] skip_callback  whether we should skip calling the callback
+               function; this is required after start_array() and
+               start_object() SAX events, because otherwise we would call the
+               callback function with an empty array or object, respectively.
+
+    @invariant If the ref stack is empty, then the passed value will be the new
+               root.
+    @invariant If the ref stack contains a value, then it is an array or an
+               object to which we can add elements
+
+    @return pair of boolean (whether value should be kept) and pointer (to the
+            passed value in the ref_stack hierarchy; nullptr if not kept)
+    */
+    template<typename Value>
+    std::pair<bool, BasicJsonType*> handle_value(Value&& v, const bool skip_callback = false)
+    {
+        JSON_ASSERT(!keep_stack.empty());
+
+        // do not handle this value if we know it would be added to a discarded
+        // container
+        if (!keep_stack.back())
+        {
+            return {false, nullptr};
+        }
+
+        // create value
+        auto value = BasicJsonType(std::forward<Value>(v));
+
+        // check callback
+        const bool keep = skip_callback || callback(static_cast<int>(ref_stack.size()), parse_event_t::value, value);
+
+        // do not handle this value if we just learnt it shall be discarded
+        if (!keep)
+        {
+            return {false, nullptr};
+        }
+
+        if (ref_stack.empty())
+        {
+            root = std::move(value);
+            return {true, & root};
+        }
+
+        // skip this value if we already decided to skip the parent
+        // (https://github.com/nlohmann/json/issues/971#issuecomment-413678360)
+        if (!ref_stack.back())
+        {
+            return {false, nullptr};
+        }
+
+        // we now only expect arrays and objects
+        JSON_ASSERT(ref_stack.back()->is_array() || ref_stack.back()->is_object());
+
+        // array
+        if (ref_stack.back()->is_array())
+        {
+            ref_stack.back()->m_data.m_value.array->emplace_back(std::move(value));
+            return {true, & (ref_stack.back()->m_data.m_value.array->back())};
+        }
+
+        // object
+        JSON_ASSERT(ref_stack.back()->is_object());
+        // check if we should store an element for the current key
+        JSON_ASSERT(!key_keep_stack.empty());
+        const bool store_element = key_keep_stack.back();
+        key_keep_stack.pop_back();
+
+        if (!store_element)
+        {
+            return {false, nullptr};
+        }
+
+        JSON_ASSERT(object_element);
+        *object_element = std::move(value);
+        return {true, object_element};
+    }
+
+    /// the parsed JSON value
+    BasicJsonType& root;
+    /// stack to model hierarchy of values
+    std::vector<BasicJsonType*> ref_stack {};
+    /// stack to manage which values to keep
+    std::vector<bool> keep_stack {};
+    /// stack to manage which object keys to keep
+    std::vector<bool> key_keep_stack {};
+    /// helper to hold the reference for the next object element
+    BasicJsonType* object_element = nullptr;
+    /// whether a syntax error occurred
+    bool errored = false;
+    /// callback function
+    const parser_callback_t callback = nullptr;
+    /// whether to throw exceptions in case of errors
+    const bool allow_exceptions = true;
+    /// a discarded value for the callback
+    BasicJsonType discarded = BasicJsonType::value_t::discarded;
+};
+
+template<typename BasicJsonType>
+class json_sax_acceptor
+{
+  public:
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
+    using binary_t = typename BasicJsonType::binary_t;
+
+    bool null()
+    {
+        return true;
+    }
+
+    bool boolean(bool /*unused*/)
+    {
+        return true;
+    }
+
+    bool number_integer(number_integer_t /*unused*/)
+    {
+        return true;
+    }
+
+    bool number_unsigned(number_unsigned_t /*unused*/)
+    {
+        return true;
+    }
+
+    bool number_float(number_float_t /*unused*/, const string_t& /*unused*/)
+    {
+        return true;
+    }
+
+    bool string(string_t& /*unused*/)
+    {
+        return true;
+    }
+
+    bool binary(binary_t& /*unused*/)
+    {
+        return true;
+    }
+
+    bool start_object(std::size_t /*unused*/ = static_cast<std::size_t>(-1))
+    {
+        return true;
+    }
+
+    bool key(string_t& /*unused*/)
+    {
+        return true;
+    }
+
+    bool end_object()
+    {
+        return true;
+    }
+
+    bool start_array(std::size_t /*unused*/ = static_cast<std::size_t>(-1))
+    {
+        return true;
+    }
+
+    bool end_array()
+    {
+        return true;
+    }
+
+    bool parse_error(std::size_t /*unused*/, const std::string& /*unused*/, const detail::exception& /*unused*/)
+    {
+        return false;
+    }
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/input/lexer.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <array> // array
+#include <clocale> // localeconv
+#include <cstddef> // size_t
+#include <cstdio> // snprintf
+#include <cstdlib> // strtof, strtod, strtold, strtoll, strtoull
+#include <initializer_list> // initializer_list
+#include <string> // char_traits, string
+#include <utility> // move
+#include <vector> // vector
+
+// #include <nlohmann/detail/input/input_adapters.hpp>
+
+// #include <nlohmann/detail/input/position_t.hpp>
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+///////////
+// lexer //
+///////////
+
+template<typename BasicJsonType>
+class lexer_base
+{
+  public:
+    /// token types for the parser
+    enum class token_type
+    {
+        uninitialized,    ///< indicating the scanner is uninitialized
+        literal_true,     ///< the `true` literal
+        literal_false,    ///< the `false` literal
+        literal_null,     ///< the `null` literal
+        value_string,     ///< a string -- use get_string() for actual value
+        value_unsigned,   ///< an unsigned integer -- use get_number_unsigned() for actual value
+        value_integer,    ///< a signed integer -- use get_number_integer() for actual value
+        value_float,      ///< an floating point number -- use get_number_float() for actual value
+        begin_array,      ///< the character for array begin `[`
+        begin_object,     ///< the character for object begin `{`
+        end_array,        ///< the character for array end `]`
+        end_object,       ///< the character for object end `}`
+        name_separator,   ///< the name separator `:`
+        value_separator,  ///< the value separator `,`
+        parse_error,      ///< indicating a parse error
+        end_of_input,     ///< indicating the end of the input buffer
+        literal_or_value  ///< a literal or the begin of a value (only for diagnostics)
+    };
+
+    /// return name of values of type token_type (only used for errors)
+    JSON_HEDLEY_RETURNS_NON_NULL
+    JSON_HEDLEY_CONST
+    static const char* token_type_name(const token_type t) noexcept
+    {
+        switch (t)
+        {
+            case token_type::uninitialized:
+                return "<uninitialized>";
+            case token_type::literal_true:
+                return "true literal";
+            case token_type::literal_false:
+                return "false literal";
+            case token_type::literal_null:
+                return "null literal";
+            case token_type::value_string:
+                return "string literal";
+            case token_type::value_unsigned:
+            case token_type::value_integer:
+            case token_type::value_float:
+                return "number literal";
+            case token_type::begin_array:
+                return "'['";
+            case token_type::begin_object:
+                return "'{'";
+            case token_type::end_array:
+                return "']'";
+            case token_type::end_object:
+                return "'}'";
+            case token_type::name_separator:
+                return "':'";
+            case token_type::value_separator:
+                return "','";
+            case token_type::parse_error:
+                return "<parse error>";
+            case token_type::end_of_input:
+                return "end of input";
+            case token_type::literal_or_value:
+                return "'[', '{', or a literal";
+            // LCOV_EXCL_START
+            default: // catch non-enum values
+                return "unknown token";
+                // LCOV_EXCL_STOP
+        }
+    }
+};
+/*!
+@brief lexical analysis
+
+This class organizes the lexical analysis during JSON deserialization.
+*/
+template<typename BasicJsonType, typename InputAdapterType>
+class lexer : public lexer_base<BasicJsonType>
+{
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
+    using char_type = typename InputAdapterType::char_type;
+    using char_int_type = typename char_traits<char_type>::int_type;
+
+  public:
+    using token_type = typename lexer_base<BasicJsonType>::token_type;
+
+    explicit lexer(InputAdapterType&& adapter, bool ignore_comments_ = false) noexcept
+        : ia(std::move(adapter))
+        , ignore_comments(ignore_comments_)
+        , decimal_point_char(static_cast<char_int_type>(get_decimal_point()))
+    {}
+
+    // delete because of pointer members
+    lexer(const lexer&) = delete;
+    lexer(lexer&&) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
+    lexer& operator=(lexer&) = delete;
+    lexer& operator=(lexer&&) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
+    ~lexer() = default;
+
+  private:
+    /////////////////////
+    // locales
+    /////////////////////
+
+    /// return the locale-dependent decimal point
+    JSON_HEDLEY_PURE
+    static char get_decimal_point() noexcept
+    {
+        const auto* loc = localeconv();
+        JSON_ASSERT(loc != nullptr);
+        return (loc->decimal_point == nullptr) ? '.' : *(loc->decimal_point);
+    }
+
+    /////////////////////
+    // scan functions
+    /////////////////////
+
+    /*!
+    @brief get codepoint from 4 hex characters following `\u`
+
+    For input "\u c1 c2 c3 c4" the codepoint is:
+      (c1 * 0x1000) + (c2 * 0x0100) + (c3 * 0x0010) + c4
+    = (c1 << 12) + (c2 << 8) + (c3 << 4) + (c4 << 0)
+
+    Furthermore, the possible characters '0'..'9', 'A'..'F', and 'a'..'f'
+    must be converted to the integers 0x0..0x9, 0xA..0xF, 0xA..0xF, resp. The
+    conversion is done by subtracting the offset (0x30, 0x37, and 0x57)
+    between the ASCII value of the character and the desired integer value.
+
+    @return codepoint (0x0000..0xFFFF) or -1 in case of an error (e.g. EOF or
+            non-hex character)
+    */
+    int get_codepoint()
+    {
+        // this function only makes sense after reading `\u`
+        JSON_ASSERT(current == 'u');
+        int codepoint = 0;
+
+        const auto factors = { 12u, 8u, 4u, 0u };
+        for (const auto factor : factors)
+        {
+            get();
+
+            if (current >= '0' && current <= '9')
+            {
+                codepoint += static_cast<int>((static_cast<unsigned int>(current) - 0x30u) << factor);
+            }
+            else if (current >= 'A' && current <= 'F')
+            {
+                codepoint += static_cast<int>((static_cast<unsigned int>(current) - 0x37u) << factor);
+            }
+            else if (current >= 'a' && current <= 'f')
+            {
+                codepoint += static_cast<int>((static_cast<unsigned int>(current) - 0x57u) << factor);
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
+        JSON_ASSERT(0x0000 <= codepoint && codepoint <= 0xFFFF);
+        return codepoint;
+    }
+
+    /*!
+    @brief check if the next byte(s) are inside a given range
+
+    Adds the current byte and, for each passed range, reads a new byte and
+    checks if it is inside the range. If a violation was detected, set up an
+    error message and return false. Otherwise, return true.
+
+    @param[in] ranges  list of integers; interpreted as list of pairs of
+                       inclusive lower and upper bound, respectively
+
+    @pre The passed list @a ranges must have 2, 4, or 6 elements; that is,
+         1, 2, or 3 pairs. This precondition is enforced by an assertion.
+
+    @return true if and only if no range violation was detected
+    */
+    bool next_byte_in_range(std::initializer_list<char_int_type> ranges)
+    {
+        JSON_ASSERT(ranges.size() == 2 || ranges.size() == 4 || ranges.size() == 6);
+        add(current);
+
+        for (auto range = ranges.begin(); range != ranges.end(); ++range)
+        {
+            get();
+            if (JSON_HEDLEY_LIKELY(*range <= current && current <= *(++range))) // NOLINT(bugprone-inc-dec-in-conditions)
+            {
+                add(current);
+            }
+            else
+            {
+                error_message = "invalid string: ill-formed UTF-8 byte";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /*!
+    @brief scan a string literal
+
+    This function scans a string according to Sect. 7 of RFC 8259. While
+    scanning, bytes are escaped and copied into buffer token_buffer. Then the
+    function returns successfully, token_buffer is *not* null-terminated (as it
+    may contain \0 bytes), and token_buffer.size() is the number of bytes in the
+    string.
+
+    @return token_type::value_string if string could be successfully scanned,
+            token_type::parse_error otherwise
+
+    @note In case of errors, variable error_message contains a textual
+          description.
+    */
+    token_type scan_string()
+    {
+        // reset token_buffer (ignore opening quote)
+        reset();
+
+        // we entered the function by reading an open quote
+        JSON_ASSERT(current == '\"');
+
+        while (true)
+        {
+            // get next character
+            switch (get())
+            {
+                // end of file while parsing string
+                case char_traits<char_type>::eof():
+                {
+                    error_message = "invalid string: missing closing quote";
+                    return token_type::parse_error;
+                }
+
+                // closing quote
+                case '\"':
+                {
+                    return token_type::value_string;
+                }
+
+                // escapes
+                case '\\':
+                {
+                    switch (get())
+                    {
+                        // quotation mark
+                        case '\"':
+                            add('\"');
+                            break;
+                        // reverse solidus
+                        case '\\':
+                            add('\\');
+                            break;
+                        // solidus
+                        case '/':
+                            add('/');
+                            break;
+                        // backspace
+                        case 'b':
+                            add('\b');
+                            break;
+                        // form feed
+                        case 'f':
+                            add('\f');
+                            break;
+                        // line feed
+                        case 'n':
+                            add('\n');
+                            break;
+                        // carriage return
+                        case 'r':
+                            add('\r');
+                            break;
+                        // tab
+                        case 't':
+                            add('\t');
+                            break;
+
+                        // unicode escapes
+                        case 'u':
+                        {
+                            const int codepoint1 = get_codepoint();
+                            int codepoint = codepoint1; // start with codepoint1
+
+                            if (JSON_HEDLEY_UNLIKELY(codepoint1 == -1))
+                            {
+                                error_message = "invalid string: '\\u' must be followed by 4 hex digits";
+                                return token_type::parse_error;
+                            }
+
+                            // check if code point is a high surrogate
+                            if (0xD800 <= codepoint1 && codepoint1 <= 0xDBFF)
+                            {
+                                // expect next \uxxxx entry
+                                if (JSON_HEDLEY_LIKELY(get() == '\\' && get() == 'u'))
+                                {
+                                    const int codepoint2 = get_codepoint();
+
+                                    if (JSON_HEDLEY_UNLIKELY(codepoint2 == -1))
+                                    {
+                                        error_message = "invalid string: '\\u' must be followed by 4 hex digits";
+                                        return token_type::parse_error;
+                                    }
+
+                                    // check if codepoint2 is a low surrogate
+                                    if (JSON_HEDLEY_LIKELY(0xDC00 <= codepoint2 && codepoint2 <= 0xDFFF))
+                                    {
+                                        // overwrite codepoint
+                                        codepoint = static_cast<int>(
+                                                        // high surrogate occupies the most significant 22 bits
+                                                        (static_cast<unsigned int>(codepoint1) << 10u)
+                                                        // low surrogate occupies the least significant 15 bits
+                                                        + static_cast<unsigned int>(codepoint2)
+                                                        // there is still the 0xD800, 0xDC00 and 0x10000 noise
+                                                        // in the result, so we have to subtract with:
+                                                        // (0xD800 << 10) + DC00 - 0x10000 = 0x35FDC00
+                                                        - 0x35FDC00u);
+                                    }
+                                    else
+                                    {
+                                        error_message = "invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF";
+                                        return token_type::parse_error;
+                                    }
+                                }
+                                else
+                                {
+                                    error_message = "invalid string: surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF";
+                                    return token_type::parse_error;
+                                }
+                            }
+                            else
+                            {
+                                if (JSON_HEDLEY_UNLIKELY(0xDC00 <= codepoint1 && codepoint1 <= 0xDFFF))
+                                {
+                                    error_message = "invalid string: surrogate U+DC00..U+DFFF must follow U+D800..U+DBFF";
+                                    return token_type::parse_error;
+                                }
+                            }
+
+                            // result of the above calculation yields a proper codepoint
+                            JSON_ASSERT(0x00 <= codepoint && codepoint <= 0x10FFFF);
+
+                            // translate codepoint into bytes
+                            if (codepoint < 0x80)
+                            {
+                                // 1-byte characters: 0xxxxxxx (ASCII)
+                                add(static_cast<char_int_type>(codepoint));
+                            }
+                            else if (codepoint <= 0x7FF)
+                            {
+                                // 2-byte characters: 110xxxxx 10xxxxxx
+                                add(static_cast<char_int_type>(0xC0u | (static_cast<unsigned int>(codepoint) >> 6u)));
+                                add(static_cast<char_int_type>(0x80u | (static_cast<unsigned int>(codepoint) & 0x3Fu)));
+                            }
+                            else if (codepoint <= 0xFFFF)
+                            {
+                                // 3-byte characters: 1110xxxx 10xxxxxx 10xxxxxx
+                                add(static_cast<char_int_type>(0xE0u | (static_cast<unsigned int>(codepoint) >> 12u)));
+                                add(static_cast<char_int_type>(0x80u | ((static_cast<unsigned int>(codepoint) >> 6u) & 0x3Fu)));
+                                add(static_cast<char_int_type>(0x80u | (static_cast<unsigned int>(codepoint) & 0x3Fu)));
+                            }
+                            else
+                            {
+                                // 4-byte characters: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+                                add(static_cast<char_int_type>(0xF0u | (static_cast<unsigned int>(codepoint) >> 18u)));
+                                add(static_cast<char_int_type>(0x80u | ((static_cast<unsigned int>(codepoint) >> 12u) & 0x3Fu)));
+                                add(static_cast<char_int_type>(0x80u | ((static_cast<unsigned int>(codepoint) >> 6u) & 0x3Fu)));
+                                add(static_cast<char_int_type>(0x80u | (static_cast<unsigned int>(codepoint) & 0x3Fu)));
+                            }
+
+                            break;
+                        }
+
+                        // other characters after escape
+                        default:
+                            error_message = "invalid string: forbidden character after backslash";
+                            return token_type::parse_error;
+                    }
+
+                    break;
+                }
+
+                // invalid control characters
+                case 0x00:
+                {
+                    error_message = "invalid string: control character U+0000 (NUL) must be escaped to \\u0000";
+                    return token_type::parse_error;
+                }
+
+                case 0x01:
+                {
+                    error_message = "invalid string: control character U+0001 (SOH) must be escaped to \\u0001";
+                    return token_type::parse_error;
+                }
+
+                case 0x02:
+                {
+                    error_message = "invalid string: control character U+0002 (STX) must be escaped to \\u0002";
+                    return token_type::parse_error;
+                }
+
+                case 0x03:
+                {
+                    error_message = "invalid string: control character U+0003 (ETX) must be escaped to \\u0003";
+                    return token_type::parse_error;
+                }
+
+                case 0x04:
+                {
+                    error_message = "invalid string: control character U+0004 (EOT) must be escaped to \\u0004";
+                    return token_type::parse_error;
+                }
+
+                case 0x05:
+                {
+                    error_message = "invalid string: control character U+0005 (ENQ) must be escaped to \\u0005";
+                    return token_type::parse_error;
+                }
+
+                case 0x06:
+                {
+                    error_message = "invalid string: control character U+0006 (ACK) must be escaped to \\u0006";
+                    return token_type::parse_error;
+                }
+
+                case 0x07:
+                {
+                    error_message = "invalid string: control character U+0007 (BEL) must be escaped to \\u0007";
+                    return token_type::parse_error;
+                }
+
+                case 0x08:
+                {
+                    error_message = "invalid string: control character U+0008 (BS) must be escaped to \\u0008 or \\b";
+                    return token_type::parse_error;
+                }
+
+                case 0x09:
+                {
+                    error_message = "invalid string: control character U+0009 (HT) must be escaped to \\u0009 or \\t";
+                    return token_type::parse_error;
+                }
+
+                case 0x0A:
+                {
+                    error_message = "invalid string: control character U+000A (LF) must be escaped to \\u000A or \\n";
+                    return token_type::parse_error;
+                }
+
+                case 0x0B:
+                {
+                    error_message = "invalid string: control character U+000B (VT) must be escaped to \\u000B";
+                    return token_type::parse_error;
+                }
+
+                case 0x0C:
+                {
+                    error_message = "invalid string: control character U+000C (FF) must be escaped to \\u000C or \\f";
+                    return token_type::parse_error;
+                }
+
+                case 0x0D:
+                {
+                    error_message = "invalid string: control character U+000D (CR) must be escaped to \\u000D or \\r";
+                    return token_type::parse_error;
+                }
+
+                case 0x0E:
+                {
+                    error_message = "invalid string: control character U+000E (SO) must be escaped to \\u000E";
+                    return token_type::parse_error;
+                }
+
+                case 0x0F:
+                {
+                    error_message = "invalid string: control character U+000F (SI) must be escaped to \\u000F";
+                    return token_type::parse_error;
+                }
+
+                case 0x10:
+                {
+                    error_message = "invalid string: control character U+0010 (DLE) must be escaped to \\u0010";
+                    return token_type::parse_error;
+                }
+
+                case 0x11:
+                {
+                    error_message = "invalid string: control character U+0011 (DC1) must be escaped to \\u0011";
+                    return token_type::parse_error;
+                }
+
+                case 0x12:
+                {
+                    error_message = "invalid string: control character U+0012 (DC2) must be escaped to \\u0012";
+                    return token_type::parse_error;
+                }
+
+                case 0x13:
+                {
+                    error_message = "invalid string: control character U+0013 (DC3) must be escaped to \\u0013";
+                    return token_type::parse_error;
+                }
+
+                case 0x14:
+                {
+                    error_message = "invalid string: control character U+0014 (DC4) must be escaped to \\u0014";
+                    return token_type::parse_error;
+                }
+
+                case 0x15:
+                {
+                    error_message = "invalid string: control character U+0015 (NAK) must be escaped to \\u0015";
+                    return token_type::parse_error;
+                }
+
+                case 0x16:
+                {
+                    error_message = "invalid string: control character U+0016 (SYN) must be escaped to \\u0016";
+                    return token_type::parse_error;
+                }
+
+                case 0x17:
+                {
+                    error_message = "invalid string: control character U+0017 (ETB) must be escaped to \\u0017";
+                    return token_type::parse_error;
+                }
+
+                case 0x18:
+                {
+                    error_message = "invalid string: control character U+0018 (CAN) must be escaped to \\u0018";
+                    return token_type::parse_error;
+                }
+
+                case 0x19:
+                {
+                    error_message = "invalid string: control character U+0019 (EM) must be escaped to \\u0019";
+                    return token_type::parse_error;
+                }
+
+                case 0x1A:
+                {
+                    error_message = "invalid string: control character U+001A (SUB) must be escaped to \\u001A";
+                    return token_type::parse_error;
+                }
+
+                case 0x1B:
+                {
+                    error_message = "invalid string: control character U+001B (ESC) must be escaped to \\u001B";
+                    return token_type::parse_error;
+                }
+
+                case 0x1C:
+                {
+                    error_message = "invalid string: control character U+001C (FS) must be escaped to \\u001C";
+                    return token_type::parse_error;
+                }
+
+                case 0x1D:
+                {
+                    error_message = "invalid string: control character U+001D (GS) must be escaped to \\u001D";
+                    return token_type::parse_error;
+                }
+
+                case 0x1E:
+                {
+                    error_message = "invalid string: control character U+001E (RS) must be escaped to \\u001E";
+                    return token_type::parse_error;
+                }
+
+                case 0x1F:
+                {
+                    error_message = "invalid string: control character U+001F (US) must be escaped to \\u001F";
+                    return token_type::parse_error;
+                }
+
+                // U+0020..U+007F (except U+0022 (quote) and U+005C (backspace))
+                case 0x20:
+                case 0x21:
+                case 0x23:
+                case 0x24:
+                case 0x25:
+                case 0x26:
+                case 0x27:
+                case 0x28:
+                case 0x29:
+                case 0x2A:
+                case 0x2B:
+                case 0x2C:
+                case 0x2D:
+                case 0x2E:
+                case 0x2F:
+                case 0x30:
+                case 0x31:
+                case 0x32:
+                case 0x33:
+                case 0x34:
+                case 0x35:
+                case 0x36:
+                case 0x37:
+                case 0x38:
+                case 0x39:
+                case 0x3A:
+                case 0x3B:
+                case 0x3C:
+                case 0x3D:
+                case 0x3E:
+                case 0x3F:
+                case 0x40:
+                case 0x41:
+                case 0x42:
+                case 0x43:
+                case 0x44:
+                case 0x45:
+                case 0x46:
+                case 0x47:
+                case 0x48:
+                case 0x49:
+                case 0x4A:
+                case 0x4B:
+                case 0x4C:
+                case 0x4D:
+                case 0x4E:
+                case 0x4F:
+                case 0x50:
+                case 0x51:
+                case 0x52:
+                case 0x53:
+                case 0x54:
+                case 0x55:
+                case 0x56:
+                case 0x57:
+                case 0x58:
+                case 0x59:
+                case 0x5A:
+                case 0x5B:
+                case 0x5D:
+                case 0x5E:
+                case 0x5F:
+                case 0x60:
+                case 0x61:
+                case 0x62:
+                case 0x63:
+                case 0x64:
+                case 0x65:
+                case 0x66:
+                case 0x67:
+                case 0x68:
+                case 0x69:
+                case 0x6A:
+                case 0x6B:
+                case 0x6C:
+                case 0x6D:
+                case 0x6E:
+                case 0x6F:
+                case 0x70:
+                case 0x71:
+                case 0x72:
+                case 0x73:
+                case 0x74:
+                case 0x75:
+                case 0x76:
+                case 0x77:
+                case 0x78:
+                case 0x79:
+                case 0x7A:
+                case 0x7B:
+                case 0x7C:
+                case 0x7D:
+                case 0x7E:
+                case 0x7F:
+                {
+                    add(current);
+                    break;
+                }
+
+                // U+0080..U+07FF: bytes C2..DF 80..BF
+                case 0xC2:
+                case 0xC3:
+                case 0xC4:
+                case 0xC5:
+                case 0xC6:
+                case 0xC7:
+                case 0xC8:
+                case 0xC9:
+                case 0xCA:
+                case 0xCB:
+                case 0xCC:
+                case 0xCD:
+                case 0xCE:
+                case 0xCF:
+                case 0xD0:
+                case 0xD1:
+                case 0xD2:
+                case 0xD3:
+                case 0xD4:
+                case 0xD5:
+                case 0xD6:
+                case 0xD7:
+                case 0xD8:
+                case 0xD9:
+                case 0xDA:
+                case 0xDB:
+                case 0xDC:
+                case 0xDD:
+                case 0xDE:
+                case 0xDF:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!next_byte_in_range({0x80, 0xBF})))
+                    {
+                        return token_type::parse_error;
+                    }
+                    break;
+                }
+
+                // U+0800..U+0FFF: bytes E0 A0..BF 80..BF
+                case 0xE0:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!(next_byte_in_range({0xA0, 0xBF, 0x80, 0xBF}))))
+                    {
+                        return token_type::parse_error;
+                    }
+                    break;
+                }
+
+                // U+1000..U+CFFF: bytes E1..EC 80..BF 80..BF
+                // U+E000..U+FFFF: bytes EE..EF 80..BF 80..BF
+                case 0xE1:
+                case 0xE2:
+                case 0xE3:
+                case 0xE4:
+                case 0xE5:
+                case 0xE6:
+                case 0xE7:
+                case 0xE8:
+                case 0xE9:
+                case 0xEA:
+                case 0xEB:
+                case 0xEC:
+                case 0xEE:
+                case 0xEF:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!(next_byte_in_range({0x80, 0xBF, 0x80, 0xBF}))))
+                    {
+                        return token_type::parse_error;
+                    }
+                    break;
+                }
+
+                // U+D000..U+D7FF: bytes ED 80..9F 80..BF
+                case 0xED:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!(next_byte_in_range({0x80, 0x9F, 0x80, 0xBF}))))
+                    {
+                        return token_type::parse_error;
+                    }
+                    break;
+                }
+
+                // U+10000..U+3FFFF F0 90..BF 80..BF 80..BF
+                case 0xF0:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!(next_byte_in_range({0x90, 0xBF, 0x80, 0xBF, 0x80, 0xBF}))))
+                    {
+                        return token_type::parse_error;
+                    }
+                    break;
+                }
+
+                // U+40000..U+FFFFF F1..F3 80..BF 80..BF 80..BF
+                case 0xF1:
+                case 0xF2:
+                case 0xF3:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!(next_byte_in_range({0x80, 0xBF, 0x80, 0xBF, 0x80, 0xBF}))))
+                    {
+                        return token_type::parse_error;
+                    }
+                    break;
+                }
+
+                // U+100000..U+10FFFF F4 80..8F 80..BF 80..BF
+                case 0xF4:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!(next_byte_in_range({0x80, 0x8F, 0x80, 0xBF, 0x80, 0xBF}))))
+                    {
+                        return token_type::parse_error;
+                    }
+                    break;
+                }
+
+                // remaining bytes (80..C1 and F5..FF) are ill-formed
+                default:
+                {
+                    error_message = "invalid string: ill-formed UTF-8 byte";
+                    return token_type::parse_error;
+                }
+            }
+        }
+    }
+
+    /*!
+     * @brief scan a comment
+     * @return whether comment could be scanned successfully
+     */
+    bool scan_comment()
+    {
+        switch (get())
+        {
+            // single-line comments skip input until a newline or EOF is read
+            case '/':
+            {
+                while (true)
+                {
+                    switch (get())
+                    {
+                        case '\n':
+                        case '\r':
+                        case char_traits<char_type>::eof():
+                        case '\0':
+                            return true;
+
+                        default:
+                            break;
+                    }
+                }
+            }
+
+            // multi-line comments skip input until */ is read
+            case '*':
+            {
+                while (true)
+                {
+                    switch (get())
+                    {
+                        case char_traits<char_type>::eof():
+                        case '\0':
+                        {
+                            error_message = "invalid comment; missing closing '*/'";
+                            return false;
+                        }
+
+                        case '*':
+                        {
+                            switch (get())
+                            {
+                                case '/':
+                                    return true;
+
+                                default:
+                                {
+                                    unget();
+                                    continue;
+                                }
+                            }
+                        }
+
+                        default:
+                            continue;
+                    }
+                }
+            }
+
+            // unexpected character after reading '/'
+            default:
+            {
+                error_message = "invalid comment; expecting '/' or '*' after '/'";
+                return false;
+            }
+        }
+    }
+
+    JSON_HEDLEY_NON_NULL(2)
+    static void strtof(float& f, const char* str, char** endptr) noexcept
+    {
+        f = std::strtof(str, endptr);
+    }
+
+    JSON_HEDLEY_NON_NULL(2)
+    static void strtof(double& f, const char* str, char** endptr) noexcept
+    {
+        f = std::strtod(str, endptr);
+    }
+
+    JSON_HEDLEY_NON_NULL(2)
+    static void strtof(long double& f, const char* str, char** endptr) noexcept
+    {
+        f = std::strtold(str, endptr);
+    }
+
+    /*!
+    @brief scan a number literal
+
+    This function scans a string according to Sect. 6 of RFC 8259.
+
+    The function is realized with a deterministic finite state machine derived
+    from the grammar described in RFC 8259. Starting in state "init", the
+    input is read and used to determined the next state. Only state "done"
+    accepts the number. State "error" is a trap state to model errors. In the
+    table below, "anything" means any character but the ones listed before.
+
+    state    | 0        | 1-9      | e E      | +       | -       | .        | anything
+    ---------|----------|----------|----------|---------|---------|----------|-----------
+    init     | zero     | any1     | [error]  | [error] | minus   | [error]  | [error]
+    minus    | zero     | any1     | [error]  | [error] | [error] | [error]  | [error]
+    zero     | done     | done     | exponent | done    | done    | decimal1 | done
+    any1     | any1     | any1     | exponent | done    | done    | decimal1 | done
+    decimal1 | decimal2 | decimal2 | [error]  | [error] | [error] | [error]  | [error]
+    decimal2 | decimal2 | decimal2 | exponent | done    | done    | done     | done
+    exponent | any2     | any2     | [error]  | sign    | sign    | [error]  | [error]
+    sign     | any2     | any2     | [error]  | [error] | [error] | [error]  | [error]
+    any2     | any2     | any2     | done     | done    | done    | done     | done
+
+    The state machine is realized with one label per state (prefixed with
+    "scan_number_") and `goto` statements between them. The state machine
+    contains cycles, but any cycle can be left when EOF is read. Therefore,
+    the function is guaranteed to terminate.
+
+    During scanning, the read bytes are stored in token_buffer. This string is
+    then converted to a signed integer, an unsigned integer, or a
+    floating-point number.
+
+    @return token_type::value_unsigned, token_type::value_integer, or
+            token_type::value_float if number could be successfully scanned,
+            token_type::parse_error otherwise
+
+    @note The scanner is independent of the current locale. Internally, the
+          locale's decimal point is used instead of `.` to work with the
+          locale-dependent converters.
+    */
+    token_type scan_number()  // lgtm [cpp/use-of-goto]
+    {
+        // reset token_buffer to store the number's bytes
+        reset();
+
+        // the type of the parsed number; initially set to unsigned; will be
+        // changed if minus sign, decimal point or exponent is read
+        token_type number_type = token_type::value_unsigned;
+
+        // state (init): we just found out we need to scan a number
+        switch (current)
+        {
+            case '-':
+            {
+                add(current);
+                goto scan_number_minus;
+            }
+
+            case '0':
+            {
+                add(current);
+                goto scan_number_zero;
+            }
+
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any1;
+            }
+
+            // all other characters are rejected outside scan_number()
+            default:            // LCOV_EXCL_LINE
+                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+        }
+
+scan_number_minus:
+        // state: we just parsed a leading minus sign
+        number_type = token_type::value_integer;
+        switch (get())
+        {
+            case '0':
+            {
+                add(current);
+                goto scan_number_zero;
+            }
+
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any1;
+            }
+
+            default:
+            {
+                error_message = "invalid number; expected digit after '-'";
+                return token_type::parse_error;
+            }
+        }
+
+scan_number_zero:
+        // state: we just parse a zero (maybe with a leading minus sign)
+        switch (get())
+        {
+            case '.':
+            {
+                add(decimal_point_char);
+                goto scan_number_decimal1;
+            }
+
+            case 'e':
+            case 'E':
+            {
+                add(current);
+                goto scan_number_exponent;
+            }
+
+            default:
+                goto scan_number_done;
+        }
+
+scan_number_any1:
+        // state: we just parsed a number 0-9 (maybe with a leading minus sign)
+        switch (get())
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any1;
+            }
+
+            case '.':
+            {
+                add(decimal_point_char);
+                goto scan_number_decimal1;
+            }
+
+            case 'e':
+            case 'E':
+            {
+                add(current);
+                goto scan_number_exponent;
+            }
+
+            default:
+                goto scan_number_done;
+        }
+
+scan_number_decimal1:
+        // state: we just parsed a decimal point
+        number_type = token_type::value_float;
+        switch (get())
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_decimal2;
+            }
+
+            default:
+            {
+                error_message = "invalid number; expected digit after '.'";
+                return token_type::parse_error;
+            }
+        }
+
+scan_number_decimal2:
+        // we just parsed at least one number after a decimal point
+        switch (get())
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_decimal2;
+            }
+
+            case 'e':
+            case 'E':
+            {
+                add(current);
+                goto scan_number_exponent;
+            }
+
+            default:
+                goto scan_number_done;
+        }
+
+scan_number_exponent:
+        // we just parsed an exponent
+        number_type = token_type::value_float;
+        switch (get())
+        {
+            case '+':
+            case '-':
+            {
+                add(current);
+                goto scan_number_sign;
+            }
+
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any2;
+            }
+
+            default:
+            {
+                error_message =
+                    "invalid number; expected '+', '-', or digit after exponent";
+                return token_type::parse_error;
+            }
+        }
+
+scan_number_sign:
+        // we just parsed an exponent sign
+        switch (get())
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any2;
+            }
+
+            default:
+            {
+                error_message = "invalid number; expected digit after exponent sign";
+                return token_type::parse_error;
+            }
+        }
+
+scan_number_any2:
+        // we just parsed a number after the exponent or exponent sign
+        switch (get())
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            {
+                add(current);
+                goto scan_number_any2;
+            }
+
+            default:
+                goto scan_number_done;
+        }
+
+scan_number_done:
+        // unget the character after the number (we only read it to know that
+        // we are done scanning a number)
+        unget();
+
+        char* endptr = nullptr; // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        errno = 0;
+
+        // try to parse integers first and fall back to floats
+        if (number_type == token_type::value_unsigned)
+        {
+            const auto x = std::strtoull(token_buffer.data(), &endptr, 10);
+
+            // we checked the number format before
+            JSON_ASSERT(endptr == token_buffer.data() + token_buffer.size());
+
+            if (errno == 0)
+            {
+                value_unsigned = static_cast<number_unsigned_t>(x);
+                if (value_unsigned == x)
+                {
+                    return token_type::value_unsigned;
+                }
+            }
+        }
+        else if (number_type == token_type::value_integer)
+        {
+            const auto x = std::strtoll(token_buffer.data(), &endptr, 10);
+
+            // we checked the number format before
+            JSON_ASSERT(endptr == token_buffer.data() + token_buffer.size());
+
+            if (errno == 0)
+            {
+                value_integer = static_cast<number_integer_t>(x);
+                if (value_integer == x)
+                {
+                    return token_type::value_integer;
+                }
+            }
+        }
+
+        // this code is reached if we parse a floating-point number or if an
+        // integer conversion above failed
+        strtof(value_float, token_buffer.data(), &endptr);
+
+        // we checked the number format before
+        JSON_ASSERT(endptr == token_buffer.data() + token_buffer.size());
+
+        return token_type::value_float;
+    }
+
+    /*!
+    @param[in] literal_text  the literal text to expect
+    @param[in] length        the length of the passed literal text
+    @param[in] return_type   the token type to return on success
+    */
+    JSON_HEDLEY_NON_NULL(2)
+    token_type scan_literal(const char_type* literal_text, const std::size_t length,
+                            token_type return_type)
+    {
+        JSON_ASSERT(char_traits<char_type>::to_char_type(current) == literal_text[0]);
+        for (std::size_t i = 1; i < length; ++i)
+        {
+            if (JSON_HEDLEY_UNLIKELY(char_traits<char_type>::to_char_type(get()) != literal_text[i]))
+            {
+                error_message = "invalid literal";
+                return token_type::parse_error;
+            }
+        }
+        return return_type;
+    }
+
+    /////////////////////
+    // input management
+    /////////////////////
+
+    /// reset token_buffer; current character is beginning of token
+    void reset() noexcept
+    {
+        token_buffer.clear();
+        token_string.clear();
+        token_string.push_back(char_traits<char_type>::to_char_type(current));
+    }
+
+    /*
+    @brief get next character from the input
+
+    This function provides the interface to the used input adapter. It does
+    not throw in case the input reached EOF, but returns a
+    `char_traits<char>::eof()` in that case.  Stores the scanned characters
+    for use in error messages.
+
+    @return character read from the input
+    */
+    char_int_type get()
+    {
+        ++position.chars_read_total;
+        ++position.chars_read_current_line;
+
+        if (next_unget)
+        {
+            // just reset the next_unget variable and work with current
+            next_unget = false;
+        }
+        else
+        {
+            current = ia.get_character();
+        }
+
+        if (JSON_HEDLEY_LIKELY(current != char_traits<char_type>::eof()))
+        {
+            token_string.push_back(char_traits<char_type>::to_char_type(current));
+        }
+
+        if (current == '\n')
+        {
+            ++position.lines_read;
+            position.chars_read_current_line = 0;
+        }
+
+        return current;
+    }
+
+    /*!
+    @brief unget current character (read it again on next get)
+
+    We implement unget by setting variable next_unget to true. The input is not
+    changed - we just simulate ungetting by modifying chars_read_total,
+    chars_read_current_line, and token_string. The next call to get() will
+    behave as if the unget character is read again.
+    */
+    void unget()
+    {
+        next_unget = true;
+
+        --position.chars_read_total;
+
+        // in case we "unget" a newline, we have to also decrement the lines_read
+        if (position.chars_read_current_line == 0)
+        {
+            if (position.lines_read > 0)
+            {
+                --position.lines_read;
+            }
+        }
+        else
+        {
+            --position.chars_read_current_line;
+        }
+
+        if (JSON_HEDLEY_LIKELY(current != char_traits<char_type>::eof()))
+        {
+            JSON_ASSERT(!token_string.empty());
+            token_string.pop_back();
+        }
+    }
+
+    /// add a character to token_buffer
+    void add(char_int_type c)
+    {
+        token_buffer.push_back(static_cast<typename string_t::value_type>(c));
+    }
+
+  public:
+    /////////////////////
+    // value getters
+    /////////////////////
+
+    /// return integer value
+    constexpr number_integer_t get_number_integer() const noexcept
+    {
+        return value_integer;
+    }
+
+    /// return unsigned integer value
+    constexpr number_unsigned_t get_number_unsigned() const noexcept
+    {
+        return value_unsigned;
+    }
+
+    /// return floating-point value
+    constexpr number_float_t get_number_float() const noexcept
+    {
+        return value_float;
+    }
+
+    /// return current string value (implicitly resets the token; useful only once)
+    string_t& get_string()
+    {
+        return token_buffer;
+    }
+
+    /////////////////////
+    // diagnostics
+    /////////////////////
+
+    /// return position of last read token
+    constexpr position_t get_position() const noexcept
+    {
+        return position;
+    }
+
+    /// return the last read token (for errors only).  Will never contain EOF
+    /// (an arbitrary value that is not a valid char value, often -1), because
+    /// 255 may legitimately occur.  May contain NUL, which should be escaped.
+    std::string get_token_string() const
+    {
+        // escape control characters
+        std::string result;
+        for (const auto c : token_string)
+        {
+            if (static_cast<unsigned char>(c) <= '\x1F')
+            {
+                // escape control characters
+                std::array<char, 9> cs{{}};
+                static_cast<void>((std::snprintf)(cs.data(), cs.size(), "<U+%.4X>", static_cast<unsigned char>(c))); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+                result += cs.data();
+            }
+            else
+            {
+                // add character as is
+                result.push_back(static_cast<std::string::value_type>(c));
+            }
+        }
+
+        return result;
+    }
+
+    /// return syntax error message
+    JSON_HEDLEY_RETURNS_NON_NULL
+    constexpr const char* get_error_message() const noexcept
+    {
+        return error_message;
+    }
+
+    /////////////////////
+    // actual scanner
+    /////////////////////
+
+    /*!
+    @brief skip the UTF-8 byte order mark
+    @return true iff there is no BOM or the correct BOM has been skipped
+    */
+    bool skip_bom()
+    {
+        if (get() == 0xEF)
+        {
+            // check if we completely parse the BOM
+            return get() == 0xBB && get() == 0xBF;
+        }
+
+        // the first character is not the beginning of the BOM; unget it to
+        // process is later
+        unget();
+        return true;
+    }
+
+    void skip_whitespace()
+    {
+        do
+        {
+            get();
+        }
+        while (current == ' ' || current == '\t' || current == '\n' || current == '\r');
+    }
+
+    token_type scan()
+    {
+        // initially, skip the BOM
+        if (position.chars_read_total == 0 && !skip_bom())
+        {
+            error_message = "invalid BOM; must be 0xEF 0xBB 0xBF if given";
+            return token_type::parse_error;
+        }
+
+        // read next character and ignore whitespace
+        skip_whitespace();
+
+        // ignore comments
+        while (ignore_comments && current == '/')
+        {
+            if (!scan_comment())
+            {
+                return token_type::parse_error;
+            }
+
+            // skip following whitespace
+            skip_whitespace();
+        }
+
+        switch (current)
+        {
+            // structural characters
+            case '[':
+                return token_type::begin_array;
+            case ']':
+                return token_type::end_array;
+            case '{':
+                return token_type::begin_object;
+            case '}':
+                return token_type::end_object;
+            case ':':
+                return token_type::name_separator;
+            case ',':
+                return token_type::value_separator;
+
+            // literals
+            case 't':
+            {
+                std::array<char_type, 4> true_literal = {{static_cast<char_type>('t'), static_cast<char_type>('r'), static_cast<char_type>('u'), static_cast<char_type>('e')}};
+                return scan_literal(true_literal.data(), true_literal.size(), token_type::literal_true);
+            }
+            case 'f':
+            {
+                std::array<char_type, 5> false_literal = {{static_cast<char_type>('f'), static_cast<char_type>('a'), static_cast<char_type>('l'), static_cast<char_type>('s'), static_cast<char_type>('e')}};
+                return scan_literal(false_literal.data(), false_literal.size(), token_type::literal_false);
+            }
+            case 'n':
+            {
+                std::array<char_type, 4> null_literal = {{static_cast<char_type>('n'), static_cast<char_type>('u'), static_cast<char_type>('l'), static_cast<char_type>('l')}};
+                return scan_literal(null_literal.data(), null_literal.size(), token_type::literal_null);
+            }
+
+            // string
+            case '\"':
+                return scan_string();
+
+            // number
+            case '-':
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                return scan_number();
+
+            // end of input (the null byte is needed when parsing from
+            // string literals)
+            case '\0':
+            case char_traits<char_type>::eof():
+                return token_type::end_of_input;
+
+            // error
+            default:
+                error_message = "invalid literal";
+                return token_type::parse_error;
+        }
+    }
+
+  private:
+    /// input adapter
+    InputAdapterType ia;
+
+    /// whether comments should be ignored (true) or signaled as errors (false)
+    const bool ignore_comments = false;
+
+    /// the current character
+    char_int_type current = char_traits<char_type>::eof();
+
+    /// whether the next get() call should just return current
+    bool next_unget = false;
+
+    /// the start position of the current token
+    position_t position {};
+
+    /// raw input token string (for error messages)
+    std::vector<char_type> token_string {};
+
+    /// buffer for variable-length tokens (numbers, strings)
+    string_t token_buffer {};
+
+    /// a description of occurred lexer errors
+    const char* error_message = "";
+
+    // number values
+    number_integer_t value_integer = 0;
+    number_unsigned_t value_unsigned = 0;
+    number_float_t value_float = 0;
+
+    /// the decimal point
+    const char_int_type decimal_point_char = '.';
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/is_sax.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cstdint> // size_t
+#include <utility> // declval
+#include <string> // string
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+// #include <nlohmann/detail/meta/detected.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+template<typename T>
+using null_function_t = decltype(std::declval<T&>().null());
+
+template<typename T>
+using boolean_function_t =
+    decltype(std::declval<T&>().boolean(std::declval<bool>()));
+
+template<typename T, typename Integer>
+using number_integer_function_t =
+    decltype(std::declval<T&>().number_integer(std::declval<Integer>()));
+
+template<typename T, typename Unsigned>
+using number_unsigned_function_t =
+    decltype(std::declval<T&>().number_unsigned(std::declval<Unsigned>()));
+
+template<typename T, typename Float, typename String>
+using number_float_function_t = decltype(std::declval<T&>().number_float(
+                                    std::declval<Float>(), std::declval<const String&>()));
+
+template<typename T, typename String>
+using string_function_t =
+    decltype(std::declval<T&>().string(std::declval<String&>()));
+
+template<typename T, typename Binary>
+using binary_function_t =
+    decltype(std::declval<T&>().binary(std::declval<Binary&>()));
+
+template<typename T>
+using start_object_function_t =
+    decltype(std::declval<T&>().start_object(std::declval<std::size_t>()));
+
+template<typename T, typename String>
+using key_function_t =
+    decltype(std::declval<T&>().key(std::declval<String&>()));
+
+template<typename T>
+using end_object_function_t = decltype(std::declval<T&>().end_object());
+
+template<typename T>
+using start_array_function_t =
+    decltype(std::declval<T&>().start_array(std::declval<std::size_t>()));
+
+template<typename T>
+using end_array_function_t = decltype(std::declval<T&>().end_array());
+
+template<typename T, typename Exception>
+using parse_error_function_t = decltype(std::declval<T&>().parse_error(
+        std::declval<std::size_t>(), std::declval<const std::string&>(),
+        std::declval<const Exception&>()));
+
+template<typename SAX, typename BasicJsonType>
+struct is_sax
+{
+  private:
+    static_assert(is_basic_json<BasicJsonType>::value,
+                  "BasicJsonType must be of type basic_json<...>");
+
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
+    using binary_t = typename BasicJsonType::binary_t;
+    using exception_t = typename BasicJsonType::exception;
+
+  public:
+    static constexpr bool value =
+        is_detected_exact<bool, null_function_t, SAX>::value &&
+        is_detected_exact<bool, boolean_function_t, SAX>::value &&
+        is_detected_exact<bool, number_integer_function_t, SAX, number_integer_t>::value &&
+        is_detected_exact<bool, number_unsigned_function_t, SAX, number_unsigned_t>::value &&
+        is_detected_exact<bool, number_float_function_t, SAX, number_float_t, string_t>::value &&
+        is_detected_exact<bool, string_function_t, SAX, string_t>::value &&
+        is_detected_exact<bool, binary_function_t, SAX, binary_t>::value &&
+        is_detected_exact<bool, start_object_function_t, SAX>::value &&
+        is_detected_exact<bool, key_function_t, SAX, string_t>::value &&
+        is_detected_exact<bool, end_object_function_t, SAX>::value &&
+        is_detected_exact<bool, start_array_function_t, SAX>::value &&
+        is_detected_exact<bool, end_array_function_t, SAX>::value &&
+        is_detected_exact<bool, parse_error_function_t, SAX, exception_t>::value;
+};
+
+template<typename SAX, typename BasicJsonType>
+struct is_sax_static_asserts
+{
+  private:
+    static_assert(is_basic_json<BasicJsonType>::value,
+                  "BasicJsonType must be of type basic_json<...>");
+
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
+    using binary_t = typename BasicJsonType::binary_t;
+    using exception_t = typename BasicJsonType::exception;
+
+  public:
+    static_assert(is_detected_exact<bool, null_function_t, SAX>::value,
+                  "Missing/invalid function: bool null()");
+    static_assert(is_detected_exact<bool, boolean_function_t, SAX>::value,
+                  "Missing/invalid function: bool boolean(bool)");
+    static_assert(is_detected_exact<bool, boolean_function_t, SAX>::value,
+                  "Missing/invalid function: bool boolean(bool)");
+    static_assert(
+        is_detected_exact<bool, number_integer_function_t, SAX,
+        number_integer_t>::value,
+        "Missing/invalid function: bool number_integer(number_integer_t)");
+    static_assert(
+        is_detected_exact<bool, number_unsigned_function_t, SAX,
+        number_unsigned_t>::value,
+        "Missing/invalid function: bool number_unsigned(number_unsigned_t)");
+    static_assert(is_detected_exact<bool, number_float_function_t, SAX,
+                  number_float_t, string_t>::value,
+                  "Missing/invalid function: bool number_float(number_float_t, const string_t&)");
+    static_assert(
+        is_detected_exact<bool, string_function_t, SAX, string_t>::value,
+        "Missing/invalid function: bool string(string_t&)");
+    static_assert(
+        is_detected_exact<bool, binary_function_t, SAX, binary_t>::value,
+        "Missing/invalid function: bool binary(binary_t&)");
+    static_assert(is_detected_exact<bool, start_object_function_t, SAX>::value,
+                  "Missing/invalid function: bool start_object(std::size_t)");
+    static_assert(is_detected_exact<bool, key_function_t, SAX, string_t>::value,
+                  "Missing/invalid function: bool key(string_t&)");
+    static_assert(is_detected_exact<bool, end_object_function_t, SAX>::value,
+                  "Missing/invalid function: bool end_object()");
+    static_assert(is_detected_exact<bool, start_array_function_t, SAX>::value,
+                  "Missing/invalid function: bool start_array(std::size_t)");
+    static_assert(is_detected_exact<bool, end_array_function_t, SAX>::value,
+                  "Missing/invalid function: bool end_array()");
+    static_assert(
+        is_detected_exact<bool, parse_error_function_t, SAX, exception_t>::value,
+        "Missing/invalid function: bool parse_error(std::size_t, const "
+        "std::string&, const exception&)");
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+// #include <nlohmann/detail/string_concat.hpp>
+
+// #include <nlohmann/detail/value_t.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+/// how to treat CBOR tags
+enum class cbor_tag_handler_t
+{
+    error,   ///< throw a parse_error exception in case of a tag
+    ignore,  ///< ignore tags
+    store    ///< store tags as binary type
+};
+
+/*!
+@brief determine system byte order
+
+@return true if and only if system's byte order is little endian
+
+@note from https://stackoverflow.com/a/1001328/266378
+*/
+static inline bool little_endianness(int num = 1) noexcept
+{
+    return *reinterpret_cast<char*>(&num) == 1;
+}
+
+///////////////////
+// binary reader //
+///////////////////
+
+/*!
+@brief deserialization of CBOR, MessagePack, and UBJSON values
+*/
+template<typename BasicJsonType, typename InputAdapterType, typename SAX = json_sax_dom_parser<BasicJsonType>>
+class binary_reader
+{
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
+    using binary_t = typename BasicJsonType::binary_t;
+    using json_sax_t = SAX;
+    using char_type = typename InputAdapterType::char_type;
+    using char_int_type = typename char_traits<char_type>::int_type;
+
+  public:
+    /*!
+    @brief create a binary reader
+
+    @param[in] adapter  input adapter to read from
+    */
+    explicit binary_reader(InputAdapterType&& adapter, const input_format_t format = input_format_t::json) noexcept : ia(std::move(adapter)), input_format(format)
+    {
+        (void)detail::is_sax_static_asserts<SAX, BasicJsonType> {};
+    }
+
+    // make class move-only
+    binary_reader(const binary_reader&) = delete;
+    binary_reader(binary_reader&&) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
+    binary_reader& operator=(const binary_reader&) = delete;
+    binary_reader& operator=(binary_reader&&) = default; // NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
+    ~binary_reader() = default;
+
+    /*!
+    @param[in] format  the binary format to parse
+    @param[in] sax_    a SAX event processor
+    @param[in] strict  whether to expect the input to be consumed completed
+    @param[in] tag_handler  how to treat CBOR tags
+
+    @return whether parsing was successful
+    */
+    JSON_HEDLEY_NON_NULL(3)
+    bool sax_parse(const input_format_t format,
+                   json_sax_t* sax_,
+                   const bool strict = true,
+                   const cbor_tag_handler_t tag_handler = cbor_tag_handler_t::error)
+    {
+        sax = sax_;
+        bool result = false;
+
+        switch (format)
+        {
+            case input_format_t::bson:
+                result = parse_bson_internal();
+                break;
+
+            case input_format_t::cbor:
+                result = parse_cbor_internal(true, tag_handler);
+                break;
+
+            case input_format_t::msgpack:
+                result = parse_msgpack_internal();
+                break;
+
+            case input_format_t::ubjson:
+            case input_format_t::bjdata:
+                result = parse_ubjson_internal();
+                break;
+
+            case input_format_t::json: // LCOV_EXCL_LINE
+            default:            // LCOV_EXCL_LINE
+                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+        }
+
+        // strict mode: next byte must be EOF
+        if (result && strict)
+        {
+            if (input_format == input_format_t::ubjson || input_format == input_format_t::bjdata)
+            {
+                get_ignore_noop();
+            }
+            else
+            {
+                get();
+            }
+
+            if (JSON_HEDLEY_UNLIKELY(current != char_traits<char_type>::eof()))
+            {
+                return sax->parse_error(chars_read, get_token_string(), parse_error::create(110, chars_read,
+                                        exception_message(input_format, concat("expected end of input; last byte: 0x", get_token_string()), "value"), nullptr));
+            }
+        }
+
+        return result;
+    }
+
+  private:
+    //////////
+    // BSON //
+    //////////
+
+    /*!
+    @brief Reads in a BSON-object and passes it to the SAX-parser.
+    @return whether a valid BSON-value was passed to the SAX parser
+    */
+    bool parse_bson_internal()
+    {
+        std::int32_t document_size{};
+        get_number<std::int32_t, true>(input_format_t::bson, document_size);
+
+        if (JSON_HEDLEY_UNLIKELY(!sax->start_object(static_cast<std::size_t>(-1))))
+        {
+            return false;
+        }
+
+        if (JSON_HEDLEY_UNLIKELY(!parse_bson_element_list(/*is_array*/false)))
+        {
+            return false;
+        }
+
+        return sax->end_object();
+    }
+
+    /*!
+    @brief Parses a C-style string from the BSON input.
+    @param[in,out] result  A reference to the string variable where the read
+                            string is to be stored.
+    @return `true` if the \x00-byte indicating the end of the string was
+             encountered before the EOF; false` indicates an unexpected EOF.
+    */
+    bool get_bson_cstr(string_t& result)
+    {
+        auto out = std::back_inserter(result);
+        while (true)
+        {
+            get();
+            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format_t::bson, "cstring")))
+            {
+                return false;
+            }
+            if (current == 0x00)
+            {
+                return true;
+            }
+            *out++ = static_cast<typename string_t::value_type>(current);
+        }
+    }
+
+    /*!
+    @brief Parses a zero-terminated string of length @a len from the BSON
+           input.
+    @param[in] len  The length (including the zero-byte at the end) of the
+                    string to be read.
+    @param[in,out] result  A reference to the string variable where the read
+                            string is to be stored.
+    @tparam NumberType The type of the length @a len
+    @pre len >= 1
+    @return `true` if the string was successfully parsed
+    */
+    template<typename NumberType>
+    bool get_bson_string(const NumberType len, string_t& result)
+    {
+        if (JSON_HEDLEY_UNLIKELY(len < 1))
+        {
+            auto last_token = get_token_string();
+            return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                    exception_message(input_format_t::bson, concat("string length must be at least 1, is ", std::to_string(len)), "string"), nullptr));
+        }
+
+        return get_string(input_format_t::bson, len - static_cast<NumberType>(1), result) && get() != char_traits<char_type>::eof();
+    }
+
+    /*!
+    @brief Parses a byte array input of length @a len from the BSON input.
+    @param[in] len  The length of the byte array to be read.
+    @param[in,out] result  A reference to the binary variable where the read
+                            array is to be stored.
+    @tparam NumberType The type of the length @a len
+    @pre len >= 0
+    @return `true` if the byte array was successfully parsed
+    */
+    template<typename NumberType>
+    bool get_bson_binary(const NumberType len, binary_t& result)
+    {
+        if (JSON_HEDLEY_UNLIKELY(len < 0))
+        {
+            auto last_token = get_token_string();
+            return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                    exception_message(input_format_t::bson, concat("byte array length cannot be negative, is ", std::to_string(len)), "binary"), nullptr));
+        }
+
+        // All BSON binary values have a subtype
+        std::uint8_t subtype{};
+        get_number<std::uint8_t>(input_format_t::bson, subtype);
+        result.set_subtype(subtype);
+
+        return get_binary(input_format_t::bson, len, result);
+    }
+
+    /*!
+    @brief Read a BSON document element of the given @a element_type.
+    @param[in] element_type The BSON element type, c.f. http://bsonspec.org/spec.html
+    @param[in] element_type_parse_position The position in the input stream,
+               where the `element_type` was read.
+    @warning Not all BSON element types are supported yet. An unsupported
+             @a element_type will give rise to a parse_error.114:
+             Unsupported BSON record type 0x...
+    @return whether a valid BSON-object/array was passed to the SAX parser
+    */
+    bool parse_bson_element_internal(const char_int_type element_type,
+                                     const std::size_t element_type_parse_position)
+    {
+        switch (element_type)
+        {
+            case 0x01: // double
+            {
+                double number{};
+                return get_number<double, true>(input_format_t::bson, number) && sax->number_float(static_cast<number_float_t>(number), "");
+            }
+
+            case 0x02: // string
+            {
+                std::int32_t len{};
+                string_t value;
+                return get_number<std::int32_t, true>(input_format_t::bson, len) && get_bson_string(len, value) && sax->string(value);
+            }
+
+            case 0x03: // object
+            {
+                return parse_bson_internal();
+            }
+
+            case 0x04: // array
+            {
+                return parse_bson_array();
+            }
+
+            case 0x05: // binary
+            {
+                std::int32_t len{};
+                binary_t value;
+                return get_number<std::int32_t, true>(input_format_t::bson, len) && get_bson_binary(len, value) && sax->binary(value);
+            }
+
+            case 0x08: // boolean
+            {
+                return sax->boolean(get() != 0);
+            }
+
+            case 0x0A: // null
+            {
+                return sax->null();
+            }
+
+            case 0x10: // int32
+            {
+                std::int32_t value{};
+                return get_number<std::int32_t, true>(input_format_t::bson, value) && sax->number_integer(value);
+            }
+
+            case 0x12: // int64
+            {
+                std::int64_t value{};
+                return get_number<std::int64_t, true>(input_format_t::bson, value) && sax->number_integer(value);
+            }
+
+            default: // anything else not supported (yet)
+            {
+                std::array<char, 3> cr{{}};
+                static_cast<void>((std::snprintf)(cr.data(), cr.size(), "%.2hhX", static_cast<unsigned char>(element_type))); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+                const std::string cr_str{cr.data()};
+                return sax->parse_error(element_type_parse_position, cr_str,
+                                        parse_error::create(114, element_type_parse_position, concat("Unsupported BSON record type 0x", cr_str), nullptr));
+            }
+        }
+    }
+
+    /*!
+    @brief Read a BSON element list (as specified in the BSON-spec)
+
+    The same binary layout is used for objects and arrays, hence it must be
+    indicated with the argument @a is_array which one is expected
+    (true --> array, false --> object).
+
+    @param[in] is_array Determines if the element list being read is to be
+                        treated as an object (@a is_array == false), or as an
+                        array (@a is_array == true).
+    @return whether a valid BSON-object/array was passed to the SAX parser
+    */
+    bool parse_bson_element_list(const bool is_array)
+    {
+        string_t key;
+
+        while (auto element_type = get())
+        {
+            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format_t::bson, "element list")))
+            {
+                return false;
+            }
+
+            const std::size_t element_type_parse_position = chars_read;
+            if (JSON_HEDLEY_UNLIKELY(!get_bson_cstr(key)))
+            {
+                return false;
+            }
+
+            if (!is_array && !sax->key(key))
+            {
+                return false;
+            }
+
+            if (JSON_HEDLEY_UNLIKELY(!parse_bson_element_internal(element_type, element_type_parse_position)))
+            {
+                return false;
+            }
+
+            // get_bson_cstr only appends
+            key.clear();
+        }
+
+        return true;
+    }
+
+    /*!
+    @brief Reads an array from the BSON input and passes it to the SAX-parser.
+    @return whether a valid BSON-array was passed to the SAX parser
+    */
+    bool parse_bson_array()
+    {
+        std::int32_t document_size{};
+        get_number<std::int32_t, true>(input_format_t::bson, document_size);
+
+        if (JSON_HEDLEY_UNLIKELY(!sax->start_array(static_cast<std::size_t>(-1))))
+        {
+            return false;
+        }
+
+        if (JSON_HEDLEY_UNLIKELY(!parse_bson_element_list(/*is_array*/true)))
+        {
+            return false;
+        }
+
+        return sax->end_array();
+    }
+
+    //////////
+    // CBOR //
+    //////////
+
+    /*!
+    @param[in] get_char  whether a new character should be retrieved from the
+                         input (true) or whether the last read character should
+                         be considered instead (false)
+    @param[in] tag_handler how CBOR tags should be treated
+
+    @return whether a valid CBOR value was passed to the SAX parser
+    */
+    bool parse_cbor_internal(const bool get_char,
+                             const cbor_tag_handler_t tag_handler)
+    {
+        switch (get_char ? get() : current)
+        {
+            // EOF
+            case char_traits<char_type>::eof():
+                return unexpect_eof(input_format_t::cbor, "value");
+
+            // Integer 0x00..0x17 (0..23)
+            case 0x00:
+            case 0x01:
+            case 0x02:
+            case 0x03:
+            case 0x04:
+            case 0x05:
+            case 0x06:
+            case 0x07:
+            case 0x08:
+            case 0x09:
+            case 0x0A:
+            case 0x0B:
+            case 0x0C:
+            case 0x0D:
+            case 0x0E:
+            case 0x0F:
+            case 0x10:
+            case 0x11:
+            case 0x12:
+            case 0x13:
+            case 0x14:
+            case 0x15:
+            case 0x16:
+            case 0x17:
+                return sax->number_unsigned(static_cast<number_unsigned_t>(current));
+
+            case 0x18: // Unsigned integer (one-byte uint8_t follows)
+            {
+                std::uint8_t number{};
+                return get_number(input_format_t::cbor, number) && sax->number_unsigned(number);
+            }
+
+            case 0x19: // Unsigned integer (two-byte uint16_t follows)
+            {
+                std::uint16_t number{};
+                return get_number(input_format_t::cbor, number) && sax->number_unsigned(number);
+            }
+
+            case 0x1A: // Unsigned integer (four-byte uint32_t follows)
+            {
+                std::uint32_t number{};
+                return get_number(input_format_t::cbor, number) && sax->number_unsigned(number);
+            }
+
+            case 0x1B: // Unsigned integer (eight-byte uint64_t follows)
+            {
+                std::uint64_t number{};
+                return get_number(input_format_t::cbor, number) && sax->number_unsigned(number);
+            }
+
+            // Negative integer -1-0x00..-1-0x17 (-1..-24)
+            case 0x20:
+            case 0x21:
+            case 0x22:
+            case 0x23:
+            case 0x24:
+            case 0x25:
+            case 0x26:
+            case 0x27:
+            case 0x28:
+            case 0x29:
+            case 0x2A:
+            case 0x2B:
+            case 0x2C:
+            case 0x2D:
+            case 0x2E:
+            case 0x2F:
+            case 0x30:
+            case 0x31:
+            case 0x32:
+            case 0x33:
+            case 0x34:
+            case 0x35:
+            case 0x36:
+            case 0x37:
+                return sax->number_integer(static_cast<std::int8_t>(0x20 - 1 - current));
+
+            case 0x38: // Negative integer (one-byte uint8_t follows)
+            {
+                std::uint8_t number{};
+                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1) - number);
+            }
+
+            case 0x39: // Negative integer -1-n (two-byte uint16_t follows)
+            {
+                std::uint16_t number{};
+                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1) - number);
+            }
+
+            case 0x3A: // Negative integer -1-n (four-byte uint32_t follows)
+            {
+                std::uint32_t number{};
+                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1) - number);
+            }
+
+            case 0x3B: // Negative integer -1-n (eight-byte uint64_t follows)
+            {
+                std::uint64_t number{};
+                return get_number(input_format_t::cbor, number) && sax->number_integer(static_cast<number_integer_t>(-1)
+                        - static_cast<number_integer_t>(number));
+            }
+
+            // Binary data (0x00..0x17 bytes follow)
+            case 0x40:
+            case 0x41:
+            case 0x42:
+            case 0x43:
+            case 0x44:
+            case 0x45:
+            case 0x46:
+            case 0x47:
+            case 0x48:
+            case 0x49:
+            case 0x4A:
+            case 0x4B:
+            case 0x4C:
+            case 0x4D:
+            case 0x4E:
+            case 0x4F:
+            case 0x50:
+            case 0x51:
+            case 0x52:
+            case 0x53:
+            case 0x54:
+            case 0x55:
+            case 0x56:
+            case 0x57:
+            case 0x58: // Binary data (one-byte uint8_t for n follows)
+            case 0x59: // Binary data (two-byte uint16_t for n follow)
+            case 0x5A: // Binary data (four-byte uint32_t for n follow)
+            case 0x5B: // Binary data (eight-byte uint64_t for n follow)
+            case 0x5F: // Binary data (indefinite length)
+            {
+                binary_t b;
+                return get_cbor_binary(b) && sax->binary(b);
+            }
+
+            // UTF-8 string (0x00..0x17 bytes follow)
+            case 0x60:
+            case 0x61:
+            case 0x62:
+            case 0x63:
+            case 0x64:
+            case 0x65:
+            case 0x66:
+            case 0x67:
+            case 0x68:
+            case 0x69:
+            case 0x6A:
+            case 0x6B:
+            case 0x6C:
+            case 0x6D:
+            case 0x6E:
+            case 0x6F:
+            case 0x70:
+            case 0x71:
+            case 0x72:
+            case 0x73:
+            case 0x74:
+            case 0x75:
+            case 0x76:
+            case 0x77:
+            case 0x78: // UTF-8 string (one-byte uint8_t for n follows)
+            case 0x79: // UTF-8 string (two-byte uint16_t for n follow)
+            case 0x7A: // UTF-8 string (four-byte uint32_t for n follow)
+            case 0x7B: // UTF-8 string (eight-byte uint64_t for n follow)
+            case 0x7F: // UTF-8 string (indefinite length)
+            {
+                string_t s;
+                return get_cbor_string(s) && sax->string(s);
+            }
+
+            // array (0x00..0x17 data items follow)
+            case 0x80:
+            case 0x81:
+            case 0x82:
+            case 0x83:
+            case 0x84:
+            case 0x85:
+            case 0x86:
+            case 0x87:
+            case 0x88:
+            case 0x89:
+            case 0x8A:
+            case 0x8B:
+            case 0x8C:
+            case 0x8D:
+            case 0x8E:
+            case 0x8F:
+            case 0x90:
+            case 0x91:
+            case 0x92:
+            case 0x93:
+            case 0x94:
+            case 0x95:
+            case 0x96:
+            case 0x97:
+                return get_cbor_array(
+                           conditional_static_cast<std::size_t>(static_cast<unsigned int>(current) & 0x1Fu), tag_handler);
+
+            case 0x98: // array (one-byte uint8_t for n follows)
+            {
+                std::uint8_t len{};
+                return get_number(input_format_t::cbor, len) && get_cbor_array(static_cast<std::size_t>(len), tag_handler);
+            }
+
+            case 0x99: // array (two-byte uint16_t for n follow)
+            {
+                std::uint16_t len{};
+                return get_number(input_format_t::cbor, len) && get_cbor_array(static_cast<std::size_t>(len), tag_handler);
+            }
+
+            case 0x9A: // array (four-byte uint32_t for n follow)
+            {
+                std::uint32_t len{};
+                return get_number(input_format_t::cbor, len) && get_cbor_array(conditional_static_cast<std::size_t>(len), tag_handler);
+            }
+
+            case 0x9B: // array (eight-byte uint64_t for n follow)
+            {
+                std::uint64_t len{};
+                return get_number(input_format_t::cbor, len) && get_cbor_array(conditional_static_cast<std::size_t>(len), tag_handler);
+            }
+
+            case 0x9F: // array (indefinite length)
+                return get_cbor_array(static_cast<std::size_t>(-1), tag_handler);
+
+            // map (0x00..0x17 pairs of data items follow)
+            case 0xA0:
+            case 0xA1:
+            case 0xA2:
+            case 0xA3:
+            case 0xA4:
+            case 0xA5:
+            case 0xA6:
+            case 0xA7:
+            case 0xA8:
+            case 0xA9:
+            case 0xAA:
+            case 0xAB:
+            case 0xAC:
+            case 0xAD:
+            case 0xAE:
+            case 0xAF:
+            case 0xB0:
+            case 0xB1:
+            case 0xB2:
+            case 0xB3:
+            case 0xB4:
+            case 0xB5:
+            case 0xB6:
+            case 0xB7:
+                return get_cbor_object(conditional_static_cast<std::size_t>(static_cast<unsigned int>(current) & 0x1Fu), tag_handler);
+
+            case 0xB8: // map (one-byte uint8_t for n follows)
+            {
+                std::uint8_t len{};
+                return get_number(input_format_t::cbor, len) && get_cbor_object(static_cast<std::size_t>(len), tag_handler);
+            }
+
+            case 0xB9: // map (two-byte uint16_t for n follow)
+            {
+                std::uint16_t len{};
+                return get_number(input_format_t::cbor, len) && get_cbor_object(static_cast<std::size_t>(len), tag_handler);
+            }
+
+            case 0xBA: // map (four-byte uint32_t for n follow)
+            {
+                std::uint32_t len{};
+                return get_number(input_format_t::cbor, len) && get_cbor_object(conditional_static_cast<std::size_t>(len), tag_handler);
+            }
+
+            case 0xBB: // map (eight-byte uint64_t for n follow)
+            {
+                std::uint64_t len{};
+                return get_number(input_format_t::cbor, len) && get_cbor_object(conditional_static_cast<std::size_t>(len), tag_handler);
+            }
+
+            case 0xBF: // map (indefinite length)
+                return get_cbor_object(static_cast<std::size_t>(-1), tag_handler);
+
+            case 0xC6: // tagged item
+            case 0xC7:
+            case 0xC8:
+            case 0xC9:
+            case 0xCA:
+            case 0xCB:
+            case 0xCC:
+            case 0xCD:
+            case 0xCE:
+            case 0xCF:
+            case 0xD0:
+            case 0xD1:
+            case 0xD2:
+            case 0xD3:
+            case 0xD4:
+            case 0xD8: // tagged item (1 bytes follow)
+            case 0xD9: // tagged item (2 bytes follow)
+            case 0xDA: // tagged item (4 bytes follow)
+            case 0xDB: // tagged item (8 bytes follow)
+            {
+                switch (tag_handler)
+                {
+                    case cbor_tag_handler_t::error:
+                    {
+                        auto last_token = get_token_string();
+                        return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                                exception_message(input_format_t::cbor, concat("invalid byte: 0x", last_token), "value"), nullptr));
+                    }
+
+                    case cbor_tag_handler_t::ignore:
+                    {
+                        // ignore binary subtype
+                        switch (current)
+                        {
+                            case 0xD8:
+                            {
+                                std::uint8_t subtype_to_ignore{};
+                                get_number(input_format_t::cbor, subtype_to_ignore);
+                                break;
+                            }
+                            case 0xD9:
+                            {
+                                std::uint16_t subtype_to_ignore{};
+                                get_number(input_format_t::cbor, subtype_to_ignore);
+                                break;
+                            }
+                            case 0xDA:
+                            {
+                                std::uint32_t subtype_to_ignore{};
+                                get_number(input_format_t::cbor, subtype_to_ignore);
+                                break;
+                            }
+                            case 0xDB:
+                            {
+                                std::uint64_t subtype_to_ignore{};
+                                get_number(input_format_t::cbor, subtype_to_ignore);
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                        return parse_cbor_internal(true, tag_handler);
+                    }
+
+                    case cbor_tag_handler_t::store:
+                    {
+                        binary_t b;
+                        // use binary subtype and store in binary container
+                        switch (current)
+                        {
+                            case 0xD8:
+                            {
+                                std::uint8_t subtype{};
+                                get_number(input_format_t::cbor, subtype);
+                                b.set_subtype(detail::conditional_static_cast<typename binary_t::subtype_type>(subtype));
+                                break;
+                            }
+                            case 0xD9:
+                            {
+                                std::uint16_t subtype{};
+                                get_number(input_format_t::cbor, subtype);
+                                b.set_subtype(detail::conditional_static_cast<typename binary_t::subtype_type>(subtype));
+                                break;
+                            }
+                            case 0xDA:
+                            {
+                                std::uint32_t subtype{};
+                                get_number(input_format_t::cbor, subtype);
+                                b.set_subtype(detail::conditional_static_cast<typename binary_t::subtype_type>(subtype));
+                                break;
+                            }
+                            case 0xDB:
+                            {
+                                std::uint64_t subtype{};
+                                get_number(input_format_t::cbor, subtype);
+                                b.set_subtype(detail::conditional_static_cast<typename binary_t::subtype_type>(subtype));
+                                break;
+                            }
+                            default:
+                                return parse_cbor_internal(true, tag_handler);
+                        }
+                        get();
+                        return get_cbor_binary(b) && sax->binary(b);
+                    }
+
+                    default:                 // LCOV_EXCL_LINE
+                        JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+                        return false;        // LCOV_EXCL_LINE
+                }
+            }
+
+            case 0xF4: // false
+                return sax->boolean(false);
+
+            case 0xF5: // true
+                return sax->boolean(true);
+
+            case 0xF6: // null
+                return sax->null();
+
+            case 0xF9: // Half-Precision Float (two-byte IEEE 754)
+            {
+                const auto byte1_raw = get();
+                if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format_t::cbor, "number")))
+                {
+                    return false;
+                }
+                const auto byte2_raw = get();
+                if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format_t::cbor, "number")))
+                {
+                    return false;
+                }
+
+                const auto byte1 = static_cast<unsigned char>(byte1_raw);
+                const auto byte2 = static_cast<unsigned char>(byte2_raw);
+
+                // code from RFC 7049, Appendix D, Figure 3:
+                // As half-precision floating-point numbers were only added
+                // to IEEE 754 in 2008, today's programming platforms often
+                // still only have limited support for them. It is very
+                // easy to include at least decoding support for them even
+                // without such support. An example of a small decoder for
+                // half-precision floating-point numbers in the C language
+                // is shown in Fig. 3.
+                const auto half = static_cast<unsigned int>((byte1 << 8u) + byte2);
+                const double val = [&half]
+                {
+                    const int exp = (half >> 10u) & 0x1Fu;
+                    const unsigned int mant = half & 0x3FFu;
+                    JSON_ASSERT(0 <= exp&& exp <= 32);
+                    JSON_ASSERT(mant <= 1024);
+                    switch (exp)
+                    {
+                        case 0:
+                            return std::ldexp(mant, -24);
+                        case 31:
+                            return (mant == 0)
+                            ? std::numeric_limits<double>::infinity()
+                            : std::numeric_limits<double>::quiet_NaN();
+                        default:
+                            return std::ldexp(mant + 1024, exp - 25);
+                    }
+                }();
+                return sax->number_float((half & 0x8000u) != 0
+                                         ? static_cast<number_float_t>(-val)
+                                         : static_cast<number_float_t>(val), "");
+            }
+
+            case 0xFA: // Single-Precision Float (four-byte IEEE 754)
+            {
+                float number{};
+                return get_number(input_format_t::cbor, number) && sax->number_float(static_cast<number_float_t>(number), "");
+            }
+
+            case 0xFB: // Double-Precision Float (eight-byte IEEE 754)
+            {
+                double number{};
+                return get_number(input_format_t::cbor, number) && sax->number_float(static_cast<number_float_t>(number), "");
+            }
+
+            default: // anything else (0xFF is handled inside the other types)
+            {
+                auto last_token = get_token_string();
+                return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                        exception_message(input_format_t::cbor, concat("invalid byte: 0x", last_token), "value"), nullptr));
+            }
+        }
+    }
+
+    /*!
+    @brief reads a CBOR string
+
+    This function first reads starting bytes to determine the expected
+    string length and then copies this number of bytes into a string.
+    Additionally, CBOR's strings with indefinite lengths are supported.
+
+    @param[out] result  created string
+
+    @return whether string creation completed
+    */
+    bool get_cbor_string(string_t& result)
+    {
+        if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format_t::cbor, "string")))
+        {
+            return false;
+        }
+
+        switch (current)
+        {
+            // UTF-8 string (0x00..0x17 bytes follow)
+            case 0x60:
+            case 0x61:
+            case 0x62:
+            case 0x63:
+            case 0x64:
+            case 0x65:
+            case 0x66:
+            case 0x67:
+            case 0x68:
+            case 0x69:
+            case 0x6A:
+            case 0x6B:
+            case 0x6C:
+            case 0x6D:
+            case 0x6E:
+            case 0x6F:
+            case 0x70:
+            case 0x71:
+            case 0x72:
+            case 0x73:
+            case 0x74:
+            case 0x75:
+            case 0x76:
+            case 0x77:
+            {
+                return get_string(input_format_t::cbor, static_cast<unsigned int>(current) & 0x1Fu, result);
+            }
+
+            case 0x78: // UTF-8 string (one-byte uint8_t for n follows)
+            {
+                std::uint8_t len{};
+                return get_number(input_format_t::cbor, len) && get_string(input_format_t::cbor, len, result);
+            }
+
+            case 0x79: // UTF-8 string (two-byte uint16_t for n follow)
+            {
+                std::uint16_t len{};
+                return get_number(input_format_t::cbor, len) && get_string(input_format_t::cbor, len, result);
+            }
+
+            case 0x7A: // UTF-8 string (four-byte uint32_t for n follow)
+            {
+                std::uint32_t len{};
+                return get_number(input_format_t::cbor, len) && get_string(input_format_t::cbor, len, result);
+            }
+
+            case 0x7B: // UTF-8 string (eight-byte uint64_t for n follow)
+            {
+                std::uint64_t len{};
+                return get_number(input_format_t::cbor, len) && get_string(input_format_t::cbor, len, result);
+            }
+
+            case 0x7F: // UTF-8 string (indefinite length)
+            {
+                while (get() != 0xFF)
+                {
+                    string_t chunk;
+                    if (!get_cbor_string(chunk))
+                    {
+                        return false;
+                    }
+                    result.append(chunk);
+                }
+                return true;
+            }
+
+            default:
+            {
+                auto last_token = get_token_string();
+                return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read,
+                                        exception_message(input_format_t::cbor, concat("expected length specification (0x60-0x7B) or indefinite string type (0x7F); last byte: 0x", last_token), "string"), nullptr));
+            }
+        }
+    }
+
+    /*!
+    @brief reads a CBOR byte array
+
+    This function first reads starting bytes to determine the expected
+    byte array length and then copies this number of bytes into the byte array.
+    Additionally, CBOR's byte arrays with indefinite lengths are supported.
+
+    @param[out] result  created byte array
+
+    @return whether byte array creation completed
+    */
+    bool get_cbor_binary(binary_t& result)
+    {
+        if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format_t::cbor, "binary")))
+        {
+            return false;
+        }
+
+        switch (current)
+        {
+            // Binary data (0x00..0x17 bytes follow)
+            case 0x40:
+            case 0x41:
+            case 0x42:
+            case 0x43:
+            case 0x44:
+            case 0x45:
+            case 0x46:
+            case 0x47:
+            case 0x48:
+            case 0x49:
+            case 0x4A:
+            case 0x4B:
+            case 0x4C:
+            case 0x4D:
+            case 0x4E:
+            case 0x4F:
+            case 0x50:
+            case 0x51:
+            case 0x52:
+            case 0x53:
+            case 0x54:
+            case 0x55:
+            case 0x56:
+            case 0x57:
+            {
+                return get_binary(input_format_t::cbor, static_cast<unsigned int>(current) & 0x1Fu, result);
+            }
+
+            case 0x58: // Binary data (one-byte uint8_t for n follows)
+            {
+                std::uint8_t len{};
+                return get_number(input_format_t::cbor, len) &&
+                       get_binary(input_format_t::cbor, len, result);
+            }
+
+            case 0x59: // Binary data (two-byte uint16_t for n follow)
+            {
+                std::uint16_t len{};
+                return get_number(input_format_t::cbor, len) &&
+                       get_binary(input_format_t::cbor, len, result);
+            }
+
+            case 0x5A: // Binary data (four-byte uint32_t for n follow)
+            {
+                std::uint32_t len{};
+                return get_number(input_format_t::cbor, len) &&
+                       get_binary(input_format_t::cbor, len, result);
+            }
+
+            case 0x5B: // Binary data (eight-byte uint64_t for n follow)
+            {
+                std::uint64_t len{};
+                return get_number(input_format_t::cbor, len) &&
+                       get_binary(input_format_t::cbor, len, result);
+            }
+
+            case 0x5F: // Binary data (indefinite length)
+            {
+                while (get() != 0xFF)
+                {
+                    binary_t chunk;
+                    if (!get_cbor_binary(chunk))
+                    {
+                        return false;
+                    }
+                    result.insert(result.end(), chunk.begin(), chunk.end());
+                }
+                return true;
+            }
+
+            default:
+            {
+                auto last_token = get_token_string();
+                return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read,
+                                        exception_message(input_format_t::cbor, concat("expected length specification (0x40-0x5B) or indefinite binary array type (0x5F); last byte: 0x", last_token), "binary"), nullptr));
+            }
+        }
+    }
+
+    /*!
+    @param[in] len  the length of the array or static_cast<std::size_t>(-1) for an
+                    array of indefinite size
+    @param[in] tag_handler how CBOR tags should be treated
+    @return whether array creation completed
+    */
+    bool get_cbor_array(const std::size_t len,
+                        const cbor_tag_handler_t tag_handler)
+    {
+        if (JSON_HEDLEY_UNLIKELY(!sax->start_array(len)))
+        {
+            return false;
+        }
+
+        if (len != static_cast<std::size_t>(-1))
+        {
+            for (std::size_t i = 0; i < len; ++i)
+            {
+                if (JSON_HEDLEY_UNLIKELY(!parse_cbor_internal(true, tag_handler)))
+                {
+                    return false;
+                }
+            }
+        }
+        else
+        {
+            while (get() != 0xFF)
+            {
+                if (JSON_HEDLEY_UNLIKELY(!parse_cbor_internal(false, tag_handler)))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return sax->end_array();
+    }
+
+    /*!
+    @param[in] len  the length of the object or static_cast<std::size_t>(-1) for an
+                    object of indefinite size
+    @param[in] tag_handler how CBOR tags should be treated
+    @return whether object creation completed
+    */
+    bool get_cbor_object(const std::size_t len,
+                         const cbor_tag_handler_t tag_handler)
+    {
+        if (JSON_HEDLEY_UNLIKELY(!sax->start_object(len)))
+        {
+            return false;
+        }
+
+        if (len != 0)
+        {
+            string_t key;
+            if (len != static_cast<std::size_t>(-1))
+            {
+                for (std::size_t i = 0; i < len; ++i)
+                {
+                    get();
+                    if (JSON_HEDLEY_UNLIKELY(!get_cbor_string(key) || !sax->key(key)))
+                    {
+                        return false;
+                    }
+
+                    if (JSON_HEDLEY_UNLIKELY(!parse_cbor_internal(true, tag_handler)))
+                    {
+                        return false;
+                    }
+                    key.clear();
+                }
+            }
+            else
+            {
+                while (get() != 0xFF)
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!get_cbor_string(key) || !sax->key(key)))
+                    {
+                        return false;
+                    }
+
+                    if (JSON_HEDLEY_UNLIKELY(!parse_cbor_internal(true, tag_handler)))
+                    {
+                        return false;
+                    }
+                    key.clear();
+                }
+            }
+        }
+
+        return sax->end_object();
+    }
+
+    /////////////
+    // MsgPack //
+    /////////////
+
+    /*!
+    @return whether a valid MessagePack value was passed to the SAX parser
+    */
+    bool parse_msgpack_internal()
+    {
+        switch (get())
+        {
+            // EOF
+            case char_traits<char_type>::eof():
+                return unexpect_eof(input_format_t::msgpack, "value");
+
+            // positive fixint
+            case 0x00:
+            case 0x01:
+            case 0x02:
+            case 0x03:
+            case 0x04:
+            case 0x05:
+            case 0x06:
+            case 0x07:
+            case 0x08:
+            case 0x09:
+            case 0x0A:
+            case 0x0B:
+            case 0x0C:
+            case 0x0D:
+            case 0x0E:
+            case 0x0F:
+            case 0x10:
+            case 0x11:
+            case 0x12:
+            case 0x13:
+            case 0x14:
+            case 0x15:
+            case 0x16:
+            case 0x17:
+            case 0x18:
+            case 0x19:
+            case 0x1A:
+            case 0x1B:
+            case 0x1C:
+            case 0x1D:
+            case 0x1E:
+            case 0x1F:
+            case 0x20:
+            case 0x21:
+            case 0x22:
+            case 0x23:
+            case 0x24:
+            case 0x25:
+            case 0x26:
+            case 0x27:
+            case 0x28:
+            case 0x29:
+            case 0x2A:
+            case 0x2B:
+            case 0x2C:
+            case 0x2D:
+            case 0x2E:
+            case 0x2F:
+            case 0x30:
+            case 0x31:
+            case 0x32:
+            case 0x33:
+            case 0x34:
+            case 0x35:
+            case 0x36:
+            case 0x37:
+            case 0x38:
+            case 0x39:
+            case 0x3A:
+            case 0x3B:
+            case 0x3C:
+            case 0x3D:
+            case 0x3E:
+            case 0x3F:
+            case 0x40:
+            case 0x41:
+            case 0x42:
+            case 0x43:
+            case 0x44:
+            case 0x45:
+            case 0x46:
+            case 0x47:
+            case 0x48:
+            case 0x49:
+            case 0x4A:
+            case 0x4B:
+            case 0x4C:
+            case 0x4D:
+            case 0x4E:
+            case 0x4F:
+            case 0x50:
+            case 0x51:
+            case 0x52:
+            case 0x53:
+            case 0x54:
+            case 0x55:
+            case 0x56:
+            case 0x57:
+            case 0x58:
+            case 0x59:
+            case 0x5A:
+            case 0x5B:
+            case 0x5C:
+            case 0x5D:
+            case 0x5E:
+            case 0x5F:
+            case 0x60:
+            case 0x61:
+            case 0x62:
+            case 0x63:
+            case 0x64:
+            case 0x65:
+            case 0x66:
+            case 0x67:
+            case 0x68:
+            case 0x69:
+            case 0x6A:
+            case 0x6B:
+            case 0x6C:
+            case 0x6D:
+            case 0x6E:
+            case 0x6F:
+            case 0x70:
+            case 0x71:
+            case 0x72:
+            case 0x73:
+            case 0x74:
+            case 0x75:
+            case 0x76:
+            case 0x77:
+            case 0x78:
+            case 0x79:
+            case 0x7A:
+            case 0x7B:
+            case 0x7C:
+            case 0x7D:
+            case 0x7E:
+            case 0x7F:
+                return sax->number_unsigned(static_cast<number_unsigned_t>(current));
+
+            // fixmap
+            case 0x80:
+            case 0x81:
+            case 0x82:
+            case 0x83:
+            case 0x84:
+            case 0x85:
+            case 0x86:
+            case 0x87:
+            case 0x88:
+            case 0x89:
+            case 0x8A:
+            case 0x8B:
+            case 0x8C:
+            case 0x8D:
+            case 0x8E:
+            case 0x8F:
+                return get_msgpack_object(conditional_static_cast<std::size_t>(static_cast<unsigned int>(current) & 0x0Fu));
+
+            // fixarray
+            case 0x90:
+            case 0x91:
+            case 0x92:
+            case 0x93:
+            case 0x94:
+            case 0x95:
+            case 0x96:
+            case 0x97:
+            case 0x98:
+            case 0x99:
+            case 0x9A:
+            case 0x9B:
+            case 0x9C:
+            case 0x9D:
+            case 0x9E:
+            case 0x9F:
+                return get_msgpack_array(conditional_static_cast<std::size_t>(static_cast<unsigned int>(current) & 0x0Fu));
+
+            // fixstr
+            case 0xA0:
+            case 0xA1:
+            case 0xA2:
+            case 0xA3:
+            case 0xA4:
+            case 0xA5:
+            case 0xA6:
+            case 0xA7:
+            case 0xA8:
+            case 0xA9:
+            case 0xAA:
+            case 0xAB:
+            case 0xAC:
+            case 0xAD:
+            case 0xAE:
+            case 0xAF:
+            case 0xB0:
+            case 0xB1:
+            case 0xB2:
+            case 0xB3:
+            case 0xB4:
+            case 0xB5:
+            case 0xB6:
+            case 0xB7:
+            case 0xB8:
+            case 0xB9:
+            case 0xBA:
+            case 0xBB:
+            case 0xBC:
+            case 0xBD:
+            case 0xBE:
+            case 0xBF:
+            case 0xD9: // str 8
+            case 0xDA: // str 16
+            case 0xDB: // str 32
+            {
+                string_t s;
+                return get_msgpack_string(s) && sax->string(s);
+            }
+
+            case 0xC0: // nil
+                return sax->null();
+
+            case 0xC2: // false
+                return sax->boolean(false);
+
+            case 0xC3: // true
+                return sax->boolean(true);
+
+            case 0xC4: // bin 8
+            case 0xC5: // bin 16
+            case 0xC6: // bin 32
+            case 0xC7: // ext 8
+            case 0xC8: // ext 16
+            case 0xC9: // ext 32
+            case 0xD4: // fixext 1
+            case 0xD5: // fixext 2
+            case 0xD6: // fixext 4
+            case 0xD7: // fixext 8
+            case 0xD8: // fixext 16
+            {
+                binary_t b;
+                return get_msgpack_binary(b) && sax->binary(b);
+            }
+
+            case 0xCA: // float 32
+            {
+                float number{};
+                return get_number(input_format_t::msgpack, number) && sax->number_float(static_cast<number_float_t>(number), "");
+            }
+
+            case 0xCB: // float 64
+            {
+                double number{};
+                return get_number(input_format_t::msgpack, number) && sax->number_float(static_cast<number_float_t>(number), "");
+            }
+
+            case 0xCC: // uint 8
+            {
+                std::uint8_t number{};
+                return get_number(input_format_t::msgpack, number) && sax->number_unsigned(number);
+            }
+
+            case 0xCD: // uint 16
+            {
+                std::uint16_t number{};
+                return get_number(input_format_t::msgpack, number) && sax->number_unsigned(number);
+            }
+
+            case 0xCE: // uint 32
+            {
+                std::uint32_t number{};
+                return get_number(input_format_t::msgpack, number) && sax->number_unsigned(number);
+            }
+
+            case 0xCF: // uint 64
+            {
+                std::uint64_t number{};
+                return get_number(input_format_t::msgpack, number) && sax->number_unsigned(number);
+            }
+
+            case 0xD0: // int 8
+            {
+                std::int8_t number{};
+                return get_number(input_format_t::msgpack, number) && sax->number_integer(number);
+            }
+
+            case 0xD1: // int 16
+            {
+                std::int16_t number{};
+                return get_number(input_format_t::msgpack, number) && sax->number_integer(number);
+            }
+
+            case 0xD2: // int 32
+            {
+                std::int32_t number{};
+                return get_number(input_format_t::msgpack, number) && sax->number_integer(number);
+            }
+
+            case 0xD3: // int 64
+            {
+                std::int64_t number{};
+                return get_number(input_format_t::msgpack, number) && sax->number_integer(number);
+            }
+
+            case 0xDC: // array 16
+            {
+                std::uint16_t len{};
+                return get_number(input_format_t::msgpack, len) && get_msgpack_array(static_cast<std::size_t>(len));
+            }
+
+            case 0xDD: // array 32
+            {
+                std::uint32_t len{};
+                return get_number(input_format_t::msgpack, len) && get_msgpack_array(conditional_static_cast<std::size_t>(len));
+            }
+
+            case 0xDE: // map 16
+            {
+                std::uint16_t len{};
+                return get_number(input_format_t::msgpack, len) && get_msgpack_object(static_cast<std::size_t>(len));
+            }
+
+            case 0xDF: // map 32
+            {
+                std::uint32_t len{};
+                return get_number(input_format_t::msgpack, len) && get_msgpack_object(conditional_static_cast<std::size_t>(len));
+            }
+
+            // negative fixint
+            case 0xE0:
+            case 0xE1:
+            case 0xE2:
+            case 0xE3:
+            case 0xE4:
+            case 0xE5:
+            case 0xE6:
+            case 0xE7:
+            case 0xE8:
+            case 0xE9:
+            case 0xEA:
+            case 0xEB:
+            case 0xEC:
+            case 0xED:
+            case 0xEE:
+            case 0xEF:
+            case 0xF0:
+            case 0xF1:
+            case 0xF2:
+            case 0xF3:
+            case 0xF4:
+            case 0xF5:
+            case 0xF6:
+            case 0xF7:
+            case 0xF8:
+            case 0xF9:
+            case 0xFA:
+            case 0xFB:
+            case 0xFC:
+            case 0xFD:
+            case 0xFE:
+            case 0xFF:
+                return sax->number_integer(static_cast<std::int8_t>(current));
+
+            default: // anything else
+            {
+                auto last_token = get_token_string();
+                return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                        exception_message(input_format_t::msgpack, concat("invalid byte: 0x", last_token), "value"), nullptr));
+            }
+        }
+    }
+
+    /*!
+    @brief reads a MessagePack string
+
+    This function first reads starting bytes to determine the expected
+    string length and then copies this number of bytes into a string.
+
+    @param[out] result  created string
+
+    @return whether string creation completed
+    */
+    bool get_msgpack_string(string_t& result)
+    {
+        if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format_t::msgpack, "string")))
+        {
+            return false;
+        }
+
+        switch (current)
+        {
+            // fixstr
+            case 0xA0:
+            case 0xA1:
+            case 0xA2:
+            case 0xA3:
+            case 0xA4:
+            case 0xA5:
+            case 0xA6:
+            case 0xA7:
+            case 0xA8:
+            case 0xA9:
+            case 0xAA:
+            case 0xAB:
+            case 0xAC:
+            case 0xAD:
+            case 0xAE:
+            case 0xAF:
+            case 0xB0:
+            case 0xB1:
+            case 0xB2:
+            case 0xB3:
+            case 0xB4:
+            case 0xB5:
+            case 0xB6:
+            case 0xB7:
+            case 0xB8:
+            case 0xB9:
+            case 0xBA:
+            case 0xBB:
+            case 0xBC:
+            case 0xBD:
+            case 0xBE:
+            case 0xBF:
+            {
+                return get_string(input_format_t::msgpack, static_cast<unsigned int>(current) & 0x1Fu, result);
+            }
+
+            case 0xD9: // str 8
+            {
+                std::uint8_t len{};
+                return get_number(input_format_t::msgpack, len) && get_string(input_format_t::msgpack, len, result);
+            }
+
+            case 0xDA: // str 16
+            {
+                std::uint16_t len{};
+                return get_number(input_format_t::msgpack, len) && get_string(input_format_t::msgpack, len, result);
+            }
+
+            case 0xDB: // str 32
+            {
+                std::uint32_t len{};
+                return get_number(input_format_t::msgpack, len) && get_string(input_format_t::msgpack, len, result);
+            }
+
+            default:
+            {
+                auto last_token = get_token_string();
+                return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read,
+                                        exception_message(input_format_t::msgpack, concat("expected length specification (0xA0-0xBF, 0xD9-0xDB); last byte: 0x", last_token), "string"), nullptr));
+            }
+        }
+    }
+
+    /*!
+    @brief reads a MessagePack byte array
+
+    This function first reads starting bytes to determine the expected
+    byte array length and then copies this number of bytes into a byte array.
+
+    @param[out] result  created byte array
+
+    @return whether byte array creation completed
+    */
+    bool get_msgpack_binary(binary_t& result)
+    {
+        // helper function to set the subtype
+        auto assign_and_return_true = [&result](std::int8_t subtype)
+        {
+            result.set_subtype(static_cast<std::uint8_t>(subtype));
+            return true;
+        };
+
+        switch (current)
+        {
+            case 0xC4: // bin 8
+            {
+                std::uint8_t len{};
+                return get_number(input_format_t::msgpack, len) &&
+                       get_binary(input_format_t::msgpack, len, result);
+            }
+
+            case 0xC5: // bin 16
+            {
+                std::uint16_t len{};
+                return get_number(input_format_t::msgpack, len) &&
+                       get_binary(input_format_t::msgpack, len, result);
+            }
+
+            case 0xC6: // bin 32
+            {
+                std::uint32_t len{};
+                return get_number(input_format_t::msgpack, len) &&
+                       get_binary(input_format_t::msgpack, len, result);
+            }
+
+            case 0xC7: // ext 8
+            {
+                std::uint8_t len{};
+                std::int8_t subtype{};
+                return get_number(input_format_t::msgpack, len) &&
+                       get_number(input_format_t::msgpack, subtype) &&
+                       get_binary(input_format_t::msgpack, len, result) &&
+                       assign_and_return_true(subtype);
+            }
+
+            case 0xC8: // ext 16
+            {
+                std::uint16_t len{};
+                std::int8_t subtype{};
+                return get_number(input_format_t::msgpack, len) &&
+                       get_number(input_format_t::msgpack, subtype) &&
+                       get_binary(input_format_t::msgpack, len, result) &&
+                       assign_and_return_true(subtype);
+            }
+
+            case 0xC9: // ext 32
+            {
+                std::uint32_t len{};
+                std::int8_t subtype{};
+                return get_number(input_format_t::msgpack, len) &&
+                       get_number(input_format_t::msgpack, subtype) &&
+                       get_binary(input_format_t::msgpack, len, result) &&
+                       assign_and_return_true(subtype);
+            }
+
+            case 0xD4: // fixext 1
+            {
+                std::int8_t subtype{};
+                return get_number(input_format_t::msgpack, subtype) &&
+                       get_binary(input_format_t::msgpack, 1, result) &&
+                       assign_and_return_true(subtype);
+            }
+
+            case 0xD5: // fixext 2
+            {
+                std::int8_t subtype{};
+                return get_number(input_format_t::msgpack, subtype) &&
+                       get_binary(input_format_t::msgpack, 2, result) &&
+                       assign_and_return_true(subtype);
+            }
+
+            case 0xD6: // fixext 4
+            {
+                std::int8_t subtype{};
+                return get_number(input_format_t::msgpack, subtype) &&
+                       get_binary(input_format_t::msgpack, 4, result) &&
+                       assign_and_return_true(subtype);
+            }
+
+            case 0xD7: // fixext 8
+            {
+                std::int8_t subtype{};
+                return get_number(input_format_t::msgpack, subtype) &&
+                       get_binary(input_format_t::msgpack, 8, result) &&
+                       assign_and_return_true(subtype);
+            }
+
+            case 0xD8: // fixext 16
+            {
+                std::int8_t subtype{};
+                return get_number(input_format_t::msgpack, subtype) &&
+                       get_binary(input_format_t::msgpack, 16, result) &&
+                       assign_and_return_true(subtype);
+            }
+
+            default:           // LCOV_EXCL_LINE
+                return false;  // LCOV_EXCL_LINE
+        }
+    }
+
+    /*!
+    @param[in] len  the length of the array
+    @return whether array creation completed
+    */
+    bool get_msgpack_array(const std::size_t len)
+    {
+        if (JSON_HEDLEY_UNLIKELY(!sax->start_array(len)))
+        {
+            return false;
+        }
+
+        for (std::size_t i = 0; i < len; ++i)
+        {
+            if (JSON_HEDLEY_UNLIKELY(!parse_msgpack_internal()))
+            {
+                return false;
+            }
+        }
+
+        return sax->end_array();
+    }
+
+    /*!
+    @param[in] len  the length of the object
+    @return whether object creation completed
+    */
+    bool get_msgpack_object(const std::size_t len)
+    {
+        if (JSON_HEDLEY_UNLIKELY(!sax->start_object(len)))
+        {
+            return false;
+        }
+
+        string_t key;
+        for (std::size_t i = 0; i < len; ++i)
+        {
+            get();
+            if (JSON_HEDLEY_UNLIKELY(!get_msgpack_string(key) || !sax->key(key)))
+            {
+                return false;
+            }
+
+            if (JSON_HEDLEY_UNLIKELY(!parse_msgpack_internal()))
+            {
+                return false;
+            }
+            key.clear();
+        }
+
+        return sax->end_object();
+    }
+
+    ////////////
+    // UBJSON //
+    ////////////
+
+    /*!
+    @param[in] get_char  whether a new character should be retrieved from the
+                         input (true, default) or whether the last read
+                         character should be considered instead
+
+    @return whether a valid UBJSON value was passed to the SAX parser
+    */
+    bool parse_ubjson_internal(const bool get_char = true)
+    {
+        return get_ubjson_value(get_char ? get_ignore_noop() : current);
+    }
+
+    /*!
+    @brief reads a UBJSON string
+
+    This function is either called after reading the 'S' byte explicitly
+    indicating a string, or in case of an object key where the 'S' byte can be
+    left out.
+
+    @param[out] result   created string
+    @param[in] get_char  whether a new character should be retrieved from the
+                         input (true, default) or whether the last read
+                         character should be considered instead
+
+    @return whether string creation completed
+    */
+    bool get_ubjson_string(string_t& result, const bool get_char = true)
+    {
+        if (get_char)
+        {
+            get();  // TODO(niels): may we ignore N here?
+        }
+
+        if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "value")))
+        {
+            return false;
+        }
+
+        switch (current)
+        {
+            case 'U':
+            {
+                std::uint8_t len{};
+                return get_number(input_format, len) && get_string(input_format, len, result);
+            }
+
+            case 'i':
+            {
+                std::int8_t len{};
+                return get_number(input_format, len) && get_string(input_format, len, result);
+            }
+
+            case 'I':
+            {
+                std::int16_t len{};
+                return get_number(input_format, len) && get_string(input_format, len, result);
+            }
+
+            case 'l':
+            {
+                std::int32_t len{};
+                return get_number(input_format, len) && get_string(input_format, len, result);
+            }
+
+            case 'L':
+            {
+                std::int64_t len{};
+                return get_number(input_format, len) && get_string(input_format, len, result);
+            }
+
+            case 'u':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                std::uint16_t len{};
+                return get_number(input_format, len) && get_string(input_format, len, result);
+            }
+
+            case 'm':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                std::uint32_t len{};
+                return get_number(input_format, len) && get_string(input_format, len, result);
+            }
+
+            case 'M':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                std::uint64_t len{};
+                return get_number(input_format, len) && get_string(input_format, len, result);
+            }
+
+            default:
+                break;
+        }
+        auto last_token = get_token_string();
+        std::string message;
+
+        if (input_format != input_format_t::bjdata)
+        {
+            message = "expected length type specification (U, i, I, l, L); last byte: 0x" + last_token;
+        }
+        else
+        {
+            message = "expected length type specification (U, i, u, I, m, l, M, L); last byte: 0x" + last_token;
+        }
+        return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format, message, "string"), nullptr));
+    }
+
+    /*!
+    @param[out] dim  an integer vector storing the ND array dimensions
+    @return whether reading ND array size vector is successful
+    */
+    bool get_ubjson_ndarray_size(std::vector<size_t>& dim)
+    {
+        std::pair<std::size_t, char_int_type> size_and_type;
+        size_t dimlen = 0;
+        bool no_ndarray = true;
+
+        if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_type(size_and_type, no_ndarray)))
+        {
+            return false;
+        }
+
+        if (size_and_type.first != npos)
+        {
+            if (size_and_type.second != 0)
+            {
+                if (size_and_type.second != 'N')
+                {
+                    for (std::size_t i = 0; i < size_and_type.first; ++i)
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, no_ndarray, size_and_type.second)))
+                        {
+                            return false;
+                        }
+                        dim.push_back(dimlen);
+                    }
+                }
+            }
+            else
+            {
+                for (std::size_t i = 0; i < size_and_type.first; ++i)
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, no_ndarray)))
+                    {
+                        return false;
+                    }
+                    dim.push_back(dimlen);
+                }
+            }
+        }
+        else
+        {
+            while (current != ']')
+            {
+                if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_value(dimlen, no_ndarray, current)))
+                {
+                    return false;
+                }
+                dim.push_back(dimlen);
+                get_ignore_noop();
+            }
+        }
+        return true;
+    }
+
+    /*!
+    @param[out] result  determined size
+    @param[in,out] is_ndarray  for input, `true` means already inside an ndarray vector
+                               or ndarray dimension is not allowed; `false` means ndarray
+                               is allowed; for output, `true` means an ndarray is found;
+                               is_ndarray can only return `true` when its initial value
+                               is `false`
+    @param[in] prefix  type marker if already read, otherwise set to 0
+
+    @return whether size determination completed
+    */
+    bool get_ubjson_size_value(std::size_t& result, bool& is_ndarray, char_int_type prefix = 0)
+    {
+        if (prefix == 0)
+        {
+            prefix = get_ignore_noop();
+        }
+
+        switch (prefix)
+        {
+            case 'U':
+            {
+                std::uint8_t number{};
+                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format, number)))
+                {
+                    return false;
+                }
+                result = static_cast<std::size_t>(number);
+                return true;
+            }
+
+            case 'i':
+            {
+                std::int8_t number{};
+                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format, number)))
+                {
+                    return false;
+                }
+                if (number < 0)
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read,
+                                            exception_message(input_format, "count in an optimized container must be positive", "size"), nullptr));
+                }
+                result = static_cast<std::size_t>(number); // NOLINT(bugprone-signed-char-misuse,cert-str34-c): number is not a char
+                return true;
+            }
+
+            case 'I':
+            {
+                std::int16_t number{};
+                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format, number)))
+                {
+                    return false;
+                }
+                if (number < 0)
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read,
+                                            exception_message(input_format, "count in an optimized container must be positive", "size"), nullptr));
+                }
+                result = static_cast<std::size_t>(number);
+                return true;
+            }
+
+            case 'l':
+            {
+                std::int32_t number{};
+                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format, number)))
+                {
+                    return false;
+                }
+                if (number < 0)
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read,
+                                            exception_message(input_format, "count in an optimized container must be positive", "size"), nullptr));
+                }
+                result = static_cast<std::size_t>(number);
+                return true;
+            }
+
+            case 'L':
+            {
+                std::int64_t number{};
+                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format, number)))
+                {
+                    return false;
+                }
+                if (number < 0)
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read,
+                                            exception_message(input_format, "count in an optimized container must be positive", "size"), nullptr));
+                }
+                if (!value_in_range_of<std::size_t>(number))
+                {
+                    return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408,
+                                            exception_message(input_format, "integer value overflow", "size"), nullptr));
+                }
+                result = static_cast<std::size_t>(number);
+                return true;
+            }
+
+            case 'u':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                std::uint16_t number{};
+                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format, number)))
+                {
+                    return false;
+                }
+                result = static_cast<std::size_t>(number);
+                return true;
+            }
+
+            case 'm':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                std::uint32_t number{};
+                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format, number)))
+                {
+                    return false;
+                }
+                result = conditional_static_cast<std::size_t>(number);
+                return true;
+            }
+
+            case 'M':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                std::uint64_t number{};
+                if (JSON_HEDLEY_UNLIKELY(!get_number(input_format, number)))
+                {
+                    return false;
+                }
+                if (!value_in_range_of<std::size_t>(number))
+                {
+                    return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408,
+                                            exception_message(input_format, "integer value overflow", "size"), nullptr));
+                }
+                result = detail::conditional_static_cast<std::size_t>(number);
+                return true;
+            }
+
+            case '[':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                if (is_ndarray) // ndarray dimensional vector can only contain integers, and can not embed another array
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "ndarray dimensional vector is not allowed", "size"), nullptr));
+                }
+                std::vector<size_t> dim;
+                if (JSON_HEDLEY_UNLIKELY(!get_ubjson_ndarray_size(dim)))
+                {
+                    return false;
+                }
+                if (dim.size() == 1 || (dim.size() == 2 && dim.at(0) == 1)) // return normal array size if 1D row vector
+                {
+                    result = dim.at(dim.size() - 1);
+                    return true;
+                }
+                if (!dim.empty())  // if ndarray, convert to an object in JData annotated array format
+                {
+                    for (auto i : dim) // test if any dimension in an ndarray is 0, if so, return a 1D empty container
+                    {
+                        if ( i == 0 )
+                        {
+                            result = 0;
+                            return true;
+                        }
+                    }
+
+                    string_t key = "_ArraySize_";
+                    if (JSON_HEDLEY_UNLIKELY(!sax->start_object(3) || !sax->key(key) || !sax->start_array(dim.size())))
+                    {
+                        return false;
+                    }
+                    result = 1;
+                    for (auto i : dim)
+                    {
+                        result *= i;
+                        if (result == 0 || result == npos) // because dim elements shall not have zeros, result = 0 means overflow happened; it also can't be npos as it is used to initialize size in get_ubjson_size_type()
+                        {
+                            return sax->parse_error(chars_read, get_token_string(), out_of_range::create(408, exception_message(input_format, "excessive ndarray size caused overflow", "size"), nullptr));
+                        }
+                        if (JSON_HEDLEY_UNLIKELY(!sax->number_unsigned(static_cast<number_unsigned_t>(i))))
+                        {
+                            return false;
+                        }
+                    }
+                    is_ndarray = true;
+                    return sax->end_array();
+                }
+                result = 0;
+                return true;
+            }
+
+            default:
+                break;
+        }
+        auto last_token = get_token_string();
+        std::string message;
+
+        if (input_format != input_format_t::bjdata)
+        {
+            message = "expected length type specification (U, i, I, l, L) after '#'; last byte: 0x" + last_token;
+        }
+        else
+        {
+            message = "expected length type specification (U, i, u, I, m, l, M, L) after '#'; last byte: 0x" + last_token;
+        }
+        return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read, exception_message(input_format, message, "size"), nullptr));
+    }
+
+    /*!
+    @brief determine the type and size for a container
+
+    In the optimized UBJSON format, a type and a size can be provided to allow
+    for a more compact representation.
+
+    @param[out] result  pair of the size and the type
+    @param[in] inside_ndarray  whether the parser is parsing an ND array dimensional vector
+
+    @return whether pair creation completed
+    */
+    bool get_ubjson_size_type(std::pair<std::size_t, char_int_type>& result, bool inside_ndarray = false)
+    {
+        result.first = npos; // size
+        result.second = 0; // type
+        bool is_ndarray = false;
+
+        get_ignore_noop();
+
+        if (current == '$')
+        {
+            result.second = get();  // must not ignore 'N', because 'N' maybe the type
+            if (input_format == input_format_t::bjdata
+                    && JSON_HEDLEY_UNLIKELY(std::binary_search(bjd_optimized_type_markers.begin(), bjd_optimized_type_markers.end(), result.second)))
+            {
+                auto last_token = get_token_string();
+                return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                        exception_message(input_format, concat("marker 0x", last_token, " is not a permitted optimized array type"), "type"), nullptr));
+            }
+
+            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "type")))
+            {
+                return false;
+            }
+
+            get_ignore_noop();
+            if (JSON_HEDLEY_UNLIKELY(current != '#'))
+            {
+                if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "value")))
+                {
+                    return false;
+                }
+                auto last_token = get_token_string();
+                return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                        exception_message(input_format, concat("expected '#' after type information; last byte: 0x", last_token), "size"), nullptr));
+            }
+
+            const bool is_error = get_ubjson_size_value(result.first, is_ndarray);
+            if (input_format == input_format_t::bjdata && is_ndarray)
+            {
+                if (inside_ndarray)
+                {
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(112, chars_read,
+                                            exception_message(input_format, "ndarray can not be recursive", "size"), nullptr));
+                }
+                result.second |= (1 << 8); // use bit 8 to indicate ndarray, all UBJSON and BJData markers should be ASCII letters
+            }
+            return is_error;
+        }
+
+        if (current == '#')
+        {
+            const bool is_error = get_ubjson_size_value(result.first, is_ndarray);
+            if (input_format == input_format_t::bjdata && is_ndarray)
+            {
+                return sax->parse_error(chars_read, get_token_string(), parse_error::create(112, chars_read,
+                                        exception_message(input_format, "ndarray requires both type and size", "size"), nullptr));
+            }
+            return is_error;
+        }
+
+        return true;
+    }
+
+    /*!
+    @param prefix  the previously read or set type prefix
+    @return whether value creation completed
+    */
+    bool get_ubjson_value(const char_int_type prefix)
+    {
+        switch (prefix)
+        {
+            case char_traits<char_type>::eof():  // EOF
+                return unexpect_eof(input_format, "value");
+
+            case 'T':  // true
+                return sax->boolean(true);
+            case 'F':  // false
+                return sax->boolean(false);
+
+            case 'Z':  // null
+                return sax->null();
+
+            case 'U':
+            {
+                std::uint8_t number{};
+                return get_number(input_format, number) && sax->number_unsigned(number);
+            }
+
+            case 'i':
+            {
+                std::int8_t number{};
+                return get_number(input_format, number) && sax->number_integer(number);
+            }
+
+            case 'I':
+            {
+                std::int16_t number{};
+                return get_number(input_format, number) && sax->number_integer(number);
+            }
+
+            case 'l':
+            {
+                std::int32_t number{};
+                return get_number(input_format, number) && sax->number_integer(number);
+            }
+
+            case 'L':
+            {
+                std::int64_t number{};
+                return get_number(input_format, number) && sax->number_integer(number);
+            }
+
+            case 'u':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                std::uint16_t number{};
+                return get_number(input_format, number) && sax->number_unsigned(number);
+            }
+
+            case 'm':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                std::uint32_t number{};
+                return get_number(input_format, number) && sax->number_unsigned(number);
+            }
+
+            case 'M':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                std::uint64_t number{};
+                return get_number(input_format, number) && sax->number_unsigned(number);
+            }
+
+            case 'h':
+            {
+                if (input_format != input_format_t::bjdata)
+                {
+                    break;
+                }
+                const auto byte1_raw = get();
+                if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "number")))
+                {
+                    return false;
+                }
+                const auto byte2_raw = get();
+                if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "number")))
+                {
+                    return false;
+                }
+
+                const auto byte1 = static_cast<unsigned char>(byte1_raw);
+                const auto byte2 = static_cast<unsigned char>(byte2_raw);
+
+                // code from RFC 7049, Appendix D, Figure 3:
+                // As half-precision floating-point numbers were only added
+                // to IEEE 754 in 2008, today's programming platforms often
+                // still only have limited support for them. It is very
+                // easy to include at least decoding support for them even
+                // without such support. An example of a small decoder for
+                // half-precision floating-point numbers in the C language
+                // is shown in Fig. 3.
+                const auto half = static_cast<unsigned int>((byte2 << 8u) + byte1);
+                const double val = [&half]
+                {
+                    const int exp = (half >> 10u) & 0x1Fu;
+                    const unsigned int mant = half & 0x3FFu;
+                    JSON_ASSERT(0 <= exp&& exp <= 32);
+                    JSON_ASSERT(mant <= 1024);
+                    switch (exp)
+                    {
+                        case 0:
+                            return std::ldexp(mant, -24);
+                        case 31:
+                            return (mant == 0)
+                            ? std::numeric_limits<double>::infinity()
+                            : std::numeric_limits<double>::quiet_NaN();
+                        default:
+                            return std::ldexp(mant + 1024, exp - 25);
+                    }
+                }();
+                return sax->number_float((half & 0x8000u) != 0
+                                         ? static_cast<number_float_t>(-val)
+                                         : static_cast<number_float_t>(val), "");
+            }
+
+            case 'd':
+            {
+                float number{};
+                return get_number(input_format, number) && sax->number_float(static_cast<number_float_t>(number), "");
+            }
+
+            case 'D':
+            {
+                double number{};
+                return get_number(input_format, number) && sax->number_float(static_cast<number_float_t>(number), "");
+            }
+
+            case 'H':
+            {
+                return get_ubjson_high_precision_number();
+            }
+
+            case 'C':  // char
+            {
+                get();
+                if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "char")))
+                {
+                    return false;
+                }
+                if (JSON_HEDLEY_UNLIKELY(current > 127))
+                {
+                    auto last_token = get_token_string();
+                    return sax->parse_error(chars_read, last_token, parse_error::create(113, chars_read,
+                                            exception_message(input_format, concat("byte after 'C' must be in range 0x00..0x7F; last byte: 0x", last_token), "char"), nullptr));
+                }
+                string_t s(1, static_cast<typename string_t::value_type>(current));
+                return sax->string(s);
+            }
+
+            case 'S':  // string
+            {
+                string_t s;
+                return get_ubjson_string(s) && sax->string(s);
+            }
+
+            case '[':  // array
+                return get_ubjson_array();
+
+            case '{':  // object
+                return get_ubjson_object();
+
+            default: // anything else
+                break;
+        }
+        auto last_token = get_token_string();
+        return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read, exception_message(input_format, "invalid byte: 0x" + last_token, "value"), nullptr));
+    }
+
+    /*!
+    @return whether array creation completed
+    */
+    bool get_ubjson_array()
+    {
+        std::pair<std::size_t, char_int_type> size_and_type;
+        if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_type(size_and_type)))
+        {
+            return false;
+        }
+
+        // if bit-8 of size_and_type.second is set to 1, encode bjdata ndarray as an object in JData annotated array format (https://github.com/NeuroJSON/jdata):
+        // {"_ArrayType_" : "typeid", "_ArraySize_" : [n1, n2, ...], "_ArrayData_" : [v1, v2, ...]}
+
+        if (input_format == input_format_t::bjdata && size_and_type.first != npos && (size_and_type.second & (1 << 8)) != 0)
+        {
+            size_and_type.second &= ~(static_cast<char_int_type>(1) << 8);  // use bit 8 to indicate ndarray, here we remove the bit to restore the type marker
+            auto it = std::lower_bound(bjd_types_map.begin(), bjd_types_map.end(), size_and_type.second, [](const bjd_type & p, char_int_type t)
+            {
+                return p.first < t;
+            });
+            string_t key = "_ArrayType_";
+            if (JSON_HEDLEY_UNLIKELY(it == bjd_types_map.end() || it->first != size_and_type.second))
+            {
+                auto last_token = get_token_string();
+                return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                        exception_message(input_format, "invalid byte: 0x" + last_token, "type"), nullptr));
+            }
+
+            string_t type = it->second; // sax->string() takes a reference
+            if (JSON_HEDLEY_UNLIKELY(!sax->key(key) || !sax->string(type)))
+            {
+                return false;
+            }
+
+            if (size_and_type.second == 'C')
+            {
+                size_and_type.second = 'U';
+            }
+
+            key = "_ArrayData_";
+            if (JSON_HEDLEY_UNLIKELY(!sax->key(key) || !sax->start_array(size_and_type.first) ))
+            {
+                return false;
+            }
+
+            for (std::size_t i = 0; i < size_and_type.first; ++i)
+            {
+                if (JSON_HEDLEY_UNLIKELY(!get_ubjson_value(size_and_type.second)))
+                {
+                    return false;
+                }
+            }
+
+            return (sax->end_array() && sax->end_object());
+        }
+
+        if (size_and_type.first != npos)
+        {
+            if (JSON_HEDLEY_UNLIKELY(!sax->start_array(size_and_type.first)))
+            {
+                return false;
+            }
+
+            if (size_and_type.second != 0)
+            {
+                if (size_and_type.second != 'N')
+                {
+                    for (std::size_t i = 0; i < size_and_type.first; ++i)
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!get_ubjson_value(size_and_type.second)))
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                for (std::size_t i = 0; i < size_and_type.first; ++i)
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!parse_ubjson_internal()))
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+        else
+        {
+            if (JSON_HEDLEY_UNLIKELY(!sax->start_array(static_cast<std::size_t>(-1))))
+            {
+                return false;
+            }
+
+            while (current != ']')
+            {
+                if (JSON_HEDLEY_UNLIKELY(!parse_ubjson_internal(false)))
+                {
+                    return false;
+                }
+                get_ignore_noop();
+            }
+        }
+
+        return sax->end_array();
+    }
+
+    /*!
+    @return whether object creation completed
+    */
+    bool get_ubjson_object()
+    {
+        std::pair<std::size_t, char_int_type> size_and_type;
+        if (JSON_HEDLEY_UNLIKELY(!get_ubjson_size_type(size_and_type)))
+        {
+            return false;
+        }
+
+        // do not accept ND-array size in objects in BJData
+        if (input_format == input_format_t::bjdata && size_and_type.first != npos && (size_and_type.second & (1 << 8)) != 0)
+        {
+            auto last_token = get_token_string();
+            return sax->parse_error(chars_read, last_token, parse_error::create(112, chars_read,
+                                    exception_message(input_format, "BJData object does not support ND-array size in optimized format", "object"), nullptr));
+        }
+
+        string_t key;
+        if (size_and_type.first != npos)
+        {
+            if (JSON_HEDLEY_UNLIKELY(!sax->start_object(size_and_type.first)))
+            {
+                return false;
+            }
+
+            if (size_and_type.second != 0)
+            {
+                for (std::size_t i = 0; i < size_and_type.first; ++i)
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!get_ubjson_string(key) || !sax->key(key)))
+                    {
+                        return false;
+                    }
+                    if (JSON_HEDLEY_UNLIKELY(!get_ubjson_value(size_and_type.second)))
+                    {
+                        return false;
+                    }
+                    key.clear();
+                }
+            }
+            else
+            {
+                for (std::size_t i = 0; i < size_and_type.first; ++i)
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!get_ubjson_string(key) || !sax->key(key)))
+                    {
+                        return false;
+                    }
+                    if (JSON_HEDLEY_UNLIKELY(!parse_ubjson_internal()))
+                    {
+                        return false;
+                    }
+                    key.clear();
+                }
+            }
+        }
+        else
+        {
+            if (JSON_HEDLEY_UNLIKELY(!sax->start_object(static_cast<std::size_t>(-1))))
+            {
+                return false;
+            }
+
+            while (current != '}')
+            {
+                if (JSON_HEDLEY_UNLIKELY(!get_ubjson_string(key, false) || !sax->key(key)))
+                {
+                    return false;
+                }
+                if (JSON_HEDLEY_UNLIKELY(!parse_ubjson_internal()))
+                {
+                    return false;
+                }
+                get_ignore_noop();
+                key.clear();
+            }
+        }
+
+        return sax->end_object();
+    }
+
+    // Note, no reader for UBJSON binary types is implemented because they do
+    // not exist
+
+    bool get_ubjson_high_precision_number()
+    {
+        // get size of following number string
+        std::size_t size{};
+        bool no_ndarray = true;
+        auto res = get_ubjson_size_value(size, no_ndarray);
+        if (JSON_HEDLEY_UNLIKELY(!res))
+        {
+            return res;
+        }
+
+        // get number string
+        std::vector<char> number_vector;
+        for (std::size_t i = 0; i < size; ++i)
+        {
+            get();
+            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(input_format, "number")))
+            {
+                return false;
+            }
+            number_vector.push_back(static_cast<char>(current));
+        }
+
+        // parse number string
+        using ia_type = decltype(detail::input_adapter(number_vector));
+        auto number_lexer = detail::lexer<BasicJsonType, ia_type>(detail::input_adapter(number_vector), false);
+        const auto result_number = number_lexer.scan();
+        const auto number_string = number_lexer.get_token_string();
+        const auto result_remainder = number_lexer.scan();
+
+        using token_type = typename detail::lexer_base<BasicJsonType>::token_type;
+
+        if (JSON_HEDLEY_UNLIKELY(result_remainder != token_type::end_of_input))
+        {
+            return sax->parse_error(chars_read, number_string, parse_error::create(115, chars_read,
+                                    exception_message(input_format, concat("invalid number text: ", number_lexer.get_token_string()), "high-precision number"), nullptr));
+        }
+
+        switch (result_number)
+        {
+            case token_type::value_integer:
+                return sax->number_integer(number_lexer.get_number_integer());
+            case token_type::value_unsigned:
+                return sax->number_unsigned(number_lexer.get_number_unsigned());
+            case token_type::value_float:
+                return sax->number_float(number_lexer.get_number_float(), std::move(number_string));
+            case token_type::uninitialized:
+            case token_type::literal_true:
+            case token_type::literal_false:
+            case token_type::literal_null:
+            case token_type::value_string:
+            case token_type::begin_array:
+            case token_type::begin_object:
+            case token_type::end_array:
+            case token_type::end_object:
+            case token_type::name_separator:
+            case token_type::value_separator:
+            case token_type::parse_error:
+            case token_type::end_of_input:
+            case token_type::literal_or_value:
+            default:
+                return sax->parse_error(chars_read, number_string, parse_error::create(115, chars_read,
+                                        exception_message(input_format, concat("invalid number text: ", number_lexer.get_token_string()), "high-precision number"), nullptr));
+        }
+    }
+
+    ///////////////////////
+    // Utility functions //
+    ///////////////////////
+
+    /*!
+    @brief get next character from the input
+
+    This function provides the interface to the used input adapter. It does
+    not throw in case the input reached EOF, but returns a -'ve valued
+    `char_traits<char_type>::eof()` in that case.
+
+    @return character read from the input
+    */
+    char_int_type get()
+    {
+        ++chars_read;
+        return current = ia.get_character();
+    }
+
+    /*!
+    @return character read from the input after ignoring all 'N' entries
+    */
+    char_int_type get_ignore_noop()
+    {
+        do
+        {
+            get();
+        }
+        while (current == 'N');
+
+        return current;
+    }
+
+    /*
+    @brief read a number from the input
+
+    @tparam NumberType the type of the number
+    @param[in] format   the current format (for diagnostics)
+    @param[out] result  number of type @a NumberType
+
+    @return whether conversion completed
+
+    @note This function needs to respect the system's endianness, because
+          bytes in CBOR, MessagePack, and UBJSON are stored in network order
+          (big endian) and therefore need reordering on little endian systems.
+          On the other hand, BSON and BJData use little endian and should reorder
+          on big endian systems.
+    */
+    template<typename NumberType, bool InputIsLittleEndian = false>
+    bool get_number(const input_format_t format, NumberType& result)
+    {
+        // step 1: read input into array with system's byte order
+        std::array<std::uint8_t, sizeof(NumberType)> vec{};
+        for (std::size_t i = 0; i < sizeof(NumberType); ++i)
+        {
+            get();
+            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "number")))
+            {
+                return false;
+            }
+
+            // reverse byte order prior to conversion if necessary
+            if (is_little_endian != (InputIsLittleEndian || format == input_format_t::bjdata))
+            {
+                vec[sizeof(NumberType) - i - 1] = static_cast<std::uint8_t>(current);
+            }
+            else
+            {
+                vec[i] = static_cast<std::uint8_t>(current); // LCOV_EXCL_LINE
+            }
+        }
+
+        // step 2: convert array into number of type T and return
+        std::memcpy(&result, vec.data(), sizeof(NumberType));
+        return true;
+    }
+
+    /*!
+    @brief create a string by reading characters from the input
+
+    @tparam NumberType the type of the number
+    @param[in] format the current format (for diagnostics)
+    @param[in] len number of characters to read
+    @param[out] result string created by reading @a len bytes
+
+    @return whether string creation completed
+
+    @note We can not reserve @a len bytes for the result, because @a len
+          may be too large. Usually, @ref unexpect_eof() detects the end of
+          the input before we run out of string memory.
+    */
+    template<typename NumberType>
+    bool get_string(const input_format_t format,
+                    const NumberType len,
+                    string_t& result)
+    {
+        bool success = true;
+        for (NumberType i = 0; i < len; i++)
+        {
+            get();
+            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "string")))
+            {
+                success = false;
+                break;
+            }
+            result.push_back(static_cast<typename string_t::value_type>(current));
+        }
+        return success;
+    }
+
+    /*!
+    @brief create a byte array by reading bytes from the input
+
+    @tparam NumberType the type of the number
+    @param[in] format the current format (for diagnostics)
+    @param[in] len number of bytes to read
+    @param[out] result byte array created by reading @a len bytes
+
+    @return whether byte array creation completed
+
+    @note We can not reserve @a len bytes for the result, because @a len
+          may be too large. Usually, @ref unexpect_eof() detects the end of
+          the input before we run out of memory.
+    */
+    template<typename NumberType>
+    bool get_binary(const input_format_t format,
+                    const NumberType len,
+                    binary_t& result)
+    {
+        bool success = true;
+        for (NumberType i = 0; i < len; i++)
+        {
+            get();
+            if (JSON_HEDLEY_UNLIKELY(!unexpect_eof(format, "binary")))
+            {
+                success = false;
+                break;
+            }
+            result.push_back(static_cast<std::uint8_t>(current));
+        }
+        return success;
+    }
+
+    /*!
+    @param[in] format   the current format (for diagnostics)
+    @param[in] context  further context information (for diagnostics)
+    @return whether the last read character is not EOF
+    */
+    JSON_HEDLEY_NON_NULL(3)
+    bool unexpect_eof(const input_format_t format, const char* context) const
+    {
+        if (JSON_HEDLEY_UNLIKELY(current == char_traits<char_type>::eof()))
+        {
+            return sax->parse_error(chars_read, "<end of file>",
+                                    parse_error::create(110, chars_read, exception_message(format, "unexpected end of input", context), nullptr));
+        }
+        return true;
+    }
+
+    /*!
+    @return a string representation of the last read byte
+    */
+    std::string get_token_string() const
+    {
+        std::array<char, 3> cr{{}};
+        static_cast<void>((std::snprintf)(cr.data(), cr.size(), "%.2hhX", static_cast<unsigned char>(current))); // NOLINT(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        return std::string{cr.data()};
+    }
+
+    /*!
+    @param[in] format   the current format
+    @param[in] detail   a detailed error message
+    @param[in] context  further context information
+    @return a message string to use in the parse_error exceptions
+    */
+    std::string exception_message(const input_format_t format,
+                                  const std::string& detail,
+                                  const std::string& context) const
+    {
+        std::string error_msg = "syntax error while parsing ";
+
+        switch (format)
+        {
+            case input_format_t::cbor:
+                error_msg += "CBOR";
+                break;
+
+            case input_format_t::msgpack:
+                error_msg += "MessagePack";
+                break;
+
+            case input_format_t::ubjson:
+                error_msg += "UBJSON";
+                break;
+
+            case input_format_t::bson:
+                error_msg += "BSON";
+                break;
+
+            case input_format_t::bjdata:
+                error_msg += "BJData";
+                break;
+
+            case input_format_t::json: // LCOV_EXCL_LINE
+            default:            // LCOV_EXCL_LINE
+                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+        }
+
+        return concat(error_msg, ' ', context, ": ", detail);
+    }
+
+  private:
+    static JSON_INLINE_VARIABLE constexpr std::size_t npos = static_cast<std::size_t>(-1);
+
+    /// input adapter
+    InputAdapterType ia;
+
+    /// the current character
+    char_int_type current = char_traits<char_type>::eof();
+
+    /// the number of characters read
+    std::size_t chars_read = 0;
+
+    /// whether we can assume little endianness
+    const bool is_little_endian = little_endianness();
+
+    /// input format
+    const input_format_t input_format = input_format_t::json;
+
+    /// the SAX parser
+    json_sax_t* sax = nullptr;
+
+    // excluded markers in bjdata optimized type
+#define JSON_BINARY_READER_MAKE_BJD_OPTIMIZED_TYPE_MARKERS_ \
+    make_array<char_int_type>('F', 'H', 'N', 'S', 'T', 'Z', '[', '{')
+
+#define JSON_BINARY_READER_MAKE_BJD_TYPES_MAP_ \
+    make_array<bjd_type>(                      \
+    bjd_type{'C', "char"},                     \
+    bjd_type{'D', "double"},                   \
+    bjd_type{'I', "int16"},                    \
+    bjd_type{'L', "int64"},                    \
+    bjd_type{'M', "uint64"},                   \
+    bjd_type{'U', "uint8"},                    \
+    bjd_type{'d', "single"},                   \
+    bjd_type{'i', "int8"},                     \
+    bjd_type{'l', "int32"},                    \
+    bjd_type{'m', "uint32"},                   \
+    bjd_type{'u', "uint16"})
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    // lookup tables
+    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+    const decltype(JSON_BINARY_READER_MAKE_BJD_OPTIMIZED_TYPE_MARKERS_) bjd_optimized_type_markers =
+        JSON_BINARY_READER_MAKE_BJD_OPTIMIZED_TYPE_MARKERS_;
+
+    using bjd_type = std::pair<char_int_type, string_t>;
+    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+    const decltype(JSON_BINARY_READER_MAKE_BJD_TYPES_MAP_) bjd_types_map =
+        JSON_BINARY_READER_MAKE_BJD_TYPES_MAP_;
+
+#undef JSON_BINARY_READER_MAKE_BJD_OPTIMIZED_TYPE_MARKERS_
+#undef JSON_BINARY_READER_MAKE_BJD_TYPES_MAP_
+};
+
+#ifndef JSON_HAS_CPP_17
+    template<typename BasicJsonType, typename InputAdapterType, typename SAX>
+    constexpr std::size_t binary_reader<BasicJsonType, InputAdapterType, SAX>::npos;
+#endif
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/input/input_adapters.hpp>
+
+// #include <nlohmann/detail/input/lexer.hpp>
+
+// #include <nlohmann/detail/input/parser.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cmath> // isfinite
+#include <cstdint> // uint8_t
+#include <functional> // function
+#include <string> // string
+#include <utility> // move
+#include <vector> // vector
+
+// #include <nlohmann/detail/exceptions.hpp>
+
+// #include <nlohmann/detail/input/input_adapters.hpp>
+
+// #include <nlohmann/detail/input/json_sax.hpp>
+
+// #include <nlohmann/detail/input/lexer.hpp>
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/is_sax.hpp>
+
+// #include <nlohmann/detail/string_concat.hpp>
+
+// #include <nlohmann/detail/value_t.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+////////////
+// parser //
+////////////
+
+enum class parse_event_t : std::uint8_t
+{
+    /// the parser read `{` and started to process a JSON object
+    object_start,
+    /// the parser read `}` and finished processing a JSON object
+    object_end,
+    /// the parser read `[` and started to process a JSON array
+    array_start,
+    /// the parser read `]` and finished processing a JSON array
+    array_end,
+    /// the parser read a key of a value in an object
+    key,
+    /// the parser finished reading a JSON value
+    value
+};
+
+template<typename BasicJsonType>
+using parser_callback_t =
+    std::function<bool(int /*depth*/, parse_event_t /*event*/, BasicJsonType& /*parsed*/)>;
+
+/*!
+@brief syntax analysis
+
+This class implements a recursive descent parser.
+*/
+template<typename BasicJsonType, typename InputAdapterType>
+class parser
+{
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+    using string_t = typename BasicJsonType::string_t;
+    using lexer_t = lexer<BasicJsonType, InputAdapterType>;
+    using token_type = typename lexer_t::token_type;
+
+  public:
+    /// a parser reading from an input adapter
+    explicit parser(InputAdapterType&& adapter,
+                    const parser_callback_t<BasicJsonType> cb = nullptr,
+                    const bool allow_exceptions_ = true,
+                    const bool skip_comments = false)
+        : callback(cb)
+        , m_lexer(std::move(adapter), skip_comments)
+        , allow_exceptions(allow_exceptions_)
+    {
+        // read first token
+        get_token();
+    }
+
+    /*!
+    @brief public parser interface
+
+    @param[in] strict      whether to expect the last token to be EOF
+    @param[in,out] result  parsed JSON value
+
+    @throw parse_error.101 in case of an unexpected token
+    @throw parse_error.102 if to_unicode fails or surrogate error
+    @throw parse_error.103 if to_unicode fails
+    */
+    void parse(const bool strict, BasicJsonType& result)
+    {
+        if (callback)
+        {
+            json_sax_dom_callback_parser<BasicJsonType> sdp(result, callback, allow_exceptions);
+            sax_parse_internal(&sdp);
+
+            // in strict mode, input must be completely read
+            if (strict && (get_token() != token_type::end_of_input))
+            {
+                sdp.parse_error(m_lexer.get_position(),
+                                m_lexer.get_token_string(),
+                                parse_error::create(101, m_lexer.get_position(),
+                                                    exception_message(token_type::end_of_input, "value"), nullptr));
+            }
+
+            // in case of an error, return discarded value
+            if (sdp.is_errored())
+            {
+                result = value_t::discarded;
+                return;
+            }
+
+            // set top-level value to null if it was discarded by the callback
+            // function
+            if (result.is_discarded())
+            {
+                result = nullptr;
+            }
+        }
+        else
+        {
+            json_sax_dom_parser<BasicJsonType> sdp(result, allow_exceptions);
+            sax_parse_internal(&sdp);
+
+            // in strict mode, input must be completely read
+            if (strict && (get_token() != token_type::end_of_input))
+            {
+                sdp.parse_error(m_lexer.get_position(),
+                                m_lexer.get_token_string(),
+                                parse_error::create(101, m_lexer.get_position(), exception_message(token_type::end_of_input, "value"), nullptr));
+            }
+
+            // in case of an error, return discarded value
+            if (sdp.is_errored())
+            {
+                result = value_t::discarded;
+                return;
+            }
+        }
+
+        result.assert_invariant();
+    }
+
+    /*!
+    @brief public accept interface
+
+    @param[in] strict  whether to expect the last token to be EOF
+    @return whether the input is a proper JSON text
+    */
+    bool accept(const bool strict = true)
+    {
+        json_sax_acceptor<BasicJsonType> sax_acceptor;
+        return sax_parse(&sax_acceptor, strict);
+    }
+
+    template<typename SAX>
+    JSON_HEDLEY_NON_NULL(2)
+    bool sax_parse(SAX* sax, const bool strict = true)
+    {
+        (void)detail::is_sax_static_asserts<SAX, BasicJsonType> {};
+        const bool result = sax_parse_internal(sax);
+
+        // strict mode: next byte must be EOF
+        if (result && strict && (get_token() != token_type::end_of_input))
+        {
+            return sax->parse_error(m_lexer.get_position(),
+                                    m_lexer.get_token_string(),
+                                    parse_error::create(101, m_lexer.get_position(), exception_message(token_type::end_of_input, "value"), nullptr));
+        }
+
+        return result;
+    }
+
+  private:
+    template<typename SAX>
+    JSON_HEDLEY_NON_NULL(2)
+    bool sax_parse_internal(SAX* sax)
+    {
+        // stack to remember the hierarchy of structured values we are parsing
+        // true = array; false = object
+        std::vector<bool> states;
+        // value to avoid a goto (see comment where set to true)
+        bool skip_to_state_evaluation = false;
+
+        while (true)
+        {
+            if (!skip_to_state_evaluation)
+            {
+                // invariant: get_token() was called before each iteration
+                switch (last_token)
+                {
+                    case token_type::begin_object:
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!sax->start_object(static_cast<std::size_t>(-1))))
+                        {
+                            return false;
+                        }
+
+                        // closing } -> we are done
+                        if (get_token() == token_type::end_object)
+                        {
+                            if (JSON_HEDLEY_UNLIKELY(!sax->end_object()))
+                            {
+                                return false;
+                            }
+                            break;
+                        }
+
+                        // parse key
+                        if (JSON_HEDLEY_UNLIKELY(last_token != token_type::value_string))
+                        {
+                            return sax->parse_error(m_lexer.get_position(),
+                                                    m_lexer.get_token_string(),
+                                                    parse_error::create(101, m_lexer.get_position(), exception_message(token_type::value_string, "object key"), nullptr));
+                        }
+                        if (JSON_HEDLEY_UNLIKELY(!sax->key(m_lexer.get_string())))
+                        {
+                            return false;
+                        }
+
+                        // parse separator (:)
+                        if (JSON_HEDLEY_UNLIKELY(get_token() != token_type::name_separator))
+                        {
+                            return sax->parse_error(m_lexer.get_position(),
+                                                    m_lexer.get_token_string(),
+                                                    parse_error::create(101, m_lexer.get_position(), exception_message(token_type::name_separator, "object separator"), nullptr));
+                        }
+
+                        // remember we are now inside an object
+                        states.push_back(false);
+
+                        // parse values
+                        get_token();
+                        continue;
+                    }
+
+                    case token_type::begin_array:
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!sax->start_array(static_cast<std::size_t>(-1))))
+                        {
+                            return false;
+                        }
+
+                        // closing ] -> we are done
+                        if (get_token() == token_type::end_array)
+                        {
+                            if (JSON_HEDLEY_UNLIKELY(!sax->end_array()))
+                            {
+                                return false;
+                            }
+                            break;
+                        }
+
+                        // remember we are now inside an array
+                        states.push_back(true);
+
+                        // parse values (no need to call get_token)
+                        continue;
+                    }
+
+                    case token_type::value_float:
+                    {
+                        const auto res = m_lexer.get_number_float();
+
+                        if (JSON_HEDLEY_UNLIKELY(!std::isfinite(res)))
+                        {
+                            return sax->parse_error(m_lexer.get_position(),
+                                                    m_lexer.get_token_string(),
+                                                    out_of_range::create(406, concat("number overflow parsing '", m_lexer.get_token_string(), '\''), nullptr));
+                        }
+
+                        if (JSON_HEDLEY_UNLIKELY(!sax->number_float(res, m_lexer.get_string())))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    }
+
+                    case token_type::literal_false:
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!sax->boolean(false)))
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+
+                    case token_type::literal_null:
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!sax->null()))
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+
+                    case token_type::literal_true:
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!sax->boolean(true)))
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+
+                    case token_type::value_integer:
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!sax->number_integer(m_lexer.get_number_integer())))
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+
+                    case token_type::value_string:
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!sax->string(m_lexer.get_string())))
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+
+                    case token_type::value_unsigned:
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!sax->number_unsigned(m_lexer.get_number_unsigned())))
+                        {
+                            return false;
+                        }
+                        break;
+                    }
+
+                    case token_type::parse_error:
+                    {
+                        // using "uninitialized" to avoid "expected" message
+                        return sax->parse_error(m_lexer.get_position(),
+                                                m_lexer.get_token_string(),
+                                                parse_error::create(101, m_lexer.get_position(), exception_message(token_type::uninitialized, "value"), nullptr));
+                    }
+                    case token_type::end_of_input:
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(m_lexer.get_position().chars_read_total == 1))
+                        {
+                            return sax->parse_error(m_lexer.get_position(),
+                                                    m_lexer.get_token_string(),
+                                                    parse_error::create(101, m_lexer.get_position(),
+                                                            "attempting to parse an empty input; check that your input string or stream contains the expected JSON", nullptr));
+                        }
+
+                        return sax->parse_error(m_lexer.get_position(),
+                                                m_lexer.get_token_string(),
+                                                parse_error::create(101, m_lexer.get_position(), exception_message(token_type::literal_or_value, "value"), nullptr));
+                    }
+                    case token_type::uninitialized:
+                    case token_type::end_array:
+                    case token_type::end_object:
+                    case token_type::name_separator:
+                    case token_type::value_separator:
+                    case token_type::literal_or_value:
+                    default: // the last token was unexpected
+                    {
+                        return sax->parse_error(m_lexer.get_position(),
+                                                m_lexer.get_token_string(),
+                                                parse_error::create(101, m_lexer.get_position(), exception_message(token_type::literal_or_value, "value"), nullptr));
+                    }
+                }
+            }
+            else
+            {
+                skip_to_state_evaluation = false;
+            }
+
+            // we reached this line after we successfully parsed a value
+            if (states.empty())
+            {
+                // empty stack: we reached the end of the hierarchy: done
+                return true;
+            }
+
+            if (states.back())  // array
+            {
+                // comma -> next value
+                if (get_token() == token_type::value_separator)
+                {
+                    // parse a new value
+                    get_token();
+                    continue;
+                }
+
+                // closing ]
+                if (JSON_HEDLEY_LIKELY(last_token == token_type::end_array))
+                {
+                    if (JSON_HEDLEY_UNLIKELY(!sax->end_array()))
+                    {
+                        return false;
+                    }
+
+                    // We are done with this array. Before we can parse a
+                    // new value, we need to evaluate the new state first.
+                    // By setting skip_to_state_evaluation to false, we
+                    // are effectively jumping to the beginning of this if.
+                    JSON_ASSERT(!states.empty());
+                    states.pop_back();
+                    skip_to_state_evaluation = true;
+                    continue;
+                }
+
+                return sax->parse_error(m_lexer.get_position(),
+                                        m_lexer.get_token_string(),
+                                        parse_error::create(101, m_lexer.get_position(), exception_message(token_type::end_array, "array"), nullptr));
+            }
+
+            // states.back() is false -> object
+
+            // comma -> next value
+            if (get_token() == token_type::value_separator)
+            {
+                // parse key
+                if (JSON_HEDLEY_UNLIKELY(get_token() != token_type::value_string))
+                {
+                    return sax->parse_error(m_lexer.get_position(),
+                                            m_lexer.get_token_string(),
+                                            parse_error::create(101, m_lexer.get_position(), exception_message(token_type::value_string, "object key"), nullptr));
+                }
+
+                if (JSON_HEDLEY_UNLIKELY(!sax->key(m_lexer.get_string())))
+                {
+                    return false;
+                }
+
+                // parse separator (:)
+                if (JSON_HEDLEY_UNLIKELY(get_token() != token_type::name_separator))
+                {
+                    return sax->parse_error(m_lexer.get_position(),
+                                            m_lexer.get_token_string(),
+                                            parse_error::create(101, m_lexer.get_position(), exception_message(token_type::name_separator, "object separator"), nullptr));
+                }
+
+                // parse values
+                get_token();
+                continue;
+            }
+
+            // closing }
+            if (JSON_HEDLEY_LIKELY(last_token == token_type::end_object))
+            {
+                if (JSON_HEDLEY_UNLIKELY(!sax->end_object()))
+                {
+                    return false;
+                }
+
+                // We are done with this object. Before we can parse a
+                // new value, we need to evaluate the new state first.
+                // By setting skip_to_state_evaluation to false, we
+                // are effectively jumping to the beginning of this if.
+                JSON_ASSERT(!states.empty());
+                states.pop_back();
+                skip_to_state_evaluation = true;
+                continue;
+            }
+
+            return sax->parse_error(m_lexer.get_position(),
+                                    m_lexer.get_token_string(),
+                                    parse_error::create(101, m_lexer.get_position(), exception_message(token_type::end_object, "object"), nullptr));
+        }
+    }
+
+    /// get next token from lexer
+    token_type get_token()
+    {
+        return last_token = m_lexer.scan();
+    }
+
+    std::string exception_message(const token_type expected, const std::string& context)
+    {
+        std::string error_msg = "syntax error ";
+
+        if (!context.empty())
+        {
+            error_msg += concat("while parsing ", context, ' ');
+        }
+
+        error_msg += "- ";
+
+        if (last_token == token_type::parse_error)
+        {
+            error_msg += concat(m_lexer.get_error_message(), "; last read: '",
+                                m_lexer.get_token_string(), '\'');
+        }
+        else
+        {
+            error_msg += concat("unexpected ", lexer_t::token_type_name(last_token));
+        }
+
+        if (expected != token_type::uninitialized)
+        {
+            error_msg += concat("; expected ", lexer_t::token_type_name(expected));
+        }
+
+        return error_msg;
+    }
+
+  private:
+    /// callback function
+    const parser_callback_t<BasicJsonType> callback = nullptr;
+    /// the type of the last read token
+    token_type last_token = token_type::uninitialized;
+    /// the lexer
+    lexer_t m_lexer;
+    /// whether to throw exceptions in case of errors
+    const bool allow_exceptions = true;
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/iterators/internal_iterator.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+// #include <nlohmann/detail/iterators/primitive_iterator.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cstddef> // ptrdiff_t
+#include <limits>  // numeric_limits
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+/*
+@brief an iterator for primitive JSON types
+
+This class models an iterator for primitive JSON types (boolean, number,
+string). It's only purpose is to allow the iterator/const_iterator classes
+to "iterate" over primitive values. Internally, the iterator is modeled by
+a `difference_type` variable. Value begin_value (`0`) models the begin,
+end_value (`1`) models past the end.
+*/
+class primitive_iterator_t
+{
+  private:
+    using difference_type = std::ptrdiff_t;
+    static constexpr difference_type begin_value = 0;
+    static constexpr difference_type end_value = begin_value + 1;
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    /// iterator as signed integer type
+    difference_type m_it = (std::numeric_limits<std::ptrdiff_t>::min)();
+
+  public:
+    constexpr difference_type get_value() const noexcept
+    {
+        return m_it;
+    }
+
+    /// set iterator to a defined beginning
+    void set_begin() noexcept
+    {
+        m_it = begin_value;
+    }
+
+    /// set iterator to a defined past the end
+    void set_end() noexcept
+    {
+        m_it = end_value;
+    }
+
+    /// return whether the iterator can be dereferenced
+    constexpr bool is_begin() const noexcept
+    {
+        return m_it == begin_value;
+    }
+
+    /// return whether the iterator is at end
+    constexpr bool is_end() const noexcept
+    {
+        return m_it == end_value;
+    }
+
+    friend constexpr bool operator==(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
+    {
+        return lhs.m_it == rhs.m_it;
+    }
+
+    friend constexpr bool operator<(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
+    {
+        return lhs.m_it < rhs.m_it;
+    }
+
+    primitive_iterator_t operator+(difference_type n) noexcept
+    {
+        auto result = *this;
+        result += n;
+        return result;
+    }
+
+    friend constexpr difference_type operator-(primitive_iterator_t lhs, primitive_iterator_t rhs) noexcept
+    {
+        return lhs.m_it - rhs.m_it;
+    }
+
+    primitive_iterator_t& operator++() noexcept
+    {
+        ++m_it;
+        return *this;
+    }
+
+    primitive_iterator_t operator++(int)& noexcept // NOLINT(cert-dcl21-cpp)
+    {
+        auto result = *this;
+        ++m_it;
+        return result;
+    }
+
+    primitive_iterator_t& operator--() noexcept
+    {
+        --m_it;
+        return *this;
+    }
+
+    primitive_iterator_t operator--(int)& noexcept // NOLINT(cert-dcl21-cpp)
+    {
+        auto result = *this;
+        --m_it;
+        return result;
+    }
+
+    primitive_iterator_t& operator+=(difference_type n) noexcept
+    {
+        m_it += n;
+        return *this;
+    }
+
+    primitive_iterator_t& operator-=(difference_type n) noexcept
+    {
+        m_it -= n;
+        return *this;
+    }
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+/*!
+@brief an iterator value
+
+@note This structure could easily be a union, but MSVC currently does not allow
+unions members with complex constructors, see https://github.com/nlohmann/json/pull/105.
+*/
+template<typename BasicJsonType> struct internal_iterator
+{
+    /// iterator for JSON objects
+    typename BasicJsonType::object_t::iterator object_iterator {};
+    /// iterator for JSON arrays
+    typename BasicJsonType::array_t::iterator array_iterator {};
+    /// generic iterator for all other types
+    primitive_iterator_t primitive_iterator {};
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/iterators/iter_impl.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <iterator> // iterator, random_access_iterator_tag, bidirectional_iterator_tag, advance, next
+#include <type_traits> // conditional, is_const, remove_const
+
+// #include <nlohmann/detail/exceptions.hpp>
+
+// #include <nlohmann/detail/iterators/internal_iterator.hpp>
+
+// #include <nlohmann/detail/iterators/primitive_iterator.hpp>
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/cpp_future.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+// #include <nlohmann/detail/value_t.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+// forward declare, to be able to friend it later on
+template<typename IteratorType> class iteration_proxy;
+template<typename IteratorType> class iteration_proxy_value;
+
+/*!
+@brief a template for a bidirectional iterator for the @ref basic_json class
+This class implements a both iterators (iterator and const_iterator) for the
+@ref basic_json class.
+@note An iterator is called *initialized* when a pointer to a JSON value has
+      been set (e.g., by a constructor or a copy assignment). If the iterator is
+      default-constructed, it is *uninitialized* and most methods are undefined.
+      **The library uses assertions to detect calls on uninitialized iterators.**
+@requirement The class satisfies the following concept requirements:
+-
+[BidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator):
+  The iterator that can be moved can be moved in both directions (i.e.
+  incremented and decremented).
+@since version 1.0.0, simplified in version 2.0.9, change to bidirectional
+       iterators in version 3.0.0 (see https://github.com/nlohmann/json/issues/593)
+*/
+template<typename BasicJsonType>
+class iter_impl // NOLINT(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)
+{
+    /// the iterator with BasicJsonType of different const-ness
+    using other_iter_impl = iter_impl<typename std::conditional<std::is_const<BasicJsonType>::value, typename std::remove_const<BasicJsonType>::type, const BasicJsonType>::type>;
+    /// allow basic_json to access private members
+    friend other_iter_impl;
+    friend BasicJsonType;
+    friend iteration_proxy<iter_impl>;
+    friend iteration_proxy_value<iter_impl>;
+
+    using object_t = typename BasicJsonType::object_t;
+    using array_t = typename BasicJsonType::array_t;
+    // make sure BasicJsonType is basic_json or const basic_json
+    static_assert(is_basic_json<typename std::remove_const<BasicJsonType>::type>::value,
+                  "iter_impl only accepts (const) basic_json");
+    // superficial check for the LegacyBidirectionalIterator named requirement
+    static_assert(std::is_base_of<std::bidirectional_iterator_tag, std::bidirectional_iterator_tag>::value
+                  &&  std::is_base_of<std::bidirectional_iterator_tag, typename std::iterator_traits<typename array_t::iterator>::iterator_category>::value,
+                  "basic_json iterator assumes array and object type iterators satisfy the LegacyBidirectionalIterator named requirement.");
+
+  public:
+    /// The std::iterator class template (used as a base class to provide typedefs) is deprecated in C++17.
+    /// The C++ Standard has never required user-defined iterators to derive from std::iterator.
+    /// A user-defined iterator should provide publicly accessible typedefs named
+    /// iterator_category, value_type, difference_type, pointer, and reference.
+    /// Note that value_type is required to be non-const, even for constant iterators.
+    using iterator_category = std::bidirectional_iterator_tag;
+
+    /// the type of the values when the iterator is dereferenced
+    using value_type = typename BasicJsonType::value_type;
+    /// a type to represent differences between iterators
+    using difference_type = typename BasicJsonType::difference_type;
+    /// defines a pointer to the type iterated over (value_type)
+    using pointer = typename std::conditional<std::is_const<BasicJsonType>::value,
+          typename BasicJsonType::const_pointer,
+          typename BasicJsonType::pointer>::type;
+    /// defines a reference to the type iterated over (value_type)
+    using reference =
+        typename std::conditional<std::is_const<BasicJsonType>::value,
+        typename BasicJsonType::const_reference,
+        typename BasicJsonType::reference>::type;
+
+    iter_impl() = default;
+    ~iter_impl() = default;
+    iter_impl(iter_impl&&) noexcept = default;
+    iter_impl& operator=(iter_impl&&) noexcept = default;
+
+    /*!
+    @brief constructor for a given JSON instance
+    @param[in] object  pointer to a JSON object for this iterator
+    @pre object != nullptr
+    @post The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    explicit iter_impl(pointer object) noexcept : m_object(object)
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+            {
+                m_it.object_iterator = typename object_t::iterator();
+                break;
+            }
+
+            case value_t::array:
+            {
+                m_it.array_iterator = typename array_t::iterator();
+                break;
+            }
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                m_it.primitive_iterator = primitive_iterator_t();
+                break;
+            }
+        }
+    }
+
+    /*!
+    @note The conventional copy constructor and copy assignment are implicitly
+          defined. Combined with the following converting constructor and
+          assignment, they support: (1) copy from iterator to iterator, (2)
+          copy from const iterator to const iterator, and (3) conversion from
+          iterator to const iterator. However conversion from const iterator
+          to iterator is not defined.
+    */
+
+    /*!
+    @brief const copy constructor
+    @param[in] other const iterator to copy from
+    @note This copy constructor had to be defined explicitly to circumvent a bug
+          occurring on msvc v19.0 compiler (VS 2015) debug build. For more
+          information refer to: https://github.com/nlohmann/json/issues/1608
+    */
+    iter_impl(const iter_impl<const BasicJsonType>& other) noexcept
+        : m_object(other.m_object), m_it(other.m_it)
+    {}
+
+    /*!
+    @brief converting assignment
+    @param[in] other const iterator to copy from
+    @return const/non-const iterator
+    @note It is not checked whether @a other is initialized.
+    */
+    iter_impl& operator=(const iter_impl<const BasicJsonType>& other) noexcept
+    {
+        if (&other != this)
+        {
+            m_object = other.m_object;
+            m_it = other.m_it;
+        }
+        return *this;
+    }
+
+    /*!
+    @brief converting constructor
+    @param[in] other  non-const iterator to copy from
+    @note It is not checked whether @a other is initialized.
+    */
+    iter_impl(const iter_impl<typename std::remove_const<BasicJsonType>::type>& other) noexcept
+        : m_object(other.m_object), m_it(other.m_it)
+    {}
+
+    /*!
+    @brief converting assignment
+    @param[in] other  non-const iterator to copy from
+    @return const/non-const iterator
+    @note It is not checked whether @a other is initialized.
+    */
+    iter_impl& operator=(const iter_impl<typename std::remove_const<BasicJsonType>::type>& other) noexcept // NOLINT(cert-oop54-cpp)
+    {
+        m_object = other.m_object;
+        m_it = other.m_it;
+        return *this;
+    }
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    /*!
+    @brief set the iterator to the first value
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    void set_begin() noexcept
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+            {
+                m_it.object_iterator = m_object->m_data.m_value.object->begin();
+                break;
+            }
+
+            case value_t::array:
+            {
+                m_it.array_iterator = m_object->m_data.m_value.array->begin();
+                break;
+            }
+
+            case value_t::null:
+            {
+                // set to end so begin()==end() is true: null is empty
+                m_it.primitive_iterator.set_end();
+                break;
+            }
+
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                m_it.primitive_iterator.set_begin();
+                break;
+            }
+        }
+    }
+
+    /*!
+    @brief set the iterator past the last value
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    void set_end() noexcept
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+            {
+                m_it.object_iterator = m_object->m_data.m_value.object->end();
+                break;
+            }
+
+            case value_t::array:
+            {
+                m_it.array_iterator = m_object->m_data.m_value.array->end();
+                break;
+            }
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                m_it.primitive_iterator.set_end();
+                break;
+            }
+        }
+    }
+
+  public:
+    /*!
+    @brief return a reference to the value pointed to by the iterator
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    reference operator*() const
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+            {
+                JSON_ASSERT(m_it.object_iterator != m_object->m_data.m_value.object->end());
+                return m_it.object_iterator->second;
+            }
+
+            case value_t::array:
+            {
+                JSON_ASSERT(m_it.array_iterator != m_object->m_data.m_value.array->end());
+                return *m_it.array_iterator;
+            }
+
+            case value_t::null:
+                JSON_THROW(invalid_iterator::create(214, "cannot get value", m_object));
+
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                if (JSON_HEDLEY_LIKELY(m_it.primitive_iterator.is_begin()))
+                {
+                    return *m_object;
+                }
+
+                JSON_THROW(invalid_iterator::create(214, "cannot get value", m_object));
+            }
+        }
+    }
+
+    /*!
+    @brief dereference the iterator
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    pointer operator->() const
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+            {
+                JSON_ASSERT(m_it.object_iterator != m_object->m_data.m_value.object->end());
+                return &(m_it.object_iterator->second);
+            }
+
+            case value_t::array:
+            {
+                JSON_ASSERT(m_it.array_iterator != m_object->m_data.m_value.array->end());
+                return &*m_it.array_iterator;
+            }
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                if (JSON_HEDLEY_LIKELY(m_it.primitive_iterator.is_begin()))
+                {
+                    return m_object;
+                }
+
+                JSON_THROW(invalid_iterator::create(214, "cannot get value", m_object));
+            }
+        }
+    }
+
+    /*!
+    @brief post-increment (it++)
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    iter_impl operator++(int)& // NOLINT(cert-dcl21-cpp)
+    {
+        auto result = *this;
+        ++(*this);
+        return result;
+    }
+
+    /*!
+    @brief pre-increment (++it)
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    iter_impl& operator++()
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+            {
+                std::advance(m_it.object_iterator, 1);
+                break;
+            }
+
+            case value_t::array:
+            {
+                std::advance(m_it.array_iterator, 1);
+                break;
+            }
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                ++m_it.primitive_iterator;
+                break;
+            }
+        }
+
+        return *this;
+    }
+
+    /*!
+    @brief post-decrement (it--)
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    iter_impl operator--(int)& // NOLINT(cert-dcl21-cpp)
+    {
+        auto result = *this;
+        --(*this);
+        return result;
+    }
+
+    /*!
+    @brief pre-decrement (--it)
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    iter_impl& operator--()
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+            {
+                std::advance(m_it.object_iterator, -1);
+                break;
+            }
+
+            case value_t::array:
+            {
+                std::advance(m_it.array_iterator, -1);
+                break;
+            }
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                --m_it.primitive_iterator;
+                break;
+            }
+        }
+
+        return *this;
+    }
+
+    /*!
+    @brief comparison: equal
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    template < typename IterImpl, detail::enable_if_t < (std::is_same<IterImpl, iter_impl>::value || std::is_same<IterImpl, other_iter_impl>::value), std::nullptr_t > = nullptr >
+    bool operator==(const IterImpl& other) const
+    {
+        // if objects are not the same, the comparison is undefined
+        if (JSON_HEDLEY_UNLIKELY(m_object != other.m_object))
+        {
+            JSON_THROW(invalid_iterator::create(212, "cannot compare iterators of different containers", m_object));
+        }
+
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+                return (m_it.object_iterator == other.m_it.object_iterator);
+
+            case value_t::array:
+                return (m_it.array_iterator == other.m_it.array_iterator);
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+                return (m_it.primitive_iterator == other.m_it.primitive_iterator);
+        }
+    }
+
+    /*!
+    @brief comparison: not equal
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    template < typename IterImpl, detail::enable_if_t < (std::is_same<IterImpl, iter_impl>::value || std::is_same<IterImpl, other_iter_impl>::value), std::nullptr_t > = nullptr >
+    bool operator!=(const IterImpl& other) const
+    {
+        return !operator==(other);
+    }
+
+    /*!
+    @brief comparison: smaller
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    bool operator<(const iter_impl& other) const
+    {
+        // if objects are not the same, the comparison is undefined
+        if (JSON_HEDLEY_UNLIKELY(m_object != other.m_object))
+        {
+            JSON_THROW(invalid_iterator::create(212, "cannot compare iterators of different containers", m_object));
+        }
+
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+                JSON_THROW(invalid_iterator::create(213, "cannot compare order of object iterators", m_object));
+
+            case value_t::array:
+                return (m_it.array_iterator < other.m_it.array_iterator);
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+                return (m_it.primitive_iterator < other.m_it.primitive_iterator);
+        }
+    }
+
+    /*!
+    @brief comparison: less than or equal
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    bool operator<=(const iter_impl& other) const
+    {
+        return !other.operator < (*this);
+    }
+
+    /*!
+    @brief comparison: greater than
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    bool operator>(const iter_impl& other) const
+    {
+        return !operator<=(other);
+    }
+
+    /*!
+    @brief comparison: greater than or equal
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    bool operator>=(const iter_impl& other) const
+    {
+        return !operator<(other);
+    }
+
+    /*!
+    @brief add to iterator
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    iter_impl& operator+=(difference_type i)
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+                JSON_THROW(invalid_iterator::create(209, "cannot use offsets with object iterators", m_object));
+
+            case value_t::array:
+            {
+                std::advance(m_it.array_iterator, i);
+                break;
+            }
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                m_it.primitive_iterator += i;
+                break;
+            }
+        }
+
+        return *this;
+    }
+
+    /*!
+    @brief subtract from iterator
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    iter_impl& operator-=(difference_type i)
+    {
+        return operator+=(-i);
+    }
+
+    /*!
+    @brief add to iterator
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    iter_impl operator+(difference_type i) const
+    {
+        auto result = *this;
+        result += i;
+        return result;
+    }
+
+    /*!
+    @brief addition of distance and iterator
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    friend iter_impl operator+(difference_type i, const iter_impl& it)
+    {
+        auto result = it;
+        result += i;
+        return result;
+    }
+
+    /*!
+    @brief subtract from iterator
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    iter_impl operator-(difference_type i) const
+    {
+        auto result = *this;
+        result -= i;
+        return result;
+    }
+
+    /*!
+    @brief return difference
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    difference_type operator-(const iter_impl& other) const
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+                JSON_THROW(invalid_iterator::create(209, "cannot use offsets with object iterators", m_object));
+
+            case value_t::array:
+                return m_it.array_iterator - other.m_it.array_iterator;
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+                return m_it.primitive_iterator - other.m_it.primitive_iterator;
+        }
+    }
+
+    /*!
+    @brief access to successor
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    reference operator[](difference_type n) const
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        switch (m_object->m_data.m_type)
+        {
+            case value_t::object:
+                JSON_THROW(invalid_iterator::create(208, "cannot use operator[] for object iterators", m_object));
+
+            case value_t::array:
+                return *std::next(m_it.array_iterator, n);
+
+            case value_t::null:
+                JSON_THROW(invalid_iterator::create(214, "cannot get value", m_object));
+
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                if (JSON_HEDLEY_LIKELY(m_it.primitive_iterator.get_value() == -n))
+                {
+                    return *m_object;
+                }
+
+                JSON_THROW(invalid_iterator::create(214, "cannot get value", m_object));
+            }
+        }
+    }
+
+    /*!
+    @brief return the key of an object iterator
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    const typename object_t::key_type& key() const
+    {
+        JSON_ASSERT(m_object != nullptr);
+
+        if (JSON_HEDLEY_LIKELY(m_object->is_object()))
+        {
+            return m_it.object_iterator->first;
+        }
+
+        JSON_THROW(invalid_iterator::create(207, "cannot use key() for non-object iterators", m_object));
+    }
+
+    /*!
+    @brief return the value of an iterator
+    @pre The iterator is initialized; i.e. `m_object != nullptr`.
+    */
+    reference value() const
+    {
+        return operator*();
+    }
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    /// associated JSON instance
+    pointer m_object = nullptr;
+    /// the actual iterator of the associated instance
+    internal_iterator<typename std::remove_const<BasicJsonType>::type> m_it {};
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/iterators/iteration_proxy.hpp>
+
+// #include <nlohmann/detail/iterators/json_reverse_iterator.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <cstddef> // ptrdiff_t
+#include <iterator> // reverse_iterator
+#include <utility> // declval
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+//////////////////////
+// reverse_iterator //
+//////////////////////
+
+/*!
+@brief a template for a reverse iterator class
+
+@tparam Base the base iterator type to reverse. Valid types are @ref
+iterator (to create @ref reverse_iterator) and @ref const_iterator (to
+create @ref const_reverse_iterator).
+
+@requirement The class satisfies the following concept requirements:
+-
+[BidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator):
+  The iterator that can be moved can be moved in both directions (i.e.
+  incremented and decremented).
+- [OutputIterator](https://en.cppreference.com/w/cpp/named_req/OutputIterator):
+  It is possible to write to the pointed-to element (only if @a Base is
+  @ref iterator).
+
+@since version 1.0.0
+*/
+template<typename Base>
+class json_reverse_iterator : public std::reverse_iterator<Base>
+{
+  public:
+    using difference_type = std::ptrdiff_t;
+    /// shortcut to the reverse iterator adapter
+    using base_iterator = std::reverse_iterator<Base>;
+    /// the reference type for the pointed-to element
+    using reference = typename Base::reference;
+
+    /// create reverse iterator from iterator
+    explicit json_reverse_iterator(const typename base_iterator::iterator_type& it) noexcept
+        : base_iterator(it) {}
+
+    /// create reverse iterator from base class
+    explicit json_reverse_iterator(const base_iterator& it) noexcept : base_iterator(it) {}
+
+    /// post-increment (it++)
+    json_reverse_iterator operator++(int)& // NOLINT(cert-dcl21-cpp)
+    {
+        return static_cast<json_reverse_iterator>(base_iterator::operator++(1));
+    }
+
+    /// pre-increment (++it)
+    json_reverse_iterator& operator++()
+    {
+        return static_cast<json_reverse_iterator&>(base_iterator::operator++());
+    }
+
+    /// post-decrement (it--)
+    json_reverse_iterator operator--(int)& // NOLINT(cert-dcl21-cpp)
+    {
+        return static_cast<json_reverse_iterator>(base_iterator::operator--(1));
+    }
+
+    /// pre-decrement (--it)
+    json_reverse_iterator& operator--()
+    {
+        return static_cast<json_reverse_iterator&>(base_iterator::operator--());
+    }
+
+    /// add to iterator
+    json_reverse_iterator& operator+=(difference_type i)
+    {
+        return static_cast<json_reverse_iterator&>(base_iterator::operator+=(i));
+    }
+
+    /// add to iterator
+    json_reverse_iterator operator+(difference_type i) const
+    {
+        return static_cast<json_reverse_iterator>(base_iterator::operator+(i));
+    }
+
+    /// subtract from iterator
+    json_reverse_iterator operator-(difference_type i) const
+    {
+        return static_cast<json_reverse_iterator>(base_iterator::operator-(i));
+    }
+
+    /// return difference
+    difference_type operator-(const json_reverse_iterator& other) const
+    {
+        return base_iterator(*this) - base_iterator(other);
+    }
+
+    /// access to successor
+    reference operator[](difference_type n) const
+    {
+        return *(this->operator+(n));
+    }
+
+    /// return the key of an object iterator
+    auto key() const -> decltype(std::declval<Base>().key())
+    {
+        auto it = --this->base();
+        return it.key();
+    }
+
+    /// return the value of an iterator
+    reference value() const
+    {
+        auto it = --this->base();
+        return it.operator * ();
+    }
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/iterators/primitive_iterator.hpp>
+
+// #include <nlohmann/detail/json_custom_base_class.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <type_traits> // conditional, is_same
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+/*!
+@brief Default base class of the @ref basic_json class.
+
+So that the correct implementations of the copy / move ctors / assign operators
+of @ref basic_json do not require complex case distinctions
+(no base class / custom base class used as customization point),
+@ref basic_json always has a base class.
+By default, this class is used because it is empty and thus has no effect
+on the behavior of @ref basic_json.
+*/
+struct json_default_base {};
+
+template<class T>
+using json_base_class = typename std::conditional <
+                        std::is_same<T, void>::value,
+                        json_default_base,
+                        T
+                        >::type;
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/json_pointer.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <algorithm> // all_of
+#include <cctype> // isdigit
+#include <cerrno> // errno, ERANGE
+#include <cstdlib> // strtoull
+#ifndef JSON_NO_IO
+    #include <iosfwd> // ostream
+#endif  // JSON_NO_IO
+#include <limits> // max
+#include <numeric> // accumulate
+#include <string> // string
+#include <utility> // move
+#include <vector> // vector
+
+// #include <nlohmann/detail/exceptions.hpp>
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/string_concat.hpp>
+
+// #include <nlohmann/detail/string_escape.hpp>
+
+// #include <nlohmann/detail/value_t.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+
+/// @brief JSON Pointer defines a string syntax for identifying a specific value within a JSON document
+/// @sa https://json.nlohmann.me/api/json_pointer/
+template<typename RefStringType>
+class json_pointer
+{
+    // allow basic_json to access private members
+    NLOHMANN_BASIC_JSON_TPL_DECLARATION
+    friend class basic_json;
+
+    template<typename>
+    friend class json_pointer;
+
+    template<typename T>
+    struct string_t_helper
+    {
+        using type = T;
+    };
+
+    NLOHMANN_BASIC_JSON_TPL_DECLARATION
+    struct string_t_helper<NLOHMANN_BASIC_JSON_TPL>
+    {
+        using type = StringType;
+    };
+
+  public:
+    // for backwards compatibility accept BasicJsonType
+    using string_t = typename string_t_helper<RefStringType>::type;
+
+    /// @brief create JSON pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/json_pointer/
+    explicit json_pointer(const string_t& s = "")
+        : reference_tokens(split(s))
+    {}
+
+    /// @brief return a string representation of the JSON pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/to_string/
+    string_t to_string() const
+    {
+        return std::accumulate(reference_tokens.begin(), reference_tokens.end(),
+                               string_t{},
+                               [](const string_t& a, const string_t& b)
+        {
+            return detail::concat(a, '/', detail::escape(b));
+        });
+    }
+
+    /// @brief return a string representation of the JSON pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_string/
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.0, to_string())
+    operator string_t() const
+    {
+        return to_string();
+    }
+
+#ifndef JSON_NO_IO
+    /// @brief write string representation of the JSON pointer to stream
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ltlt/
+    friend std::ostream& operator<<(std::ostream& o, const json_pointer& ptr)
+    {
+        o << ptr.to_string();
+        return o;
+    }
+#endif
+
+    /// @brief append another JSON pointer at the end of this JSON pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_slasheq/
+    json_pointer& operator/=(const json_pointer& ptr)
+    {
+        reference_tokens.insert(reference_tokens.end(),
+                                ptr.reference_tokens.begin(),
+                                ptr.reference_tokens.end());
+        return *this;
+    }
+
+    /// @brief append an unescaped reference token at the end of this JSON pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_slasheq/
+    json_pointer& operator/=(string_t token)
+    {
+        push_back(std::move(token));
+        return *this;
+    }
+
+    /// @brief append an array index at the end of this JSON pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_slasheq/
+    json_pointer& operator/=(std::size_t array_idx)
+    {
+        return *this /= std::to_string(array_idx);
+    }
+
+    /// @brief create a new JSON pointer by appending the right JSON pointer at the end of the left JSON pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_slash/
+    friend json_pointer operator/(const json_pointer& lhs,
+                                  const json_pointer& rhs)
+    {
+        return json_pointer(lhs) /= rhs;
+    }
+
+    /// @brief create a new JSON pointer by appending the unescaped token at the end of the JSON pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_slash/
+    friend json_pointer operator/(const json_pointer& lhs, string_t token) // NOLINT(performance-unnecessary-value-param)
+    {
+        return json_pointer(lhs) /= std::move(token);
+    }
+
+    /// @brief create a new JSON pointer by appending the array-index-token at the end of the JSON pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_slash/
+    friend json_pointer operator/(const json_pointer& lhs, std::size_t array_idx)
+    {
+        return json_pointer(lhs) /= array_idx;
+    }
+
+    /// @brief returns the parent of this JSON pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/parent_pointer/
+    json_pointer parent_pointer() const
+    {
+        if (empty())
+        {
+            return *this;
+        }
+
+        json_pointer res = *this;
+        res.pop_back();
+        return res;
+    }
+
+    /// @brief remove last reference token
+    /// @sa https://json.nlohmann.me/api/json_pointer/pop_back/
+    void pop_back()
+    {
+        if (JSON_HEDLEY_UNLIKELY(empty()))
+        {
+            JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent", nullptr));
+        }
+
+        reference_tokens.pop_back();
+    }
+
+    /// @brief return last reference token
+    /// @sa https://json.nlohmann.me/api/json_pointer/back/
+    const string_t& back() const
+    {
+        if (JSON_HEDLEY_UNLIKELY(empty()))
+        {
+            JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent", nullptr));
+        }
+
+        return reference_tokens.back();
+    }
+
+    /// @brief append an unescaped token at the end of the reference pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/push_back/
+    void push_back(const string_t& token)
+    {
+        reference_tokens.push_back(token);
+    }
+
+    /// @brief append an unescaped token at the end of the reference pointer
+    /// @sa https://json.nlohmann.me/api/json_pointer/push_back/
+    void push_back(string_t&& token)
+    {
+        reference_tokens.push_back(std::move(token));
+    }
+
+    /// @brief return whether pointer points to the root document
+    /// @sa https://json.nlohmann.me/api/json_pointer/empty/
+    bool empty() const noexcept
+    {
+        return reference_tokens.empty();
+    }
+
+  private:
+    /*!
+    @param[in] s  reference token to be converted into an array index
+
+    @return integer representation of @a s
+
+    @throw parse_error.106  if an array index begins with '0'
+    @throw parse_error.109  if an array index begins not with a digit
+    @throw out_of_range.404 if string @a s could not be converted to an integer
+    @throw out_of_range.410 if an array index exceeds size_type
+    */
+    template<typename BasicJsonType>
+    static typename BasicJsonType::size_type array_index(const string_t& s)
+    {
+        using size_type = typename BasicJsonType::size_type;
+
+        // error condition (cf. RFC 6901, Sect. 4)
+        if (JSON_HEDLEY_UNLIKELY(s.size() > 1 && s[0] == '0'))
+        {
+            JSON_THROW(detail::parse_error::create(106, 0, detail::concat("array index '", s, "' must not begin with '0'"), nullptr));
+        }
+
+        // error condition (cf. RFC 6901, Sect. 4)
+        if (JSON_HEDLEY_UNLIKELY(s.size() > 1 && !(s[0] >= '1' && s[0] <= '9')))
+        {
+            JSON_THROW(detail::parse_error::create(109, 0, detail::concat("array index '", s, "' is not a number"), nullptr));
+        }
+
+        const char* p = s.c_str();
+        char* p_end = nullptr;
+        errno = 0; // strtoull doesn't reset errno
+        const unsigned long long res = std::strtoull(p, &p_end, 10); // NOLINT(runtime/int)
+        if (p == p_end // invalid input or empty string
+                || errno == ERANGE // out of range
+                || JSON_HEDLEY_UNLIKELY(static_cast<std::size_t>(p_end - p) != s.size())) // incomplete read
+        {
+            JSON_THROW(detail::out_of_range::create(404, detail::concat("unresolved reference token '", s, "'"), nullptr));
+        }
+
+        // only triggered on special platforms (like 32bit), see also
+        // https://github.com/nlohmann/json/pull/2203
+        if (res >= static_cast<unsigned long long>((std::numeric_limits<size_type>::max)()))  // NOLINT(runtime/int)
+        {
+            JSON_THROW(detail::out_of_range::create(410, detail::concat("array index ", s, " exceeds size_type"), nullptr));   // LCOV_EXCL_LINE
+        }
+
+        return static_cast<size_type>(res);
+    }
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    json_pointer top() const
+    {
+        if (JSON_HEDLEY_UNLIKELY(empty()))
+        {
+            JSON_THROW(detail::out_of_range::create(405, "JSON pointer has no parent", nullptr));
+        }
+
+        json_pointer result = *this;
+        result.reference_tokens = {reference_tokens[0]};
+        return result;
+    }
+
+  private:
+    /*!
+    @brief create and return a reference to the pointed to value
+
+    @complexity Linear in the number of reference tokens.
+
+    @throw parse_error.109 if array index is not a number
+    @throw type_error.313 if value cannot be unflattened
+    */
+    template<typename BasicJsonType>
+    BasicJsonType& get_and_create(BasicJsonType& j) const
+    {
+        auto* result = &j;
+
+        // in case no reference tokens exist, return a reference to the JSON value
+        // j which will be overwritten by a primitive value
+        for (const auto& reference_token : reference_tokens)
+        {
+            switch (result->type())
+            {
+                case detail::value_t::null:
+                {
+                    if (reference_token == "0")
+                    {
+                        // start a new array if reference token is 0
+                        result = &result->operator[](0);
+                    }
+                    else
+                    {
+                        // start a new object otherwise
+                        result = &result->operator[](reference_token);
+                    }
+                    break;
+                }
+
+                case detail::value_t::object:
+                {
+                    // create an entry in the object
+                    result = &result->operator[](reference_token);
+                    break;
+                }
+
+                case detail::value_t::array:
+                {
+                    // create an entry in the array
+                    result = &result->operator[](array_index<BasicJsonType>(reference_token));
+                    break;
+                }
+
+                /*
+                The following code is only reached if there exists a reference
+                token _and_ the current value is primitive. In this case, we have
+                an error situation, because primitive values may only occur as
+                single value; that is, with an empty list of reference tokens.
+                */
+                case detail::value_t::string:
+                case detail::value_t::boolean:
+                case detail::value_t::number_integer:
+                case detail::value_t::number_unsigned:
+                case detail::value_t::number_float:
+                case detail::value_t::binary:
+                case detail::value_t::discarded:
+                default:
+                    JSON_THROW(detail::type_error::create(313, "invalid value to unflatten", &j));
+            }
+        }
+
+        return *result;
+    }
+
+    /*!
+    @brief return a reference to the pointed to value
+
+    @note This version does not throw if a value is not present, but tries to
+          create nested values instead. For instance, calling this function
+          with pointer `"/this/that"` on a null value is equivalent to calling
+          `operator[]("this").operator[]("that")` on that value, effectively
+          changing the null value to an object.
+
+    @param[in] ptr  a JSON value
+
+    @return reference to the JSON value pointed to by the JSON pointer
+
+    @complexity Linear in the length of the JSON pointer.
+
+    @throw parse_error.106   if an array index begins with '0'
+    @throw parse_error.109   if an array index was not a number
+    @throw out_of_range.404  if the JSON pointer can not be resolved
+    */
+    template<typename BasicJsonType>
+    BasicJsonType& get_unchecked(BasicJsonType* ptr) const
+    {
+        for (const auto& reference_token : reference_tokens)
+        {
+            // convert null values to arrays or objects before continuing
+            if (ptr->is_null())
+            {
+                // check if reference token is a number
+                const bool nums =
+                    std::all_of(reference_token.begin(), reference_token.end(),
+                                [](const unsigned char x)
+                {
+                    return std::isdigit(x);
+                });
+
+                // change value to array for numbers or "-" or to object otherwise
+                *ptr = (nums || reference_token == "-")
+                       ? detail::value_t::array
+                       : detail::value_t::object;
+            }
+
+            switch (ptr->type())
+            {
+                case detail::value_t::object:
+                {
+                    // use unchecked object access
+                    ptr = &ptr->operator[](reference_token);
+                    break;
+                }
+
+                case detail::value_t::array:
+                {
+                    if (reference_token == "-")
+                    {
+                        // explicitly treat "-" as index beyond the end
+                        ptr = &ptr->operator[](ptr->m_data.m_value.array->size());
+                    }
+                    else
+                    {
+                        // convert array index to number; unchecked access
+                        ptr = &ptr->operator[](array_index<BasicJsonType>(reference_token));
+                    }
+                    break;
+                }
+
+                case detail::value_t::null:
+                case detail::value_t::string:
+                case detail::value_t::boolean:
+                case detail::value_t::number_integer:
+                case detail::value_t::number_unsigned:
+                case detail::value_t::number_float:
+                case detail::value_t::binary:
+                case detail::value_t::discarded:
+                default:
+                    JSON_THROW(detail::out_of_range::create(404, detail::concat("unresolved reference token '", reference_token, "'"), ptr));
+            }
+        }
+
+        return *ptr;
+    }
+
+    /*!
+    @throw parse_error.106   if an array index begins with '0'
+    @throw parse_error.109   if an array index was not a number
+    @throw out_of_range.402  if the array index '-' is used
+    @throw out_of_range.404  if the JSON pointer can not be resolved
+    */
+    template<typename BasicJsonType>
+    BasicJsonType& get_checked(BasicJsonType* ptr) const
+    {
+        for (const auto& reference_token : reference_tokens)
+        {
+            switch (ptr->type())
+            {
+                case detail::value_t::object:
+                {
+                    // note: at performs range check
+                    ptr = &ptr->at(reference_token);
+                    break;
+                }
+
+                case detail::value_t::array:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(reference_token == "-"))
+                    {
+                        // "-" always fails the range check
+                        JSON_THROW(detail::out_of_range::create(402, detail::concat(
+                                "array index '-' (", std::to_string(ptr->m_data.m_value.array->size()),
+                                ") is out of range"), ptr));
+                    }
+
+                    // note: at performs range check
+                    ptr = &ptr->at(array_index<BasicJsonType>(reference_token));
+                    break;
+                }
+
+                case detail::value_t::null:
+                case detail::value_t::string:
+                case detail::value_t::boolean:
+                case detail::value_t::number_integer:
+                case detail::value_t::number_unsigned:
+                case detail::value_t::number_float:
+                case detail::value_t::binary:
+                case detail::value_t::discarded:
+                default:
+                    JSON_THROW(detail::out_of_range::create(404, detail::concat("unresolved reference token '", reference_token, "'"), ptr));
+            }
+        }
+
+        return *ptr;
+    }
+
+    /*!
+    @brief return a const reference to the pointed to value
+
+    @param[in] ptr  a JSON value
+
+    @return const reference to the JSON value pointed to by the JSON
+    pointer
+
+    @throw parse_error.106   if an array index begins with '0'
+    @throw parse_error.109   if an array index was not a number
+    @throw out_of_range.402  if the array index '-' is used
+    @throw out_of_range.404  if the JSON pointer can not be resolved
+    */
+    template<typename BasicJsonType>
+    const BasicJsonType& get_unchecked(const BasicJsonType* ptr) const
+    {
+        for (const auto& reference_token : reference_tokens)
+        {
+            switch (ptr->type())
+            {
+                case detail::value_t::object:
+                {
+                    // use unchecked object access
+                    ptr = &ptr->operator[](reference_token);
+                    break;
+                }
+
+                case detail::value_t::array:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(reference_token == "-"))
+                    {
+                        // "-" cannot be used for const access
+                        JSON_THROW(detail::out_of_range::create(402, detail::concat("array index '-' (", std::to_string(ptr->m_data.m_value.array->size()), ") is out of range"), ptr));
+                    }
+
+                    // use unchecked array access
+                    ptr = &ptr->operator[](array_index<BasicJsonType>(reference_token));
+                    break;
+                }
+
+                case detail::value_t::null:
+                case detail::value_t::string:
+                case detail::value_t::boolean:
+                case detail::value_t::number_integer:
+                case detail::value_t::number_unsigned:
+                case detail::value_t::number_float:
+                case detail::value_t::binary:
+                case detail::value_t::discarded:
+                default:
+                    JSON_THROW(detail::out_of_range::create(404, detail::concat("unresolved reference token '", reference_token, "'"), ptr));
+            }
+        }
+
+        return *ptr;
+    }
+
+    /*!
+    @throw parse_error.106   if an array index begins with '0'
+    @throw parse_error.109   if an array index was not a number
+    @throw out_of_range.402  if the array index '-' is used
+    @throw out_of_range.404  if the JSON pointer can not be resolved
+    */
+    template<typename BasicJsonType>
+    const BasicJsonType& get_checked(const BasicJsonType* ptr) const
+    {
+        for (const auto& reference_token : reference_tokens)
+        {
+            switch (ptr->type())
+            {
+                case detail::value_t::object:
+                {
+                    // note: at performs range check
+                    ptr = &ptr->at(reference_token);
+                    break;
+                }
+
+                case detail::value_t::array:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(reference_token == "-"))
+                    {
+                        // "-" always fails the range check
+                        JSON_THROW(detail::out_of_range::create(402, detail::concat(
+                                "array index '-' (", std::to_string(ptr->m_data.m_value.array->size()),
+                                ") is out of range"), ptr));
+                    }
+
+                    // note: at performs range check
+                    ptr = &ptr->at(array_index<BasicJsonType>(reference_token));
+                    break;
+                }
+
+                case detail::value_t::null:
+                case detail::value_t::string:
+                case detail::value_t::boolean:
+                case detail::value_t::number_integer:
+                case detail::value_t::number_unsigned:
+                case detail::value_t::number_float:
+                case detail::value_t::binary:
+                case detail::value_t::discarded:
+                default:
+                    JSON_THROW(detail::out_of_range::create(404, detail::concat("unresolved reference token '", reference_token, "'"), ptr));
+            }
+        }
+
+        return *ptr;
+    }
+
+    /*!
+    @throw parse_error.106   if an array index begins with '0'
+    @throw parse_error.109   if an array index was not a number
+    */
+    template<typename BasicJsonType>
+    bool contains(const BasicJsonType* ptr) const
+    {
+        for (const auto& reference_token : reference_tokens)
+        {
+            switch (ptr->type())
+            {
+                case detail::value_t::object:
+                {
+                    if (!ptr->contains(reference_token))
+                    {
+                        // we did not find the key in the object
+                        return false;
+                    }
+
+                    ptr = &ptr->operator[](reference_token);
+                    break;
+                }
+
+                case detail::value_t::array:
+                {
+                    if (JSON_HEDLEY_UNLIKELY(reference_token == "-"))
+                    {
+                        // "-" always fails the range check
+                        return false;
+                    }
+                    if (JSON_HEDLEY_UNLIKELY(reference_token.size() == 1 && !("0" <= reference_token && reference_token <= "9")))
+                    {
+                        // invalid char
+                        return false;
+                    }
+                    if (JSON_HEDLEY_UNLIKELY(reference_token.size() > 1))
+                    {
+                        if (JSON_HEDLEY_UNLIKELY(!('1' <= reference_token[0] && reference_token[0] <= '9')))
+                        {
+                            // first char should be between '1' and '9'
+                            return false;
+                        }
+                        for (std::size_t i = 1; i < reference_token.size(); i++)
+                        {
+                            if (JSON_HEDLEY_UNLIKELY(!('0' <= reference_token[i] && reference_token[i] <= '9')))
+                            {
+                                // other char should be between '0' and '9'
+                                return false;
+                            }
+                        }
+                    }
+
+                    const auto idx = array_index<BasicJsonType>(reference_token);
+                    if (idx >= ptr->size())
+                    {
+                        // index out of range
+                        return false;
+                    }
+
+                    ptr = &ptr->operator[](idx);
+                    break;
+                }
+
+                case detail::value_t::null:
+                case detail::value_t::string:
+                case detail::value_t::boolean:
+                case detail::value_t::number_integer:
+                case detail::value_t::number_unsigned:
+                case detail::value_t::number_float:
+                case detail::value_t::binary:
+                case detail::value_t::discarded:
+                default:
+                {
+                    // we do not expect primitive values if there is still a
+                    // reference token to process
+                    return false;
+                }
+            }
+        }
+
+        // no reference token left means we found a primitive value
+        return true;
+    }
+
+    /*!
+    @brief split the string input to reference tokens
+
+    @note This function is only called by the json_pointer constructor.
+          All exceptions below are documented there.
+
+    @throw parse_error.107  if the pointer is not empty or begins with '/'
+    @throw parse_error.108  if character '~' is not followed by '0' or '1'
+    */
+    static std::vector<string_t> split(const string_t& reference_string)
+    {
+        std::vector<string_t> result;
+
+        // special case: empty reference string -> no reference tokens
+        if (reference_string.empty())
+        {
+            return result;
+        }
+
+        // check if nonempty reference string begins with slash
+        if (JSON_HEDLEY_UNLIKELY(reference_string[0] != '/'))
+        {
+            JSON_THROW(detail::parse_error::create(107, 1, detail::concat("JSON pointer must be empty or begin with '/' - was: '", reference_string, "'"), nullptr));
+        }
+
+        // extract the reference tokens:
+        // - slash: position of the last read slash (or end of string)
+        // - start: position after the previous slash
+        for (
+            // search for the first slash after the first character
+            std::size_t slash = reference_string.find_first_of('/', 1),
+            // set the beginning of the first reference token
+            start = 1;
+            // we can stop if start == 0 (if slash == string_t::npos)
+            start != 0;
+            // set the beginning of the next reference token
+            // (will eventually be 0 if slash == string_t::npos)
+            start = (slash == string_t::npos) ? 0 : slash + 1,
+            // find next slash
+            slash = reference_string.find_first_of('/', start))
+        {
+            // use the text between the beginning of the reference token
+            // (start) and the last slash (slash).
+            auto reference_token = reference_string.substr(start, slash - start);
+
+            // check reference tokens are properly escaped
+            for (std::size_t pos = reference_token.find_first_of('~');
+                    pos != string_t::npos;
+                    pos = reference_token.find_first_of('~', pos + 1))
+            {
+                JSON_ASSERT(reference_token[pos] == '~');
+
+                // ~ must be followed by 0 or 1
+                if (JSON_HEDLEY_UNLIKELY(pos == reference_token.size() - 1 ||
+                                         (reference_token[pos + 1] != '0' &&
+                                          reference_token[pos + 1] != '1')))
+                {
+                    JSON_THROW(detail::parse_error::create(108, 0, "escape character '~' must be followed with '0' or '1'", nullptr));
+                }
+            }
+
+            // finally, store the reference token
+            detail::unescape(reference_token);
+            result.push_back(reference_token);
+        }
+
+        return result;
+    }
+
+  private:
+    /*!
+    @param[in] reference_string  the reference string to the current value
+    @param[in] value             the value to consider
+    @param[in,out] result        the result object to insert values to
+
+    @note Empty objects or arrays are flattened to `null`.
+    */
+    template<typename BasicJsonType>
+    static void flatten(const string_t& reference_string,
+                        const BasicJsonType& value,
+                        BasicJsonType& result)
+    {
+        switch (value.type())
+        {
+            case detail::value_t::array:
+            {
+                if (value.m_data.m_value.array->empty())
+                {
+                    // flatten empty array as null
+                    result[reference_string] = nullptr;
+                }
+                else
+                {
+                    // iterate array and use index as reference string
+                    for (std::size_t i = 0; i < value.m_data.m_value.array->size(); ++i)
+                    {
+                        flatten(detail::concat(reference_string, '/', std::to_string(i)),
+                                value.m_data.m_value.array->operator[](i), result);
+                    }
+                }
+                break;
+            }
+
+            case detail::value_t::object:
+            {
+                if (value.m_data.m_value.object->empty())
+                {
+                    // flatten empty object as null
+                    result[reference_string] = nullptr;
+                }
+                else
+                {
+                    // iterate object and use keys as reference string
+                    for (const auto& element : *value.m_data.m_value.object)
+                    {
+                        flatten(detail::concat(reference_string, '/', detail::escape(element.first)), element.second, result);
+                    }
+                }
+                break;
+            }
+
+            case detail::value_t::null:
+            case detail::value_t::string:
+            case detail::value_t::boolean:
+            case detail::value_t::number_integer:
+            case detail::value_t::number_unsigned:
+            case detail::value_t::number_float:
+            case detail::value_t::binary:
+            case detail::value_t::discarded:
+            default:
+            {
+                // add primitive value with its reference string
+                result[reference_string] = value;
+                break;
+            }
+        }
+    }
+
+    /*!
+    @param[in] value  flattened JSON
+
+    @return unflattened JSON
+
+    @throw parse_error.109 if array index is not a number
+    @throw type_error.314  if value is not an object
+    @throw type_error.315  if object values are not primitive
+    @throw type_error.313  if value cannot be unflattened
+    */
+    template<typename BasicJsonType>
+    static BasicJsonType
+    unflatten(const BasicJsonType& value)
+    {
+        if (JSON_HEDLEY_UNLIKELY(!value.is_object()))
+        {
+            JSON_THROW(detail::type_error::create(314, "only objects can be unflattened", &value));
+        }
+
+        BasicJsonType result;
+
+        // iterate the JSON object values
+        for (const auto& element : *value.m_data.m_value.object)
+        {
+            if (JSON_HEDLEY_UNLIKELY(!element.second.is_primitive()))
+            {
+                JSON_THROW(detail::type_error::create(315, "values in object must be primitive", &element.second));
+            }
+
+            // assign value to reference pointed to by JSON pointer; Note that if
+            // the JSON pointer is "" (i.e., points to the whole value), function
+            // get_and_create returns a reference to result itself. An assignment
+            // will then create a primitive value.
+            json_pointer(element.first).get_and_create(result) = element.second;
+        }
+
+        return result;
+    }
+
+    // can't use conversion operator because of ambiguity
+    json_pointer<string_t> convert() const&
+    {
+        json_pointer<string_t> result;
+        result.reference_tokens = reference_tokens;
+        return result;
+    }
+
+    json_pointer<string_t> convert()&&
+    {
+        json_pointer<string_t> result;
+        result.reference_tokens = std::move(reference_tokens);
+        return result;
+    }
+
+  public:
+#if JSON_HAS_THREE_WAY_COMPARISON
+    /// @brief compares two JSON pointers for equality
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
+    template<typename RefStringTypeRhs>
+    bool operator==(const json_pointer<RefStringTypeRhs>& rhs) const noexcept
+    {
+        return reference_tokens == rhs.reference_tokens;
+    }
+
+    /// @brief compares JSON pointer and string for equality
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator==(json_pointer))
+    bool operator==(const string_t& rhs) const
+    {
+        return *this == json_pointer(rhs);
+    }
+
+    /// @brief 3-way compares two JSON pointers
+    template<typename RefStringTypeRhs>
+    std::strong_ordering operator<=>(const json_pointer<RefStringTypeRhs>& rhs) const noexcept // *NOPAD*
+    {
+        return  reference_tokens <=> rhs.reference_tokens; // *NOPAD*
+    }
+#else
+    /// @brief compares two JSON pointers for equality
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
+    template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
+                           const json_pointer<RefStringTypeRhs>& rhs) noexcept;
+
+    /// @brief compares JSON pointer and string for equality
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
+    template<typename RefStringTypeLhs, typename StringType>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
+                           const StringType& rhs);
+
+    /// @brief compares string and JSON pointer for equality
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_eq/
+    template<typename RefStringTypeRhs, typename StringType>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator==(const StringType& lhs,
+                           const json_pointer<RefStringTypeRhs>& rhs);
+
+    /// @brief compares two JSON pointers for inequality
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_ne/
+    template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator!=(const json_pointer<RefStringTypeLhs>& lhs,
+                           const json_pointer<RefStringTypeRhs>& rhs) noexcept;
+
+    /// @brief compares JSON pointer and string for inequality
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_ne/
+    template<typename RefStringTypeLhs, typename StringType>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator!=(const json_pointer<RefStringTypeLhs>& lhs,
+                           const StringType& rhs);
+
+    /// @brief compares string and JSON pointer for inequality
+    /// @sa https://json.nlohmann.me/api/json_pointer/operator_ne/
+    template<typename RefStringTypeRhs, typename StringType>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator!=(const StringType& lhs,
+                           const json_pointer<RefStringTypeRhs>& rhs);
+
+    /// @brief compares two JSON pointer for less-than
+    template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+    // NOLINTNEXTLINE(readability-redundant-declaration)
+    friend bool operator<(const json_pointer<RefStringTypeLhs>& lhs,
+                          const json_pointer<RefStringTypeRhs>& rhs) noexcept;
+#endif
+
+  private:
+    /// the reference tokens
+    std::vector<string_t> reference_tokens;
+};
+
+#if !JSON_HAS_THREE_WAY_COMPARISON
+// functions cannot be defined inside class due to ODR violations
+template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+inline bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
+                       const json_pointer<RefStringTypeRhs>& rhs) noexcept
+{
+    return lhs.reference_tokens == rhs.reference_tokens;
+}
+
+template<typename RefStringTypeLhs,
+         typename StringType = typename json_pointer<RefStringTypeLhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator==(json_pointer, json_pointer))
+inline bool operator==(const json_pointer<RefStringTypeLhs>& lhs,
+                       const StringType& rhs)
+{
+    return lhs == json_pointer<RefStringTypeLhs>(rhs);
+}
+
+template<typename RefStringTypeRhs,
+         typename StringType = typename json_pointer<RefStringTypeRhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator==(json_pointer, json_pointer))
+inline bool operator==(const StringType& lhs,
+                       const json_pointer<RefStringTypeRhs>& rhs)
+{
+    return json_pointer<RefStringTypeRhs>(lhs) == rhs;
+}
+
+template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+inline bool operator!=(const json_pointer<RefStringTypeLhs>& lhs,
+                       const json_pointer<RefStringTypeRhs>& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+
+template<typename RefStringTypeLhs,
+         typename StringType = typename json_pointer<RefStringTypeLhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator!=(json_pointer, json_pointer))
+inline bool operator!=(const json_pointer<RefStringTypeLhs>& lhs,
+                       const StringType& rhs)
+{
+    return !(lhs == rhs);
+}
+
+template<typename RefStringTypeRhs,
+         typename StringType = typename json_pointer<RefStringTypeRhs>::string_t>
+JSON_HEDLEY_DEPRECATED_FOR(3.11.2, operator!=(json_pointer, json_pointer))
+inline bool operator!=(const StringType& lhs,
+                       const json_pointer<RefStringTypeRhs>& rhs)
+{
+    return !(lhs == rhs);
+}
+
+template<typename RefStringTypeLhs, typename RefStringTypeRhs>
+inline bool operator<(const json_pointer<RefStringTypeLhs>& lhs,
+                      const json_pointer<RefStringTypeRhs>& rhs) noexcept
+{
+    return lhs.reference_tokens < rhs.reference_tokens;
+}
+#endif
+
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/json_ref.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <initializer_list>
+#include <utility>
+
+// #include <nlohmann/detail/abi_macros.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+template<typename BasicJsonType>
+class json_ref
+{
+  public:
+    using value_type = BasicJsonType;
+
+    json_ref(value_type&& value)
+        : owned_value(std::move(value))
+    {}
+
+    json_ref(const value_type& value)
+        : value_ref(&value)
+    {}
+
+    json_ref(std::initializer_list<json_ref> init)
+        : owned_value(init)
+    {}
+
+    template <
+        class... Args,
+        enable_if_t<std::is_constructible<value_type, Args...>::value, int> = 0 >
+    json_ref(Args && ... args)
+        : owned_value(std::forward<Args>(args)...)
+    {}
+
+    // class should be movable only
+    json_ref(json_ref&&) noexcept = default;
+    json_ref(const json_ref&) = delete;
+    json_ref& operator=(const json_ref&) = delete;
+    json_ref& operator=(json_ref&&) = delete;
+    ~json_ref() = default;
+
+    value_type moved_or_copied() const
+    {
+        if (value_ref == nullptr)
+        {
+            return std::move(owned_value);
+        }
+        return *value_ref;
+    }
+
+    value_type const& operator*() const
+    {
+        return value_ref ? *value_ref : owned_value;
+    }
+
+    value_type const* operator->() const
+    {
+        return &** this;
+    }
+
+  private:
+    mutable value_type owned_value = nullptr;
+    value_type const* value_ref = nullptr;
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/string_concat.hpp>
+
+// #include <nlohmann/detail/string_escape.hpp>
+
+// #include <nlohmann/detail/meta/cpp_future.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+// #include <nlohmann/detail/output/binary_writer.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <algorithm> // reverse
+#include <array> // array
+#include <map> // map
+#include <cmath> // isnan, isinf
+#include <cstdint> // uint8_t, uint16_t, uint32_t, uint64_t
+#include <cstring> // memcpy
+#include <limits> // numeric_limits
+#include <string> // string
+#include <utility> // move
+#include <vector> // vector
+
+// #include <nlohmann/detail/input/binary_reader.hpp>
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/output/output_adapters.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <algorithm> // copy
+#include <cstddef> // size_t
+#include <iterator> // back_inserter
+#include <memory> // shared_ptr, make_shared
+#include <string> // basic_string
+#include <vector> // vector
+
+#ifndef JSON_NO_IO
+    #include <ios>      // streamsize
+    #include <ostream>  // basic_ostream
+#endif  // JSON_NO_IO
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+/// abstract output adapter interface
+template<typename CharType> struct output_adapter_protocol
+{
+    virtual void write_character(CharType c) = 0;
+    virtual void write_characters(const CharType* s, std::size_t length) = 0;
+    virtual ~output_adapter_protocol() = default;
+
+    output_adapter_protocol() = default;
+    output_adapter_protocol(const output_adapter_protocol&) = default;
+    output_adapter_protocol(output_adapter_protocol&&) noexcept = default;
+    output_adapter_protocol& operator=(const output_adapter_protocol&) = default;
+    output_adapter_protocol& operator=(output_adapter_protocol&&) noexcept = default;
+};
+
+/// a type to simplify interfaces
+template<typename CharType>
+using output_adapter_t = std::shared_ptr<output_adapter_protocol<CharType>>;
+
+/// output adapter for byte vectors
+template<typename CharType, typename AllocatorType = std::allocator<CharType>>
+class output_vector_adapter : public output_adapter_protocol<CharType>
+{
+  public:
+    explicit output_vector_adapter(std::vector<CharType, AllocatorType>& vec) noexcept
+        : v(vec)
+    {}
+
+    void write_character(CharType c) override
+    {
+        v.push_back(c);
+    }
+
+    JSON_HEDLEY_NON_NULL(2)
+    void write_characters(const CharType* s, std::size_t length) override
+    {
+        v.insert(v.end(), s, s + length);
+    }
+
+  private:
+    std::vector<CharType, AllocatorType>& v;
+};
+
+#ifndef JSON_NO_IO
+/// output adapter for output streams
+template<typename CharType>
+class output_stream_adapter : public output_adapter_protocol<CharType>
+{
+  public:
+    explicit output_stream_adapter(std::basic_ostream<CharType>& s) noexcept
+        : stream(s)
+    {}
+
+    void write_character(CharType c) override
+    {
+        stream.put(c);
+    }
+
+    JSON_HEDLEY_NON_NULL(2)
+    void write_characters(const CharType* s, std::size_t length) override
+    {
+        stream.write(s, static_cast<std::streamsize>(length));
+    }
+
+  private:
+    std::basic_ostream<CharType>& stream;
+};
+#endif  // JSON_NO_IO
+
+/// output adapter for basic_string
+template<typename CharType, typename StringType = std::basic_string<CharType>>
+class output_string_adapter : public output_adapter_protocol<CharType>
+{
+  public:
+    explicit output_string_adapter(StringType& s) noexcept
+        : str(s)
+    {}
+
+    void write_character(CharType c) override
+    {
+        str.push_back(c);
+    }
+
+    JSON_HEDLEY_NON_NULL(2)
+    void write_characters(const CharType* s, std::size_t length) override
+    {
+        str.append(s, length);
+    }
+
+  private:
+    StringType& str;
+};
+
+template<typename CharType, typename StringType = std::basic_string<CharType>>
+class output_adapter
+{
+  public:
+    template<typename AllocatorType = std::allocator<CharType>>
+    output_adapter(std::vector<CharType, AllocatorType>& vec)
+        : oa(std::make_shared<output_vector_adapter<CharType, AllocatorType>>(vec)) {}
+
+#ifndef JSON_NO_IO
+    output_adapter(std::basic_ostream<CharType>& s)
+        : oa(std::make_shared<output_stream_adapter<CharType>>(s)) {}
+#endif  // JSON_NO_IO
+
+    output_adapter(StringType& s)
+        : oa(std::make_shared<output_string_adapter<CharType, StringType>>(s)) {}
+
+    operator output_adapter_t<CharType>()
+    {
+        return oa;
+    }
+
+  private:
+    output_adapter_t<CharType> oa = nullptr;
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/string_concat.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+///////////////////
+// binary writer //
+///////////////////
+
+/*!
+@brief serialization to CBOR and MessagePack values
+*/
+template<typename BasicJsonType, typename CharType>
+class binary_writer
+{
+    using string_t = typename BasicJsonType::string_t;
+    using binary_t = typename BasicJsonType::binary_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+
+  public:
+    /*!
+    @brief create a binary writer
+
+    @param[in] adapter  output adapter to write to
+    */
+    explicit binary_writer(output_adapter_t<CharType> adapter) : oa(std::move(adapter))
+    {
+        JSON_ASSERT(oa);
+    }
+
+    /*!
+    @param[in] j  JSON value to serialize
+    @pre       j.type() == value_t::object
+    */
+    void write_bson(const BasicJsonType& j)
+    {
+        switch (j.type())
+        {
+            case value_t::object:
+            {
+                write_bson_object(*j.m_data.m_value.object);
+                break;
+            }
+
+            case value_t::null:
+            case value_t::array:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                JSON_THROW(type_error::create(317, concat("to serialize to BSON, top-level type must be object, but is ", j.type_name()), &j));
+            }
+        }
+    }
+
+    /*!
+    @param[in] j  JSON value to serialize
+    */
+    void write_cbor(const BasicJsonType& j)
+    {
+        switch (j.type())
+        {
+            case value_t::null:
+            {
+                oa->write_character(to_char_type(0xF6));
+                break;
+            }
+
+            case value_t::boolean:
+            {
+                oa->write_character(j.m_data.m_value.boolean
+                                    ? to_char_type(0xF5)
+                                    : to_char_type(0xF4));
+                break;
+            }
+
+            case value_t::number_integer:
+            {
+                if (j.m_data.m_value.number_integer >= 0)
+                {
+                    // CBOR does not differentiate between positive signed
+                    // integers and unsigned integers. Therefore, we used the
+                    // code from the value_t::number_unsigned case here.
+                    if (j.m_data.m_value.number_integer <= 0x17)
+                    {
+                        write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint8_t>::max)())
+                    {
+                        oa->write_character(to_char_type(0x18));
+                        write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint16_t>::max)())
+                    {
+                        oa->write_character(to_char_type(0x19));
+                        write_number(static_cast<std::uint16_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint32_t>::max)())
+                    {
+                        oa->write_character(to_char_type(0x1A));
+                        write_number(static_cast<std::uint32_t>(j.m_data.m_value.number_integer));
+                    }
+                    else
+                    {
+                        oa->write_character(to_char_type(0x1B));
+                        write_number(static_cast<std::uint64_t>(j.m_data.m_value.number_integer));
+                    }
+                }
+                else
+                {
+                    // The conversions below encode the sign in the first
+                    // byte, and the value is converted to a positive number.
+                    const auto positive_number = -1 - j.m_data.m_value.number_integer;
+                    if (j.m_data.m_value.number_integer >= -24)
+                    {
+                        write_number(static_cast<std::uint8_t>(0x20 + positive_number));
+                    }
+                    else if (positive_number <= (std::numeric_limits<std::uint8_t>::max)())
+                    {
+                        oa->write_character(to_char_type(0x38));
+                        write_number(static_cast<std::uint8_t>(positive_number));
+                    }
+                    else if (positive_number <= (std::numeric_limits<std::uint16_t>::max)())
+                    {
+                        oa->write_character(to_char_type(0x39));
+                        write_number(static_cast<std::uint16_t>(positive_number));
+                    }
+                    else if (positive_number <= (std::numeric_limits<std::uint32_t>::max)())
+                    {
+                        oa->write_character(to_char_type(0x3A));
+                        write_number(static_cast<std::uint32_t>(positive_number));
+                    }
+                    else
+                    {
+                        oa->write_character(to_char_type(0x3B));
+                        write_number(static_cast<std::uint64_t>(positive_number));
+                    }
+                }
+                break;
+            }
+
+            case value_t::number_unsigned:
+            {
+                if (j.m_data.m_value.number_unsigned <= 0x17)
+                {
+                    write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_unsigned));
+                }
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint8_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x18));
+                    write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_unsigned));
+                }
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint16_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x19));
+                    write_number(static_cast<std::uint16_t>(j.m_data.m_value.number_unsigned));
+                }
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint32_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x1A));
+                    write_number(static_cast<std::uint32_t>(j.m_data.m_value.number_unsigned));
+                }
+                else
+                {
+                    oa->write_character(to_char_type(0x1B));
+                    write_number(static_cast<std::uint64_t>(j.m_data.m_value.number_unsigned));
+                }
+                break;
+            }
+
+            case value_t::number_float:
+            {
+                if (std::isnan(j.m_data.m_value.number_float))
+                {
+                    // NaN is 0xf97e00 in CBOR
+                    oa->write_character(to_char_type(0xF9));
+                    oa->write_character(to_char_type(0x7E));
+                    oa->write_character(to_char_type(0x00));
+                }
+                else if (std::isinf(j.m_data.m_value.number_float))
+                {
+                    // Infinity is 0xf97c00, -Infinity is 0xf9fc00
+                    oa->write_character(to_char_type(0xf9));
+                    oa->write_character(j.m_data.m_value.number_float > 0 ? to_char_type(0x7C) : to_char_type(0xFC));
+                    oa->write_character(to_char_type(0x00));
+                }
+                else
+                {
+                    write_compact_float(j.m_data.m_value.number_float, detail::input_format_t::cbor);
+                }
+                break;
+            }
+
+            case value_t::string:
+            {
+                // step 1: write control byte and the string length
+                const auto N = j.m_data.m_value.string->size();
+                if (N <= 0x17)
+                {
+                    write_number(static_cast<std::uint8_t>(0x60 + N));
+                }
+                else if (N <= (std::numeric_limits<std::uint8_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x78));
+                    write_number(static_cast<std::uint8_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint16_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x79));
+                    write_number(static_cast<std::uint16_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint32_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x7A));
+                    write_number(static_cast<std::uint32_t>(N));
+                }
+                // LCOV_EXCL_START
+                else if (N <= (std::numeric_limits<std::uint64_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x7B));
+                    write_number(static_cast<std::uint64_t>(N));
+                }
+                // LCOV_EXCL_STOP
+
+                // step 2: write the string
+                oa->write_characters(
+                    reinterpret_cast<const CharType*>(j.m_data.m_value.string->c_str()),
+                    j.m_data.m_value.string->size());
+                break;
+            }
+
+            case value_t::array:
+            {
+                // step 1: write control byte and the array size
+                const auto N = j.m_data.m_value.array->size();
+                if (N <= 0x17)
+                {
+                    write_number(static_cast<std::uint8_t>(0x80 + N));
+                }
+                else if (N <= (std::numeric_limits<std::uint8_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x98));
+                    write_number(static_cast<std::uint8_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint16_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x99));
+                    write_number(static_cast<std::uint16_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint32_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x9A));
+                    write_number(static_cast<std::uint32_t>(N));
+                }
+                // LCOV_EXCL_START
+                else if (N <= (std::numeric_limits<std::uint64_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x9B));
+                    write_number(static_cast<std::uint64_t>(N));
+                }
+                // LCOV_EXCL_STOP
+
+                // step 2: write each element
+                for (const auto& el : *j.m_data.m_value.array)
+                {
+                    write_cbor(el);
+                }
+                break;
+            }
+
+            case value_t::binary:
+            {
+                if (j.m_data.m_value.binary->has_subtype())
+                {
+                    if (j.m_data.m_value.binary->subtype() <= (std::numeric_limits<std::uint8_t>::max)())
+                    {
+                        write_number(static_cast<std::uint8_t>(0xd8));
+                        write_number(static_cast<std::uint8_t>(j.m_data.m_value.binary->subtype()));
+                    }
+                    else if (j.m_data.m_value.binary->subtype() <= (std::numeric_limits<std::uint16_t>::max)())
+                    {
+                        write_number(static_cast<std::uint8_t>(0xd9));
+                        write_number(static_cast<std::uint16_t>(j.m_data.m_value.binary->subtype()));
+                    }
+                    else if (j.m_data.m_value.binary->subtype() <= (std::numeric_limits<std::uint32_t>::max)())
+                    {
+                        write_number(static_cast<std::uint8_t>(0xda));
+                        write_number(static_cast<std::uint32_t>(j.m_data.m_value.binary->subtype()));
+                    }
+                    else if (j.m_data.m_value.binary->subtype() <= (std::numeric_limits<std::uint64_t>::max)())
+                    {
+                        write_number(static_cast<std::uint8_t>(0xdb));
+                        write_number(static_cast<std::uint64_t>(j.m_data.m_value.binary->subtype()));
+                    }
+                }
+
+                // step 1: write control byte and the binary array size
+                const auto N = j.m_data.m_value.binary->size();
+                if (N <= 0x17)
+                {
+                    write_number(static_cast<std::uint8_t>(0x40 + N));
+                }
+                else if (N <= (std::numeric_limits<std::uint8_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x58));
+                    write_number(static_cast<std::uint8_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint16_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x59));
+                    write_number(static_cast<std::uint16_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint32_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x5A));
+                    write_number(static_cast<std::uint32_t>(N));
+                }
+                // LCOV_EXCL_START
+                else if (N <= (std::numeric_limits<std::uint64_t>::max)())
+                {
+                    oa->write_character(to_char_type(0x5B));
+                    write_number(static_cast<std::uint64_t>(N));
+                }
+                // LCOV_EXCL_STOP
+
+                // step 2: write each element
+                oa->write_characters(
+                    reinterpret_cast<const CharType*>(j.m_data.m_value.binary->data()),
+                    N);
+
+                break;
+            }
+
+            case value_t::object:
+            {
+                // step 1: write control byte and the object size
+                const auto N = j.m_data.m_value.object->size();
+                if (N <= 0x17)
+                {
+                    write_number(static_cast<std::uint8_t>(0xA0 + N));
+                }
+                else if (N <= (std::numeric_limits<std::uint8_t>::max)())
+                {
+                    oa->write_character(to_char_type(0xB8));
+                    write_number(static_cast<std::uint8_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint16_t>::max)())
+                {
+                    oa->write_character(to_char_type(0xB9));
+                    write_number(static_cast<std::uint16_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint32_t>::max)())
+                {
+                    oa->write_character(to_char_type(0xBA));
+                    write_number(static_cast<std::uint32_t>(N));
+                }
+                // LCOV_EXCL_START
+                else if (N <= (std::numeric_limits<std::uint64_t>::max)())
+                {
+                    oa->write_character(to_char_type(0xBB));
+                    write_number(static_cast<std::uint64_t>(N));
+                }
+                // LCOV_EXCL_STOP
+
+                // step 2: write each element
+                for (const auto& el : *j.m_data.m_value.object)
+                {
+                    write_cbor(el.first);
+                    write_cbor(el.second);
+                }
+                break;
+            }
+
+            case value_t::discarded:
+            default:
+                break;
+        }
+    }
+
+    /*!
+    @param[in] j  JSON value to serialize
+    */
+    void write_msgpack(const BasicJsonType& j)
+    {
+        switch (j.type())
+        {
+            case value_t::null: // nil
+            {
+                oa->write_character(to_char_type(0xC0));
+                break;
+            }
+
+            case value_t::boolean: // true and false
+            {
+                oa->write_character(j.m_data.m_value.boolean
+                                    ? to_char_type(0xC3)
+                                    : to_char_type(0xC2));
+                break;
+            }
+
+            case value_t::number_integer:
+            {
+                if (j.m_data.m_value.number_integer >= 0)
+                {
+                    // MessagePack does not differentiate between positive
+                    // signed integers and unsigned integers. Therefore, we used
+                    // the code from the value_t::number_unsigned case here.
+                    if (j.m_data.m_value.number_unsigned < 128)
+                    {
+                        // positive fixnum
+                        write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint8_t>::max)())
+                    {
+                        // uint 8
+                        oa->write_character(to_char_type(0xCC));
+                        write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint16_t>::max)())
+                    {
+                        // uint 16
+                        oa->write_character(to_char_type(0xCD));
+                        write_number(static_cast<std::uint16_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint32_t>::max)())
+                    {
+                        // uint 32
+                        oa->write_character(to_char_type(0xCE));
+                        write_number(static_cast<std::uint32_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint64_t>::max)())
+                    {
+                        // uint 64
+                        oa->write_character(to_char_type(0xCF));
+                        write_number(static_cast<std::uint64_t>(j.m_data.m_value.number_integer));
+                    }
+                }
+                else
+                {
+                    if (j.m_data.m_value.number_integer >= -32)
+                    {
+                        // negative fixnum
+                        write_number(static_cast<std::int8_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_integer >= (std::numeric_limits<std::int8_t>::min)() &&
+                             j.m_data.m_value.number_integer <= (std::numeric_limits<std::int8_t>::max)())
+                    {
+                        // int 8
+                        oa->write_character(to_char_type(0xD0));
+                        write_number(static_cast<std::int8_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_integer >= (std::numeric_limits<std::int16_t>::min)() &&
+                             j.m_data.m_value.number_integer <= (std::numeric_limits<std::int16_t>::max)())
+                    {
+                        // int 16
+                        oa->write_character(to_char_type(0xD1));
+                        write_number(static_cast<std::int16_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_integer >= (std::numeric_limits<std::int32_t>::min)() &&
+                             j.m_data.m_value.number_integer <= (std::numeric_limits<std::int32_t>::max)())
+                    {
+                        // int 32
+                        oa->write_character(to_char_type(0xD2));
+                        write_number(static_cast<std::int32_t>(j.m_data.m_value.number_integer));
+                    }
+                    else if (j.m_data.m_value.number_integer >= (std::numeric_limits<std::int64_t>::min)() &&
+                             j.m_data.m_value.number_integer <= (std::numeric_limits<std::int64_t>::max)())
+                    {
+                        // int 64
+                        oa->write_character(to_char_type(0xD3));
+                        write_number(static_cast<std::int64_t>(j.m_data.m_value.number_integer));
+                    }
+                }
+                break;
+            }
+
+            case value_t::number_unsigned:
+            {
+                if (j.m_data.m_value.number_unsigned < 128)
+                {
+                    // positive fixnum
+                    write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
+                }
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint8_t>::max)())
+                {
+                    // uint 8
+                    oa->write_character(to_char_type(0xCC));
+                    write_number(static_cast<std::uint8_t>(j.m_data.m_value.number_integer));
+                }
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint16_t>::max)())
+                {
+                    // uint 16
+                    oa->write_character(to_char_type(0xCD));
+                    write_number(static_cast<std::uint16_t>(j.m_data.m_value.number_integer));
+                }
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint32_t>::max)())
+                {
+                    // uint 32
+                    oa->write_character(to_char_type(0xCE));
+                    write_number(static_cast<std::uint32_t>(j.m_data.m_value.number_integer));
+                }
+                else if (j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint64_t>::max)())
+                {
+                    // uint 64
+                    oa->write_character(to_char_type(0xCF));
+                    write_number(static_cast<std::uint64_t>(j.m_data.m_value.number_integer));
+                }
+                break;
+            }
+
+            case value_t::number_float:
+            {
+                write_compact_float(j.m_data.m_value.number_float, detail::input_format_t::msgpack);
+                break;
+            }
+
+            case value_t::string:
+            {
+                // step 1: write control byte and the string length
+                const auto N = j.m_data.m_value.string->size();
+                if (N <= 31)
+                {
+                    // fixstr
+                    write_number(static_cast<std::uint8_t>(0xA0 | N));
+                }
+                else if (N <= (std::numeric_limits<std::uint8_t>::max)())
+                {
+                    // str 8
+                    oa->write_character(to_char_type(0xD9));
+                    write_number(static_cast<std::uint8_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint16_t>::max)())
+                {
+                    // str 16
+                    oa->write_character(to_char_type(0xDA));
+                    write_number(static_cast<std::uint16_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint32_t>::max)())
+                {
+                    // str 32
+                    oa->write_character(to_char_type(0xDB));
+                    write_number(static_cast<std::uint32_t>(N));
+                }
+
+                // step 2: write the string
+                oa->write_characters(
+                    reinterpret_cast<const CharType*>(j.m_data.m_value.string->c_str()),
+                    j.m_data.m_value.string->size());
+                break;
+            }
+
+            case value_t::array:
+            {
+                // step 1: write control byte and the array size
+                const auto N = j.m_data.m_value.array->size();
+                if (N <= 15)
+                {
+                    // fixarray
+                    write_number(static_cast<std::uint8_t>(0x90 | N));
+                }
+                else if (N <= (std::numeric_limits<std::uint16_t>::max)())
+                {
+                    // array 16
+                    oa->write_character(to_char_type(0xDC));
+                    write_number(static_cast<std::uint16_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint32_t>::max)())
+                {
+                    // array 32
+                    oa->write_character(to_char_type(0xDD));
+                    write_number(static_cast<std::uint32_t>(N));
+                }
+
+                // step 2: write each element
+                for (const auto& el : *j.m_data.m_value.array)
+                {
+                    write_msgpack(el);
+                }
+                break;
+            }
+
+            case value_t::binary:
+            {
+                // step 0: determine if the binary type has a set subtype to
+                // determine whether or not to use the ext or fixext types
+                const bool use_ext = j.m_data.m_value.binary->has_subtype();
+
+                // step 1: write control byte and the byte string length
+                const auto N = j.m_data.m_value.binary->size();
+                if (N <= (std::numeric_limits<std::uint8_t>::max)())
+                {
+                    std::uint8_t output_type{};
+                    bool fixed = true;
+                    if (use_ext)
+                    {
+                        switch (N)
+                        {
+                            case 1:
+                                output_type = 0xD4; // fixext 1
+                                break;
+                            case 2:
+                                output_type = 0xD5; // fixext 2
+                                break;
+                            case 4:
+                                output_type = 0xD6; // fixext 4
+                                break;
+                            case 8:
+                                output_type = 0xD7; // fixext 8
+                                break;
+                            case 16:
+                                output_type = 0xD8; // fixext 16
+                                break;
+                            default:
+                                output_type = 0xC7; // ext 8
+                                fixed = false;
+                                break;
+                        }
+
+                    }
+                    else
+                    {
+                        output_type = 0xC4; // bin 8
+                        fixed = false;
+                    }
+
+                    oa->write_character(to_char_type(output_type));
+                    if (!fixed)
+                    {
+                        write_number(static_cast<std::uint8_t>(N));
+                    }
+                }
+                else if (N <= (std::numeric_limits<std::uint16_t>::max)())
+                {
+                    const std::uint8_t output_type = use_ext
+                                                     ? 0xC8 // ext 16
+                                                     : 0xC5; // bin 16
+
+                    oa->write_character(to_char_type(output_type));
+                    write_number(static_cast<std::uint16_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint32_t>::max)())
+                {
+                    const std::uint8_t output_type = use_ext
+                                                     ? 0xC9 // ext 32
+                                                     : 0xC6; // bin 32
+
+                    oa->write_character(to_char_type(output_type));
+                    write_number(static_cast<std::uint32_t>(N));
+                }
+
+                // step 1.5: if this is an ext type, write the subtype
+                if (use_ext)
+                {
+                    write_number(static_cast<std::int8_t>(j.m_data.m_value.binary->subtype()));
+                }
+
+                // step 2: write the byte string
+                oa->write_characters(
+                    reinterpret_cast<const CharType*>(j.m_data.m_value.binary->data()),
+                    N);
+
+                break;
+            }
+
+            case value_t::object:
+            {
+                // step 1: write control byte and the object size
+                const auto N = j.m_data.m_value.object->size();
+                if (N <= 15)
+                {
+                    // fixmap
+                    write_number(static_cast<std::uint8_t>(0x80 | (N & 0xF)));
+                }
+                else if (N <= (std::numeric_limits<std::uint16_t>::max)())
+                {
+                    // map 16
+                    oa->write_character(to_char_type(0xDE));
+                    write_number(static_cast<std::uint16_t>(N));
+                }
+                else if (N <= (std::numeric_limits<std::uint32_t>::max)())
+                {
+                    // map 32
+                    oa->write_character(to_char_type(0xDF));
+                    write_number(static_cast<std::uint32_t>(N));
+                }
+
+                // step 2: write each element
+                for (const auto& el : *j.m_data.m_value.object)
+                {
+                    write_msgpack(el.first);
+                    write_msgpack(el.second);
+                }
+                break;
+            }
+
+            case value_t::discarded:
+            default:
+                break;
+        }
+    }
+
+    /*!
+    @param[in] j  JSON value to serialize
+    @param[in] use_count   whether to use '#' prefixes (optimized format)
+    @param[in] use_type    whether to use '$' prefixes (optimized format)
+    @param[in] add_prefix  whether prefixes need to be used for this value
+    @param[in] use_bjdata  whether write in BJData format, default is false
+    */
+    void write_ubjson(const BasicJsonType& j, const bool use_count,
+                      const bool use_type, const bool add_prefix = true,
+                      const bool use_bjdata = false)
+    {
+        switch (j.type())
+        {
+            case value_t::null:
+            {
+                if (add_prefix)
+                {
+                    oa->write_character(to_char_type('Z'));
+                }
+                break;
+            }
+
+            case value_t::boolean:
+            {
+                if (add_prefix)
+                {
+                    oa->write_character(j.m_data.m_value.boolean
+                                        ? to_char_type('T')
+                                        : to_char_type('F'));
+                }
+                break;
+            }
+
+            case value_t::number_integer:
+            {
+                write_number_with_ubjson_prefix(j.m_data.m_value.number_integer, add_prefix, use_bjdata);
+                break;
+            }
+
+            case value_t::number_unsigned:
+            {
+                write_number_with_ubjson_prefix(j.m_data.m_value.number_unsigned, add_prefix, use_bjdata);
+                break;
+            }
+
+            case value_t::number_float:
+            {
+                write_number_with_ubjson_prefix(j.m_data.m_value.number_float, add_prefix, use_bjdata);
+                break;
+            }
+
+            case value_t::string:
+            {
+                if (add_prefix)
+                {
+                    oa->write_character(to_char_type('S'));
+                }
+                write_number_with_ubjson_prefix(j.m_data.m_value.string->size(), true, use_bjdata);
+                oa->write_characters(
+                    reinterpret_cast<const CharType*>(j.m_data.m_value.string->c_str()),
+                    j.m_data.m_value.string->size());
+                break;
+            }
+
+            case value_t::array:
+            {
+                if (add_prefix)
+                {
+                    oa->write_character(to_char_type('['));
+                }
+
+                bool prefix_required = true;
+                if (use_type && !j.m_data.m_value.array->empty())
+                {
+                    JSON_ASSERT(use_count);
+                    const CharType first_prefix = ubjson_prefix(j.front(), use_bjdata);
+                    const bool same_prefix = std::all_of(j.begin() + 1, j.end(),
+                                                         [this, first_prefix, use_bjdata](const BasicJsonType & v)
+                    {
+                        return ubjson_prefix(v, use_bjdata) == first_prefix;
+                    });
+
+                    std::vector<CharType> bjdx = {'[', '{', 'S', 'H', 'T', 'F', 'N', 'Z'}; // excluded markers in bjdata optimized type
+
+                    if (same_prefix && !(use_bjdata && std::find(bjdx.begin(), bjdx.end(), first_prefix) != bjdx.end()))
+                    {
+                        prefix_required = false;
+                        oa->write_character(to_char_type('$'));
+                        oa->write_character(first_prefix);
+                    }
+                }
+
+                if (use_count)
+                {
+                    oa->write_character(to_char_type('#'));
+                    write_number_with_ubjson_prefix(j.m_data.m_value.array->size(), true, use_bjdata);
+                }
+
+                for (const auto& el : *j.m_data.m_value.array)
+                {
+                    write_ubjson(el, use_count, use_type, prefix_required, use_bjdata);
+                }
+
+                if (!use_count)
+                {
+                    oa->write_character(to_char_type(']'));
+                }
+
+                break;
+            }
+
+            case value_t::binary:
+            {
+                if (add_prefix)
+                {
+                    oa->write_character(to_char_type('['));
+                }
+
+                if (use_type && !j.m_data.m_value.binary->empty())
+                {
+                    JSON_ASSERT(use_count);
+                    oa->write_character(to_char_type('$'));
+                    oa->write_character('U');
+                }
+
+                if (use_count)
+                {
+                    oa->write_character(to_char_type('#'));
+                    write_number_with_ubjson_prefix(j.m_data.m_value.binary->size(), true, use_bjdata);
+                }
+
+                if (use_type)
+                {
+                    oa->write_characters(
+                        reinterpret_cast<const CharType*>(j.m_data.m_value.binary->data()),
+                        j.m_data.m_value.binary->size());
+                }
+                else
+                {
+                    for (size_t i = 0; i < j.m_data.m_value.binary->size(); ++i)
+                    {
+                        oa->write_character(to_char_type('U'));
+                        oa->write_character(j.m_data.m_value.binary->data()[i]);
+                    }
+                }
+
+                if (!use_count)
+                {
+                    oa->write_character(to_char_type(']'));
+                }
+
+                break;
+            }
+
+            case value_t::object:
+            {
+                if (use_bjdata && j.m_data.m_value.object->size() == 3 && j.m_data.m_value.object->find("_ArrayType_") != j.m_data.m_value.object->end() && j.m_data.m_value.object->find("_ArraySize_") != j.m_data.m_value.object->end() && j.m_data.m_value.object->find("_ArrayData_") != j.m_data.m_value.object->end())
+                {
+                    if (!write_bjdata_ndarray(*j.m_data.m_value.object, use_count, use_type))  // decode bjdata ndarray in the JData format (https://github.com/NeuroJSON/jdata)
+                    {
+                        break;
+                    }
+                }
+
+                if (add_prefix)
+                {
+                    oa->write_character(to_char_type('{'));
+                }
+
+                bool prefix_required = true;
+                if (use_type && !j.m_data.m_value.object->empty())
+                {
+                    JSON_ASSERT(use_count);
+                    const CharType first_prefix = ubjson_prefix(j.front(), use_bjdata);
+                    const bool same_prefix = std::all_of(j.begin(), j.end(),
+                                                         [this, first_prefix, use_bjdata](const BasicJsonType & v)
+                    {
+                        return ubjson_prefix(v, use_bjdata) == first_prefix;
+                    });
+
+                    std::vector<CharType> bjdx = {'[', '{', 'S', 'H', 'T', 'F', 'N', 'Z'}; // excluded markers in bjdata optimized type
+
+                    if (same_prefix && !(use_bjdata && std::find(bjdx.begin(), bjdx.end(), first_prefix) != bjdx.end()))
+                    {
+                        prefix_required = false;
+                        oa->write_character(to_char_type('$'));
+                        oa->write_character(first_prefix);
+                    }
+                }
+
+                if (use_count)
+                {
+                    oa->write_character(to_char_type('#'));
+                    write_number_with_ubjson_prefix(j.m_data.m_value.object->size(), true, use_bjdata);
+                }
+
+                for (const auto& el : *j.m_data.m_value.object)
+                {
+                    write_number_with_ubjson_prefix(el.first.size(), true, use_bjdata);
+                    oa->write_characters(
+                        reinterpret_cast<const CharType*>(el.first.c_str()),
+                        el.first.size());
+                    write_ubjson(el.second, use_count, use_type, prefix_required, use_bjdata);
+                }
+
+                if (!use_count)
+                {
+                    oa->write_character(to_char_type('}'));
+                }
+
+                break;
+            }
+
+            case value_t::discarded:
+            default:
+                break;
+        }
+    }
+
+  private:
+    //////////
+    // BSON //
+    //////////
+
+    /*!
+    @return The size of a BSON document entry header, including the id marker
+            and the entry name size (and its null-terminator).
+    */
+    static std::size_t calc_bson_entry_header_size(const string_t& name, const BasicJsonType& j)
+    {
+        const auto it = name.find(static_cast<typename string_t::value_type>(0));
+        if (JSON_HEDLEY_UNLIKELY(it != BasicJsonType::string_t::npos))
+        {
+            JSON_THROW(out_of_range::create(409, concat("BSON key cannot contain code point U+0000 (at byte ", std::to_string(it), ")"), &j));
+            static_cast<void>(j);
+        }
+
+        return /*id*/ 1ul + name.size() + /*zero-terminator*/1u;
+    }
+
+    /*!
+    @brief Writes the given @a element_type and @a name to the output adapter
+    */
+    void write_bson_entry_header(const string_t& name,
+                                 const std::uint8_t element_type)
+    {
+        oa->write_character(to_char_type(element_type)); // boolean
+        oa->write_characters(
+            reinterpret_cast<const CharType*>(name.c_str()),
+            name.size() + 1u);
+    }
+
+    /*!
+    @brief Writes a BSON element with key @a name and boolean value @a value
+    */
+    void write_bson_boolean(const string_t& name,
+                            const bool value)
+    {
+        write_bson_entry_header(name, 0x08);
+        oa->write_character(value ? to_char_type(0x01) : to_char_type(0x00));
+    }
+
+    /*!
+    @brief Writes a BSON element with key @a name and double value @a value
+    */
+    void write_bson_double(const string_t& name,
+                           const double value)
+    {
+        write_bson_entry_header(name, 0x01);
+        write_number<double>(value, true);
+    }
+
+    /*!
+    @return The size of the BSON-encoded string in @a value
+    */
+    static std::size_t calc_bson_string_size(const string_t& value)
+    {
+        return sizeof(std::int32_t) + value.size() + 1ul;
+    }
+
+    /*!
+    @brief Writes a BSON element with key @a name and string value @a value
+    */
+    void write_bson_string(const string_t& name,
+                           const string_t& value)
+    {
+        write_bson_entry_header(name, 0x02);
+
+        write_number<std::int32_t>(static_cast<std::int32_t>(value.size() + 1ul), true);
+        oa->write_characters(
+            reinterpret_cast<const CharType*>(value.c_str()),
+            value.size() + 1);
+    }
+
+    /*!
+    @brief Writes a BSON element with key @a name and null value
+    */
+    void write_bson_null(const string_t& name)
+    {
+        write_bson_entry_header(name, 0x0A);
+    }
+
+    /*!
+    @return The size of the BSON-encoded integer @a value
+    */
+    static std::size_t calc_bson_integer_size(const std::int64_t value)
+    {
+        return (std::numeric_limits<std::int32_t>::min)() <= value && value <= (std::numeric_limits<std::int32_t>::max)()
+               ? sizeof(std::int32_t)
+               : sizeof(std::int64_t);
+    }
+
+    /*!
+    @brief Writes a BSON element with key @a name and integer @a value
+    */
+    void write_bson_integer(const string_t& name,
+                            const std::int64_t value)
+    {
+        if ((std::numeric_limits<std::int32_t>::min)() <= value && value <= (std::numeric_limits<std::int32_t>::max)())
+        {
+            write_bson_entry_header(name, 0x10); // int32
+            write_number<std::int32_t>(static_cast<std::int32_t>(value), true);
+        }
+        else
+        {
+            write_bson_entry_header(name, 0x12); // int64
+            write_number<std::int64_t>(static_cast<std::int64_t>(value), true);
+        }
+    }
+
+    /*!
+    @return The size of the BSON-encoded unsigned integer in @a j
+    */
+    static constexpr std::size_t calc_bson_unsigned_size(const std::uint64_t value) noexcept
+    {
+        return (value <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
+               ? sizeof(std::int32_t)
+               : sizeof(std::int64_t);
+    }
+
+    /*!
+    @brief Writes a BSON element with key @a name and unsigned @a value
+    */
+    void write_bson_unsigned(const string_t& name,
+                             const BasicJsonType& j)
+    {
+        if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
+        {
+            write_bson_entry_header(name, 0x10 /* int32 */);
+            write_number<std::int32_t>(static_cast<std::int32_t>(j.m_data.m_value.number_unsigned), true);
+        }
+        else if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)()))
+        {
+            write_bson_entry_header(name, 0x12 /* int64 */);
+            write_number<std::int64_t>(static_cast<std::int64_t>(j.m_data.m_value.number_unsigned), true);
+        }
+        else
+        {
+            JSON_THROW(out_of_range::create(407, concat("integer number ", std::to_string(j.m_data.m_value.number_unsigned), " cannot be represented by BSON as it does not fit int64"), &j));
+        }
+    }
+
+    /*!
+    @brief Writes a BSON element with key @a name and object @a value
+    */
+    void write_bson_object_entry(const string_t& name,
+                                 const typename BasicJsonType::object_t& value)
+    {
+        write_bson_entry_header(name, 0x03); // object
+        write_bson_object(value);
+    }
+
+    /*!
+    @return The size of the BSON-encoded array @a value
+    */
+    static std::size_t calc_bson_array_size(const typename BasicJsonType::array_t& value)
+    {
+        std::size_t array_index = 0ul;
+
+        const std::size_t embedded_document_size = std::accumulate(std::begin(value), std::end(value), static_cast<std::size_t>(0), [&array_index](std::size_t result, const typename BasicJsonType::array_t::value_type & el)
+        {
+            return result + calc_bson_element_size(std::to_string(array_index++), el);
+        });
+
+        return sizeof(std::int32_t) + embedded_document_size + 1ul;
+    }
+
+    /*!
+    @return The size of the BSON-encoded binary array @a value
+    */
+    static std::size_t calc_bson_binary_size(const typename BasicJsonType::binary_t& value)
+    {
+        return sizeof(std::int32_t) + value.size() + 1ul;
+    }
+
+    /*!
+    @brief Writes a BSON element with key @a name and array @a value
+    */
+    void write_bson_array(const string_t& name,
+                          const typename BasicJsonType::array_t& value)
+    {
+        write_bson_entry_header(name, 0x04); // array
+        write_number<std::int32_t>(static_cast<std::int32_t>(calc_bson_array_size(value)), true);
+
+        std::size_t array_index = 0ul;
+
+        for (const auto& el : value)
+        {
+            write_bson_element(std::to_string(array_index++), el);
+        }
+
+        oa->write_character(to_char_type(0x00));
+    }
+
+    /*!
+    @brief Writes a BSON element with key @a name and binary value @a value
+    */
+    void write_bson_binary(const string_t& name,
+                           const binary_t& value)
+    {
+        write_bson_entry_header(name, 0x05);
+
+        write_number<std::int32_t>(static_cast<std::int32_t>(value.size()), true);
+        write_number(value.has_subtype() ? static_cast<std::uint8_t>(value.subtype()) : static_cast<std::uint8_t>(0x00));
+
+        oa->write_characters(reinterpret_cast<const CharType*>(value.data()), value.size());
+    }
+
+    /*!
+    @brief Calculates the size necessary to serialize the JSON value @a j with its @a name
+    @return The calculated size for the BSON document entry for @a j with the given @a name.
+    */
+    static std::size_t calc_bson_element_size(const string_t& name,
+            const BasicJsonType& j)
+    {
+        const auto header_size = calc_bson_entry_header_size(name, j);
+        switch (j.type())
+        {
+            case value_t::object:
+                return header_size + calc_bson_object_size(*j.m_data.m_value.object);
+
+            case value_t::array:
+                return header_size + calc_bson_array_size(*j.m_data.m_value.array);
+
+            case value_t::binary:
+                return header_size + calc_bson_binary_size(*j.m_data.m_value.binary);
+
+            case value_t::boolean:
+                return header_size + 1ul;
+
+            case value_t::number_float:
+                return header_size + 8ul;
+
+            case value_t::number_integer:
+                return header_size + calc_bson_integer_size(j.m_data.m_value.number_integer);
+
+            case value_t::number_unsigned:
+                return header_size + calc_bson_unsigned_size(j.m_data.m_value.number_unsigned);
+
+            case value_t::string:
+                return header_size + calc_bson_string_size(*j.m_data.m_value.string);
+
+            case value_t::null:
+                return header_size + 0ul;
+
+            // LCOV_EXCL_START
+            case value_t::discarded:
+            default:
+                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert)
+                return 0ul;
+                // LCOV_EXCL_STOP
+        }
+    }
+
+    /*!
+    @brief Serializes the JSON value @a j to BSON and associates it with the
+           key @a name.
+    @param name The name to associate with the JSON entity @a j within the
+                current BSON document
+    */
+    void write_bson_element(const string_t& name,
+                            const BasicJsonType& j)
+    {
+        switch (j.type())
+        {
+            case value_t::object:
+                return write_bson_object_entry(name, *j.m_data.m_value.object);
+
+            case value_t::array:
+                return write_bson_array(name, *j.m_data.m_value.array);
+
+            case value_t::binary:
+                return write_bson_binary(name, *j.m_data.m_value.binary);
+
+            case value_t::boolean:
+                return write_bson_boolean(name, j.m_data.m_value.boolean);
+
+            case value_t::number_float:
+                return write_bson_double(name, j.m_data.m_value.number_float);
+
+            case value_t::number_integer:
+                return write_bson_integer(name, j.m_data.m_value.number_integer);
+
+            case value_t::number_unsigned:
+                return write_bson_unsigned(name, j);
+
+            case value_t::string:
+                return write_bson_string(name, *j.m_data.m_value.string);
+
+            case value_t::null:
+                return write_bson_null(name);
+
+            // LCOV_EXCL_START
+            case value_t::discarded:
+            default:
+                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert)
+                return;
+                // LCOV_EXCL_STOP
+        }
+    }
+
+    /*!
+    @brief Calculates the size of the BSON serialization of the given
+           JSON-object @a j.
+    @param[in] value  JSON value to serialize
+    @pre       value.type() == value_t::object
+    */
+    static std::size_t calc_bson_object_size(const typename BasicJsonType::object_t& value)
+    {
+        const std::size_t document_size = std::accumulate(value.begin(), value.end(), static_cast<std::size_t>(0),
+                                          [](size_t result, const typename BasicJsonType::object_t::value_type & el)
+        {
+            return result += calc_bson_element_size(el.first, el.second);
+        });
+
+        return sizeof(std::int32_t) + document_size + 1ul;
+    }
+
+    /*!
+    @param[in] value  JSON value to serialize
+    @pre       value.type() == value_t::object
+    */
+    void write_bson_object(const typename BasicJsonType::object_t& value)
+    {
+        write_number<std::int32_t>(static_cast<std::int32_t>(calc_bson_object_size(value)), true);
+
+        for (const auto& el : value)
+        {
+            write_bson_element(el.first, el.second);
+        }
+
+        oa->write_character(to_char_type(0x00));
+    }
+
+    //////////
+    // CBOR //
+    //////////
+
+    static constexpr CharType get_cbor_float_prefix(float /*unused*/)
+    {
+        return to_char_type(0xFA);  // Single-Precision Float
+    }
+
+    static constexpr CharType get_cbor_float_prefix(double /*unused*/)
+    {
+        return to_char_type(0xFB);  // Double-Precision Float
+    }
+
+    /////////////
+    // MsgPack //
+    /////////////
+
+    static constexpr CharType get_msgpack_float_prefix(float /*unused*/)
+    {
+        return to_char_type(0xCA);  // float 32
+    }
+
+    static constexpr CharType get_msgpack_float_prefix(double /*unused*/)
+    {
+        return to_char_type(0xCB);  // float 64
+    }
+
+    ////////////
+    // UBJSON //
+    ////////////
+
+    // UBJSON: write number (floating point)
+    template<typename NumberType, typename std::enable_if<
+                 std::is_floating_point<NumberType>::value, int>::type = 0>
+    void write_number_with_ubjson_prefix(const NumberType n,
+                                         const bool add_prefix,
+                                         const bool use_bjdata)
+    {
+        if (add_prefix)
+        {
+            oa->write_character(get_ubjson_float_prefix(n));
+        }
+        write_number(n, use_bjdata);
+    }
+
+    // UBJSON: write number (unsigned integer)
+    template<typename NumberType, typename std::enable_if<
+                 std::is_unsigned<NumberType>::value, int>::type = 0>
+    void write_number_with_ubjson_prefix(const NumberType n,
+                                         const bool add_prefix,
+                                         const bool use_bjdata)
+    {
+        if (n <= static_cast<std::uint64_t>((std::numeric_limits<std::int8_t>::max)()))
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('i'));  // int8
+            }
+            write_number(static_cast<std::uint8_t>(n), use_bjdata);
+        }
+        else if (n <= (std::numeric_limits<std::uint8_t>::max)())
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('U'));  // uint8
+            }
+            write_number(static_cast<std::uint8_t>(n), use_bjdata);
+        }
+        else if (n <= static_cast<std::uint64_t>((std::numeric_limits<std::int16_t>::max)()))
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('I'));  // int16
+            }
+            write_number(static_cast<std::int16_t>(n), use_bjdata);
+        }
+        else if (use_bjdata && n <= static_cast<uint64_t>((std::numeric_limits<uint16_t>::max)()))
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('u'));  // uint16 - bjdata only
+            }
+            write_number(static_cast<std::uint16_t>(n), use_bjdata);
+        }
+        else if (n <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('l'));  // int32
+            }
+            write_number(static_cast<std::int32_t>(n), use_bjdata);
+        }
+        else if (use_bjdata && n <= static_cast<uint64_t>((std::numeric_limits<uint32_t>::max)()))
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('m'));  // uint32 - bjdata only
+            }
+            write_number(static_cast<std::uint32_t>(n), use_bjdata);
+        }
+        else if (n <= static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)()))
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('L'));  // int64
+            }
+            write_number(static_cast<std::int64_t>(n), use_bjdata);
+        }
+        else if (use_bjdata && n <= (std::numeric_limits<uint64_t>::max)())
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('M'));  // uint64 - bjdata only
+            }
+            write_number(static_cast<std::uint64_t>(n), use_bjdata);
+        }
+        else
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('H'));  // high-precision number
+            }
+
+            const auto number = BasicJsonType(n).dump();
+            write_number_with_ubjson_prefix(number.size(), true, use_bjdata);
+            for (std::size_t i = 0; i < number.size(); ++i)
+            {
+                oa->write_character(to_char_type(static_cast<std::uint8_t>(number[i])));
+            }
+        }
+    }
+
+    // UBJSON: write number (signed integer)
+    template < typename NumberType, typename std::enable_if <
+                   std::is_signed<NumberType>::value&&
+                   !std::is_floating_point<NumberType>::value, int >::type = 0 >
+    void write_number_with_ubjson_prefix(const NumberType n,
+                                         const bool add_prefix,
+                                         const bool use_bjdata)
+    {
+        if ((std::numeric_limits<std::int8_t>::min)() <= n && n <= (std::numeric_limits<std::int8_t>::max)())
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('i'));  // int8
+            }
+            write_number(static_cast<std::int8_t>(n), use_bjdata);
+        }
+        else if (static_cast<std::int64_t>((std::numeric_limits<std::uint8_t>::min)()) <= n && n <= static_cast<std::int64_t>((std::numeric_limits<std::uint8_t>::max)()))
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('U'));  // uint8
+            }
+            write_number(static_cast<std::uint8_t>(n), use_bjdata);
+        }
+        else if ((std::numeric_limits<std::int16_t>::min)() <= n && n <= (std::numeric_limits<std::int16_t>::max)())
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('I'));  // int16
+            }
+            write_number(static_cast<std::int16_t>(n), use_bjdata);
+        }
+        else if (use_bjdata && (static_cast<std::int64_t>((std::numeric_limits<std::uint16_t>::min)()) <= n && n <= static_cast<std::int64_t>((std::numeric_limits<std::uint16_t>::max)())))
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('u'));  // uint16 - bjdata only
+            }
+            write_number(static_cast<uint16_t>(n), use_bjdata);
+        }
+        else if ((std::numeric_limits<std::int32_t>::min)() <= n && n <= (std::numeric_limits<std::int32_t>::max)())
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('l'));  // int32
+            }
+            write_number(static_cast<std::int32_t>(n), use_bjdata);
+        }
+        else if (use_bjdata && (static_cast<std::int64_t>((std::numeric_limits<std::uint32_t>::min)()) <= n && n <= static_cast<std::int64_t>((std::numeric_limits<std::uint32_t>::max)())))
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('m'));  // uint32 - bjdata only
+            }
+            write_number(static_cast<uint32_t>(n), use_bjdata);
+        }
+        else if ((std::numeric_limits<std::int64_t>::min)() <= n && n <= (std::numeric_limits<std::int64_t>::max)())
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('L'));  // int64
+            }
+            write_number(static_cast<std::int64_t>(n), use_bjdata);
+        }
+        // LCOV_EXCL_START
+        else
+        {
+            if (add_prefix)
+            {
+                oa->write_character(to_char_type('H'));  // high-precision number
+            }
+
+            const auto number = BasicJsonType(n).dump();
+            write_number_with_ubjson_prefix(number.size(), true, use_bjdata);
+            for (std::size_t i = 0; i < number.size(); ++i)
+            {
+                oa->write_character(to_char_type(static_cast<std::uint8_t>(number[i])));
+            }
+        }
+        // LCOV_EXCL_STOP
+    }
+
+    /*!
+    @brief determine the type prefix of container values
+    */
+    CharType ubjson_prefix(const BasicJsonType& j, const bool use_bjdata) const noexcept
+    {
+        switch (j.type())
+        {
+            case value_t::null:
+                return 'Z';
+
+            case value_t::boolean:
+                return j.m_data.m_value.boolean ? 'T' : 'F';
+
+            case value_t::number_integer:
+            {
+                if ((std::numeric_limits<std::int8_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::int8_t>::max)())
+                {
+                    return 'i';
+                }
+                if ((std::numeric_limits<std::uint8_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint8_t>::max)())
+                {
+                    return 'U';
+                }
+                if ((std::numeric_limits<std::int16_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::int16_t>::max)())
+                {
+                    return 'I';
+                }
+                if (use_bjdata && ((std::numeric_limits<std::uint16_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint16_t>::max)()))
+                {
+                    return 'u';
+                }
+                if ((std::numeric_limits<std::int32_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::int32_t>::max)())
+                {
+                    return 'l';
+                }
+                if (use_bjdata && ((std::numeric_limits<std::uint32_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::uint32_t>::max)()))
+                {
+                    return 'm';
+                }
+                if ((std::numeric_limits<std::int64_t>::min)() <= j.m_data.m_value.number_integer && j.m_data.m_value.number_integer <= (std::numeric_limits<std::int64_t>::max)())
+                {
+                    return 'L';
+                }
+                // anything else is treated as high-precision number
+                return 'H'; // LCOV_EXCL_LINE
+            }
+
+            case value_t::number_unsigned:
+            {
+                if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int8_t>::max)()))
+                {
+                    return 'i';
+                }
+                if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::uint8_t>::max)()))
+                {
+                    return 'U';
+                }
+                if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int16_t>::max)()))
+                {
+                    return 'I';
+                }
+                if (use_bjdata && j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::uint16_t>::max)()))
+                {
+                    return 'u';
+                }
+                if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int32_t>::max)()))
+                {
+                    return 'l';
+                }
+                if (use_bjdata && j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::uint32_t>::max)()))
+                {
+                    return 'm';
+                }
+                if (j.m_data.m_value.number_unsigned <= static_cast<std::uint64_t>((std::numeric_limits<std::int64_t>::max)()))
+                {
+                    return 'L';
+                }
+                if (use_bjdata && j.m_data.m_value.number_unsigned <= (std::numeric_limits<std::uint64_t>::max)())
+                {
+                    return 'M';
+                }
+                // anything else is treated as high-precision number
+                return 'H'; // LCOV_EXCL_LINE
+            }
+
+            case value_t::number_float:
+                return get_ubjson_float_prefix(j.m_data.m_value.number_float);
+
+            case value_t::string:
+                return 'S';
+
+            case value_t::array: // fallthrough
+            case value_t::binary:
+                return '[';
+
+            case value_t::object:
+                return '{';
+
+            case value_t::discarded:
+            default:  // discarded values
+                return 'N';
+        }
+    }
+
+    static constexpr CharType get_ubjson_float_prefix(float /*unused*/)
+    {
+        return 'd';  // float 32
+    }
+
+    static constexpr CharType get_ubjson_float_prefix(double /*unused*/)
+    {
+        return 'D';  // float 64
+    }
+
+    /*!
+    @return false if the object is successfully converted to a bjdata ndarray, true if the type or size is invalid
+    */
+    bool write_bjdata_ndarray(const typename BasicJsonType::object_t& value, const bool use_count, const bool use_type)
+    {
+        std::map<string_t, CharType> bjdtype = {{"uint8", 'U'},  {"int8", 'i'},  {"uint16", 'u'}, {"int16", 'I'},
+            {"uint32", 'm'}, {"int32", 'l'}, {"uint64", 'M'}, {"int64", 'L'}, {"single", 'd'}, {"double", 'D'}, {"char", 'C'}
+        };
+
+        string_t key = "_ArrayType_";
+        auto it = bjdtype.find(static_cast<string_t>(value.at(key)));
+        if (it == bjdtype.end())
+        {
+            return true;
+        }
+        CharType dtype = it->second;
+
+        key = "_ArraySize_";
+        std::size_t len = (value.at(key).empty() ? 0 : 1);
+        for (const auto& el : value.at(key))
+        {
+            len *= static_cast<std::size_t>(el.m_data.m_value.number_unsigned);
+        }
+
+        key = "_ArrayData_";
+        if (value.at(key).size() != len)
+        {
+            return true;
+        }
+
+        oa->write_character('[');
+        oa->write_character('$');
+        oa->write_character(dtype);
+        oa->write_character('#');
+
+        key = "_ArraySize_";
+        write_ubjson(value.at(key), use_count, use_type, true,  true);
+
+        key = "_ArrayData_";
+        if (dtype == 'U' || dtype == 'C')
+        {
+            for (const auto& el : value.at(key))
+            {
+                write_number(static_cast<std::uint8_t>(el.m_data.m_value.number_unsigned), true);
+            }
+        }
+        else if (dtype == 'i')
+        {
+            for (const auto& el : value.at(key))
+            {
+                write_number(static_cast<std::int8_t>(el.m_data.m_value.number_integer), true);
+            }
+        }
+        else if (dtype == 'u')
+        {
+            for (const auto& el : value.at(key))
+            {
+                write_number(static_cast<std::uint16_t>(el.m_data.m_value.number_unsigned), true);
+            }
+        }
+        else if (dtype == 'I')
+        {
+            for (const auto& el : value.at(key))
+            {
+                write_number(static_cast<std::int16_t>(el.m_data.m_value.number_integer), true);
+            }
+        }
+        else if (dtype == 'm')
+        {
+            for (const auto& el : value.at(key))
+            {
+                write_number(static_cast<std::uint32_t>(el.m_data.m_value.number_unsigned), true);
+            }
+        }
+        else if (dtype == 'l')
+        {
+            for (const auto& el : value.at(key))
+            {
+                write_number(static_cast<std::int32_t>(el.m_data.m_value.number_integer), true);
+            }
+        }
+        else if (dtype == 'M')
+        {
+            for (const auto& el : value.at(key))
+            {
+                write_number(static_cast<std::uint64_t>(el.m_data.m_value.number_unsigned), true);
+            }
+        }
+        else if (dtype == 'L')
+        {
+            for (const auto& el : value.at(key))
+            {
+                write_number(static_cast<std::int64_t>(el.m_data.m_value.number_integer), true);
+            }
+        }
+        else if (dtype == 'd')
+        {
+            for (const auto& el : value.at(key))
+            {
+                write_number(static_cast<float>(el.m_data.m_value.number_float), true);
+            }
+        }
+        else if (dtype == 'D')
+        {
+            for (const auto& el : value.at(key))
+            {
+                write_number(static_cast<double>(el.m_data.m_value.number_float), true);
+            }
+        }
+        return false;
+    }
+
+    ///////////////////////
+    // Utility functions //
+    ///////////////////////
+
+    /*
+    @brief write a number to output input
+    @param[in] n number of type @a NumberType
+    @param[in] OutputIsLittleEndian Set to true if output data is
+                                 required to be little endian
+    @tparam NumberType the type of the number
+
+    @note This function needs to respect the system's endianness, because bytes
+          in CBOR, MessagePack, and UBJSON are stored in network order (big
+          endian) and therefore need reordering on little endian systems.
+          On the other hand, BSON and BJData use little endian and should reorder
+          on big endian systems.
+    */
+    template<typename NumberType>
+    void write_number(const NumberType n, const bool OutputIsLittleEndian = false)
+    {
+        // step 1: write number to array of length NumberType
+        std::array<CharType, sizeof(NumberType)> vec{};
+        std::memcpy(vec.data(), &n, sizeof(NumberType));
+
+        // step 2: write array to output (with possible reordering)
+        if (is_little_endian != OutputIsLittleEndian)
+        {
+            // reverse byte order prior to conversion if necessary
+            std::reverse(vec.begin(), vec.end());
+        }
+
+        oa->write_characters(vec.data(), sizeof(NumberType));
+    }
+
+    void write_compact_float(const number_float_t n, detail::input_format_t format)
+    {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+        if (static_cast<double>(n) >= static_cast<double>(std::numeric_limits<float>::lowest()) &&
+                static_cast<double>(n) <= static_cast<double>((std::numeric_limits<float>::max)()) &&
+                static_cast<double>(static_cast<float>(n)) == static_cast<double>(n))
+        {
+            oa->write_character(format == detail::input_format_t::cbor
+                                ? get_cbor_float_prefix(static_cast<float>(n))
+                                : get_msgpack_float_prefix(static_cast<float>(n)));
+            write_number(static_cast<float>(n));
+        }
+        else
+        {
+            oa->write_character(format == detail::input_format_t::cbor
+                                ? get_cbor_float_prefix(n)
+                                : get_msgpack_float_prefix(n));
+            write_number(n);
+        }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+    }
+
+  public:
+    // The following to_char_type functions are implement the conversion
+    // between uint8_t and CharType. In case CharType is not unsigned,
+    // such a conversion is required to allow values greater than 128.
+    // See <https://github.com/nlohmann/json/issues/1286> for a discussion.
+    template < typename C = CharType,
+               enable_if_t < std::is_signed<C>::value && std::is_signed<char>::value > * = nullptr >
+    static constexpr CharType to_char_type(std::uint8_t x) noexcept
+    {
+        return *reinterpret_cast<char*>(&x);
+    }
+
+    template < typename C = CharType,
+               enable_if_t < std::is_signed<C>::value && std::is_unsigned<char>::value > * = nullptr >
+    static CharType to_char_type(std::uint8_t x) noexcept
+    {
+        static_assert(sizeof(std::uint8_t) == sizeof(CharType), "size of CharType must be equal to std::uint8_t");
+        static_assert(std::is_trivial<CharType>::value, "CharType must be trivial");
+        CharType result;
+        std::memcpy(&result, &x, sizeof(x));
+        return result;
+    }
+
+    template<typename C = CharType,
+             enable_if_t<std::is_unsigned<C>::value>* = nullptr>
+    static constexpr CharType to_char_type(std::uint8_t x) noexcept
+    {
+        return x;
+    }
+
+    template < typename InputCharType, typename C = CharType,
+               enable_if_t <
+                   std::is_signed<C>::value &&
+                   std::is_signed<char>::value &&
+                   std::is_same<char, typename std::remove_cv<InputCharType>::type>::value
+                   > * = nullptr >
+    static constexpr CharType to_char_type(InputCharType x) noexcept
+    {
+        return x;
+    }
+
+  private:
+    /// whether we can assume little endianness
+    const bool is_little_endian = little_endianness();
+
+    /// the output
+    output_adapter_t<CharType> oa = nullptr;
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/output/output_adapters.hpp>
+
+// #include <nlohmann/detail/output/serializer.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2008-2009 Björn Hoehrmann <bjoern@hoehrmann.de>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <algorithm> // reverse, remove, fill, find, none_of
+#include <array> // array
+#include <clocale> // localeconv, lconv
+#include <cmath> // labs, isfinite, isnan, signbit
+#include <cstddef> // size_t, ptrdiff_t
+#include <cstdint> // uint8_t
+#include <cstdio> // snprintf
+#include <limits> // numeric_limits
+#include <string> // string, char_traits
+#include <iomanip> // setfill, setw
+#include <type_traits> // is_same
+#include <utility> // move
+
+// #include <nlohmann/detail/conversions/to_chars.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2009 Florian Loitsch <https://florian.loitsch.com/>
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <array> // array
+#include <cmath>   // signbit, isfinite
+#include <cstdint> // intN_t, uintN_t
+#include <cstring> // memcpy, memmove
+#include <limits> // numeric_limits
+#include <type_traits> // conditional
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+/*!
+@brief implements the Grisu2 algorithm for binary to decimal floating-point
+conversion.
+
+This implementation is a slightly modified version of the reference
+implementation which may be obtained from
+http://florian.loitsch.com/publications (bench.tar.gz).
+
+The code is distributed under the MIT license, Copyright (c) 2009 Florian Loitsch.
+
+For a detailed description of the algorithm see:
+
+[1] Loitsch, "Printing Floating-Point Numbers Quickly and Accurately with
+    Integers", Proceedings of the ACM SIGPLAN 2010 Conference on Programming
+    Language Design and Implementation, PLDI 2010
+[2] Burger, Dybvig, "Printing Floating-Point Numbers Quickly and Accurately",
+    Proceedings of the ACM SIGPLAN 1996 Conference on Programming Language
+    Design and Implementation, PLDI 1996
+*/
+namespace dtoa_impl
+{
+
+template<typename Target, typename Source>
+Target reinterpret_bits(const Source source)
+{
+    static_assert(sizeof(Target) == sizeof(Source), "size mismatch");
+
+    Target target;
+    std::memcpy(&target, &source, sizeof(Source));
+    return target;
+}
+
+struct diyfp // f * 2^e
+{
+    static constexpr int kPrecision = 64; // = q
+
+    std::uint64_t f = 0;
+    int e = 0;
+
+    constexpr diyfp(std::uint64_t f_, int e_) noexcept : f(f_), e(e_) {}
+
+    /*!
+    @brief returns x - y
+    @pre x.e == y.e and x.f >= y.f
+    */
+    static diyfp sub(const diyfp& x, const diyfp& y) noexcept
+    {
+        JSON_ASSERT(x.e == y.e);
+        JSON_ASSERT(x.f >= y.f);
+
+        return {x.f - y.f, x.e};
+    }
+
+    /*!
+    @brief returns x * y
+    @note The result is rounded. (Only the upper q bits are returned.)
+    */
+    static diyfp mul(const diyfp& x, const diyfp& y) noexcept
+    {
+        static_assert(kPrecision == 64, "internal error");
+
+        // Computes:
+        //  f = round((x.f * y.f) / 2^q)
+        //  e = x.e + y.e + q
+
+        // Emulate the 64-bit * 64-bit multiplication:
+        //
+        // p = u * v
+        //   = (u_lo + 2^32 u_hi) (v_lo + 2^32 v_hi)
+        //   = (u_lo v_lo         ) + 2^32 ((u_lo v_hi         ) + (u_hi v_lo         )) + 2^64 (u_hi v_hi         )
+        //   = (p0                ) + 2^32 ((p1                ) + (p2                )) + 2^64 (p3                )
+        //   = (p0_lo + 2^32 p0_hi) + 2^32 ((p1_lo + 2^32 p1_hi) + (p2_lo + 2^32 p2_hi)) + 2^64 (p3                )
+        //   = (p0_lo             ) + 2^32 (p0_hi + p1_lo + p2_lo                      ) + 2^64 (p1_hi + p2_hi + p3)
+        //   = (p0_lo             ) + 2^32 (Q                                          ) + 2^64 (H                 )
+        //   = (p0_lo             ) + 2^32 (Q_lo + 2^32 Q_hi                           ) + 2^64 (H                 )
+        //
+        // (Since Q might be larger than 2^32 - 1)
+        //
+        //   = (p0_lo + 2^32 Q_lo) + 2^64 (Q_hi + H)
+        //
+        // (Q_hi + H does not overflow a 64-bit int)
+        //
+        //   = p_lo + 2^64 p_hi
+
+        const std::uint64_t u_lo = x.f & 0xFFFFFFFFu;
+        const std::uint64_t u_hi = x.f >> 32u;
+        const std::uint64_t v_lo = y.f & 0xFFFFFFFFu;
+        const std::uint64_t v_hi = y.f >> 32u;
+
+        const std::uint64_t p0 = u_lo * v_lo;
+        const std::uint64_t p1 = u_lo * v_hi;
+        const std::uint64_t p2 = u_hi * v_lo;
+        const std::uint64_t p3 = u_hi * v_hi;
+
+        const std::uint64_t p0_hi = p0 >> 32u;
+        const std::uint64_t p1_lo = p1 & 0xFFFFFFFFu;
+        const std::uint64_t p1_hi = p1 >> 32u;
+        const std::uint64_t p2_lo = p2 & 0xFFFFFFFFu;
+        const std::uint64_t p2_hi = p2 >> 32u;
+
+        std::uint64_t Q = p0_hi + p1_lo + p2_lo;
+
+        // The full product might now be computed as
+        //
+        // p_hi = p3 + p2_hi + p1_hi + (Q >> 32)
+        // p_lo = p0_lo + (Q << 32)
+        //
+        // But in this particular case here, the full p_lo is not required.
+        // Effectively we only need to add the highest bit in p_lo to p_hi (and
+        // Q_hi + 1 does not overflow).
+
+        Q += std::uint64_t{1} << (64u - 32u - 1u); // round, ties up
+
+        const std::uint64_t h = p3 + p2_hi + p1_hi + (Q >> 32u);
+
+        return {h, x.e + y.e + 64};
+    }
+
+    /*!
+    @brief normalize x such that the significand is >= 2^(q-1)
+    @pre x.f != 0
+    */
+    static diyfp normalize(diyfp x) noexcept
+    {
+        JSON_ASSERT(x.f != 0);
+
+        while ((x.f >> 63u) == 0)
+        {
+            x.f <<= 1u;
+            x.e--;
+        }
+
+        return x;
+    }
+
+    /*!
+    @brief normalize x such that the result has the exponent E
+    @pre e >= x.e and the upper e - x.e bits of x.f must be zero.
+    */
+    static diyfp normalize_to(const diyfp& x, const int target_exponent) noexcept
+    {
+        const int delta = x.e - target_exponent;
+
+        JSON_ASSERT(delta >= 0);
+        JSON_ASSERT(((x.f << delta) >> delta) == x.f);
+
+        return {x.f << delta, target_exponent};
+    }
+};
+
+struct boundaries
+{
+    diyfp w;
+    diyfp minus;
+    diyfp plus;
+};
+
+/*!
+Compute the (normalized) diyfp representing the input number 'value' and its
+boundaries.
+
+@pre value must be finite and positive
+*/
+template<typename FloatType>
+boundaries compute_boundaries(FloatType value)
+{
+    JSON_ASSERT(std::isfinite(value));
+    JSON_ASSERT(value > 0);
+
+    // Convert the IEEE representation into a diyfp.
+    //
+    // If v is denormal:
+    //      value = 0.F * 2^(1 - bias) = (          F) * 2^(1 - bias - (p-1))
+    // If v is normalized:
+    //      value = 1.F * 2^(E - bias) = (2^(p-1) + F) * 2^(E - bias - (p-1))
+
+    static_assert(std::numeric_limits<FloatType>::is_iec559,
+                  "internal error: dtoa_short requires an IEEE-754 floating-point implementation");
+
+    constexpr int      kPrecision = std::numeric_limits<FloatType>::digits; // = p (includes the hidden bit)
+    constexpr int      kBias      = std::numeric_limits<FloatType>::max_exponent - 1 + (kPrecision - 1);
+    constexpr int      kMinExp    = 1 - kBias;
+    constexpr std::uint64_t kHiddenBit = std::uint64_t{1} << (kPrecision - 1); // = 2^(p-1)
+
+    using bits_type = typename std::conditional<kPrecision == 24, std::uint32_t, std::uint64_t >::type;
+
+    const auto bits = static_cast<std::uint64_t>(reinterpret_bits<bits_type>(value));
+    const std::uint64_t E = bits >> (kPrecision - 1);
+    const std::uint64_t F = bits & (kHiddenBit - 1);
+
+    const bool is_denormal = E == 0;
+    const diyfp v = is_denormal
+                    ? diyfp(F, kMinExp)
+                    : diyfp(F + kHiddenBit, static_cast<int>(E) - kBias);
+
+    // Compute the boundaries m- and m+ of the floating-point value
+    // v = f * 2^e.
+    //
+    // Determine v- and v+, the floating-point predecessor and successor if v,
+    // respectively.
+    //
+    //      v- = v - 2^e        if f != 2^(p-1) or e == e_min                (A)
+    //         = v - 2^(e-1)    if f == 2^(p-1) and e > e_min                (B)
+    //
+    //      v+ = v + 2^e
+    //
+    // Let m- = (v- + v) / 2 and m+ = (v + v+) / 2. All real numbers _strictly_
+    // between m- and m+ round to v, regardless of how the input rounding
+    // algorithm breaks ties.
+    //
+    //      ---+-------------+-------------+-------------+-------------+---  (A)
+    //         v-            m-            v             m+            v+
+    //
+    //      -----------------+------+------+-------------+-------------+---  (B)
+    //                       v-     m-     v             m+            v+
+
+    const bool lower_boundary_is_closer = F == 0 && E > 1;
+    const diyfp m_plus = diyfp(2 * v.f + 1, v.e - 1);
+    const diyfp m_minus = lower_boundary_is_closer
+                          ? diyfp(4 * v.f - 1, v.e - 2)  // (B)
+                          : diyfp(2 * v.f - 1, v.e - 1); // (A)
+
+    // Determine the normalized w+ = m+.
+    const diyfp w_plus = diyfp::normalize(m_plus);
+
+    // Determine w- = m- such that e_(w-) = e_(w+).
+    const diyfp w_minus = diyfp::normalize_to(m_minus, w_plus.e);
+
+    return {diyfp::normalize(v), w_minus, w_plus};
+}
+
+// Given normalized diyfp w, Grisu needs to find a (normalized) cached
+// power-of-ten c, such that the exponent of the product c * w = f * 2^e lies
+// within a certain range [alpha, gamma] (Definition 3.2 from [1])
+//
+//      alpha <= e = e_c + e_w + q <= gamma
+//
+// or
+//
+//      f_c * f_w * 2^alpha <= f_c 2^(e_c) * f_w 2^(e_w) * 2^q
+//                          <= f_c * f_w * 2^gamma
+//
+// Since c and w are normalized, i.e. 2^(q-1) <= f < 2^q, this implies
+//
+//      2^(q-1) * 2^(q-1) * 2^alpha <= c * w * 2^q < 2^q * 2^q * 2^gamma
+//
+// or
+//
+//      2^(q - 2 + alpha) <= c * w < 2^(q + gamma)
+//
+// The choice of (alpha,gamma) determines the size of the table and the form of
+// the digit generation procedure. Using (alpha,gamma)=(-60,-32) works out well
+// in practice:
+//
+// The idea is to cut the number c * w = f * 2^e into two parts, which can be
+// processed independently: An integral part p1, and a fractional part p2:
+//
+//      f * 2^e = ( (f div 2^-e) * 2^-e + (f mod 2^-e) ) * 2^e
+//              = (f div 2^-e) + (f mod 2^-e) * 2^e
+//              = p1 + p2 * 2^e
+//
+// The conversion of p1 into decimal form requires a series of divisions and
+// modulos by (a power of) 10. These operations are faster for 32-bit than for
+// 64-bit integers, so p1 should ideally fit into a 32-bit integer. This can be
+// achieved by choosing
+//
+//      -e >= 32   or   e <= -32 := gamma
+//
+// In order to convert the fractional part
+//
+//      p2 * 2^e = p2 / 2^-e = d[-1] / 10^1 + d[-2] / 10^2 + ...
+//
+// into decimal form, the fraction is repeatedly multiplied by 10 and the digits
+// d[-i] are extracted in order:
+//
+//      (10 * p2) div 2^-e = d[-1]
+//      (10 * p2) mod 2^-e = d[-2] / 10^1 + ...
+//
+// The multiplication by 10 must not overflow. It is sufficient to choose
+//
+//      10 * p2 < 16 * p2 = 2^4 * p2 <= 2^64.
+//
+// Since p2 = f mod 2^-e < 2^-e,
+//
+//      -e <= 60   or   e >= -60 := alpha
+
+constexpr int kAlpha = -60;
+constexpr int kGamma = -32;
+
+struct cached_power // c = f * 2^e ~= 10^k
+{
+    std::uint64_t f;
+    int e;
+    int k;
+};
+
+/*!
+For a normalized diyfp w = f * 2^e, this function returns a (normalized) cached
+power-of-ten c = f_c * 2^e_c, such that the exponent of the product w * c
+satisfies (Definition 3.2 from [1])
+
+     alpha <= e_c + e + q <= gamma.
+*/
+inline cached_power get_cached_power_for_binary_exponent(int e)
+{
+    // Now
+    //
+    //      alpha <= e_c + e + q <= gamma                                    (1)
+    //      ==> f_c * 2^alpha <= c * 2^e * 2^q
+    //
+    // and since the c's are normalized, 2^(q-1) <= f_c,
+    //
+    //      ==> 2^(q - 1 + alpha) <= c * 2^(e + q)
+    //      ==> 2^(alpha - e - 1) <= c
+    //
+    // If c were an exact power of ten, i.e. c = 10^k, one may determine k as
+    //
+    //      k = ceil( log_10( 2^(alpha - e - 1) ) )
+    //        = ceil( (alpha - e - 1) * log_10(2) )
+    //
+    // From the paper:
+    // "In theory the result of the procedure could be wrong since c is rounded,
+    //  and the computation itself is approximated [...]. In practice, however,
+    //  this simple function is sufficient."
+    //
+    // For IEEE double precision floating-point numbers converted into
+    // normalized diyfp's w = f * 2^e, with q = 64,
+    //
+    //      e >= -1022      (min IEEE exponent)
+    //           -52        (p - 1)
+    //           -52        (p - 1, possibly normalize denormal IEEE numbers)
+    //           -11        (normalize the diyfp)
+    //         = -1137
+    //
+    // and
+    //
+    //      e <= +1023      (max IEEE exponent)
+    //           -52        (p - 1)
+    //           -11        (normalize the diyfp)
+    //         = 960
+    //
+    // This binary exponent range [-1137,960] results in a decimal exponent
+    // range [-307,324]. One does not need to store a cached power for each
+    // k in this range. For each such k it suffices to find a cached power
+    // such that the exponent of the product lies in [alpha,gamma].
+    // This implies that the difference of the decimal exponents of adjacent
+    // table entries must be less than or equal to
+    //
+    //      floor( (gamma - alpha) * log_10(2) ) = 8.
+    //
+    // (A smaller distance gamma-alpha would require a larger table.)
+
+    // NB:
+    // Actually this function returns c, such that -60 <= e_c + e + 64 <= -34.
+
+    constexpr int kCachedPowersMinDecExp = -300;
+    constexpr int kCachedPowersDecStep = 8;
+
+    static constexpr std::array<cached_power, 79> kCachedPowers =
+    {
+        {
+            { 0xAB70FE17C79AC6CA, -1060, -300 },
+            { 0xFF77B1FCBEBCDC4F, -1034, -292 },
+            { 0xBE5691EF416BD60C, -1007, -284 },
+            { 0x8DD01FAD907FFC3C,  -980, -276 },
+            { 0xD3515C2831559A83,  -954, -268 },
+            { 0x9D71AC8FADA6C9B5,  -927, -260 },
+            { 0xEA9C227723EE8BCB,  -901, -252 },
+            { 0xAECC49914078536D,  -874, -244 },
+            { 0x823C12795DB6CE57,  -847, -236 },
+            { 0xC21094364DFB5637,  -821, -228 },
+            { 0x9096EA6F3848984F,  -794, -220 },
+            { 0xD77485CB25823AC7,  -768, -212 },
+            { 0xA086CFCD97BF97F4,  -741, -204 },
+            { 0xEF340A98172AACE5,  -715, -196 },
+            { 0xB23867FB2A35B28E,  -688, -188 },
+            { 0x84C8D4DFD2C63F3B,  -661, -180 },
+            { 0xC5DD44271AD3CDBA,  -635, -172 },
+            { 0x936B9FCEBB25C996,  -608, -164 },
+            { 0xDBAC6C247D62A584,  -582, -156 },
+            { 0xA3AB66580D5FDAF6,  -555, -148 },
+            { 0xF3E2F893DEC3F126,  -529, -140 },
+            { 0xB5B5ADA8AAFF80B8,  -502, -132 },
+            { 0x87625F056C7C4A8B,  -475, -124 },
+            { 0xC9BCFF6034C13053,  -449, -116 },
+            { 0x964E858C91BA2655,  -422, -108 },
+            { 0xDFF9772470297EBD,  -396, -100 },
+            { 0xA6DFBD9FB8E5B88F,  -369,  -92 },
+            { 0xF8A95FCF88747D94,  -343,  -84 },
+            { 0xB94470938FA89BCF,  -316,  -76 },
+            { 0x8A08F0F8BF0F156B,  -289,  -68 },
+            { 0xCDB02555653131B6,  -263,  -60 },
+            { 0x993FE2C6D07B7FAC,  -236,  -52 },
+            { 0xE45C10C42A2B3B06,  -210,  -44 },
+            { 0xAA242499697392D3,  -183,  -36 },
+            { 0xFD87B5F28300CA0E,  -157,  -28 },
+            { 0xBCE5086492111AEB,  -130,  -20 },
+            { 0x8CBCCC096F5088CC,  -103,  -12 },
+            { 0xD1B71758E219652C,   -77,   -4 },
+            { 0x9C40000000000000,   -50,    4 },
+            { 0xE8D4A51000000000,   -24,   12 },
+            { 0xAD78EBC5AC620000,     3,   20 },
+            { 0x813F3978F8940984,    30,   28 },
+            { 0xC097CE7BC90715B3,    56,   36 },
+            { 0x8F7E32CE7BEA5C70,    83,   44 },
+            { 0xD5D238A4ABE98068,   109,   52 },
+            { 0x9F4F2726179A2245,   136,   60 },
+            { 0xED63A231D4C4FB27,   162,   68 },
+            { 0xB0DE65388CC8ADA8,   189,   76 },
+            { 0x83C7088E1AAB65DB,   216,   84 },
+            { 0xC45D1DF942711D9A,   242,   92 },
+            { 0x924D692CA61BE758,   269,  100 },
+            { 0xDA01EE641A708DEA,   295,  108 },
+            { 0xA26DA3999AEF774A,   322,  116 },
+            { 0xF209787BB47D6B85,   348,  124 },
+            { 0xB454E4A179DD1877,   375,  132 },
+            { 0x865B86925B9BC5C2,   402,  140 },
+            { 0xC83553C5C8965D3D,   428,  148 },
+            { 0x952AB45CFA97A0B3,   455,  156 },
+            { 0xDE469FBD99A05FE3,   481,  164 },
+            { 0xA59BC234DB398C25,   508,  172 },
+            { 0xF6C69A72A3989F5C,   534,  180 },
+            { 0xB7DCBF5354E9BECE,   561,  188 },
+            { 0x88FCF317F22241E2,   588,  196 },
+            { 0xCC20CE9BD35C78A5,   614,  204 },
+            { 0x98165AF37B2153DF,   641,  212 },
+            { 0xE2A0B5DC971F303A,   667,  220 },
+            { 0xA8D9D1535CE3B396,   694,  228 },
+            { 0xFB9B7CD9A4A7443C,   720,  236 },
+            { 0xBB764C4CA7A44410,   747,  244 },
+            { 0x8BAB8EEFB6409C1A,   774,  252 },
+            { 0xD01FEF10A657842C,   800,  260 },
+            { 0x9B10A4E5E9913129,   827,  268 },
+            { 0xE7109BFBA19C0C9D,   853,  276 },
+            { 0xAC2820D9623BF429,   880,  284 },
+            { 0x80444B5E7AA7CF85,   907,  292 },
+            { 0xBF21E44003ACDD2D,   933,  300 },
+            { 0x8E679C2F5E44FF8F,   960,  308 },
+            { 0xD433179D9C8CB841,   986,  316 },
+            { 0x9E19DB92B4E31BA9,  1013,  324 },
+        }
+    };
+
+    // This computation gives exactly the same results for k as
+    //      k = ceil((kAlpha - e - 1) * 0.30102999566398114)
+    // for |e| <= 1500, but doesn't require floating-point operations.
+    // NB: log_10(2) ~= 78913 / 2^18
+    JSON_ASSERT(e >= -1500);
+    JSON_ASSERT(e <=  1500);
+    const int f = kAlpha - e - 1;
+    const int k = (f * 78913) / (1 << 18) + static_cast<int>(f > 0);
+
+    const int index = (-kCachedPowersMinDecExp + k + (kCachedPowersDecStep - 1)) / kCachedPowersDecStep;
+    JSON_ASSERT(index >= 0);
+    JSON_ASSERT(static_cast<std::size_t>(index) < kCachedPowers.size());
+
+    const cached_power cached = kCachedPowers[static_cast<std::size_t>(index)];
+    JSON_ASSERT(kAlpha <= cached.e + e + 64);
+    JSON_ASSERT(kGamma >= cached.e + e + 64);
+
+    return cached;
+}
+
+/*!
+For n != 0, returns k, such that pow10 := 10^(k-1) <= n < 10^k.
+For n == 0, returns 1 and sets pow10 := 1.
+*/
+inline int find_largest_pow10(const std::uint32_t n, std::uint32_t& pow10)
+{
+    // LCOV_EXCL_START
+    if (n >= 1000000000)
+    {
+        pow10 = 1000000000;
+        return 10;
+    }
+    // LCOV_EXCL_STOP
+    if (n >= 100000000)
+    {
+        pow10 = 100000000;
+        return  9;
+    }
+    if (n >= 10000000)
+    {
+        pow10 = 10000000;
+        return  8;
+    }
+    if (n >= 1000000)
+    {
+        pow10 = 1000000;
+        return  7;
+    }
+    if (n >= 100000)
+    {
+        pow10 = 100000;
+        return  6;
+    }
+    if (n >= 10000)
+    {
+        pow10 = 10000;
+        return  5;
+    }
+    if (n >= 1000)
+    {
+        pow10 = 1000;
+        return  4;
+    }
+    if (n >= 100)
+    {
+        pow10 = 100;
+        return  3;
+    }
+    if (n >= 10)
+    {
+        pow10 = 10;
+        return  2;
+    }
+
+    pow10 = 1;
+    return 1;
+}
+
+inline void grisu2_round(char* buf, int len, std::uint64_t dist, std::uint64_t delta,
+                         std::uint64_t rest, std::uint64_t ten_k)
+{
+    JSON_ASSERT(len >= 1);
+    JSON_ASSERT(dist <= delta);
+    JSON_ASSERT(rest <= delta);
+    JSON_ASSERT(ten_k > 0);
+
+    //               <--------------------------- delta ---->
+    //                                  <---- dist --------->
+    // --------------[------------------+-------------------]--------------
+    //               M-                 w                   M+
+    //
+    //                                  ten_k
+    //                                <------>
+    //                                       <---- rest ---->
+    // --------------[------------------+----+--------------]--------------
+    //                                  w    V
+    //                                       = buf * 10^k
+    //
+    // ten_k represents a unit-in-the-last-place in the decimal representation
+    // stored in buf.
+    // Decrement buf by ten_k while this takes buf closer to w.
+
+    // The tests are written in this order to avoid overflow in unsigned
+    // integer arithmetic.
+
+    while (rest < dist
+            && delta - rest >= ten_k
+            && (rest + ten_k < dist || dist - rest > rest + ten_k - dist))
+    {
+        JSON_ASSERT(buf[len - 1] != '0');
+        buf[len - 1]--;
+        rest += ten_k;
+    }
+}
+
+/*!
+Generates V = buffer * 10^decimal_exponent, such that M- <= V <= M+.
+M- and M+ must be normalized and share the same exponent -60 <= e <= -32.
+*/
+inline void grisu2_digit_gen(char* buffer, int& length, int& decimal_exponent,
+                             diyfp M_minus, diyfp w, diyfp M_plus)
+{
+    static_assert(kAlpha >= -60, "internal error");
+    static_assert(kGamma <= -32, "internal error");
+
+    // Generates the digits (and the exponent) of a decimal floating-point
+    // number V = buffer * 10^decimal_exponent in the range [M-, M+]. The diyfp's
+    // w, M- and M+ share the same exponent e, which satisfies alpha <= e <= gamma.
+    //
+    //               <--------------------------- delta ---->
+    //                                  <---- dist --------->
+    // --------------[------------------+-------------------]--------------
+    //               M-                 w                   M+
+    //
+    // Grisu2 generates the digits of M+ from left to right and stops as soon as
+    // V is in [M-,M+].
+
+    JSON_ASSERT(M_plus.e >= kAlpha);
+    JSON_ASSERT(M_plus.e <= kGamma);
+
+    std::uint64_t delta = diyfp::sub(M_plus, M_minus).f; // (significand of (M+ - M-), implicit exponent is e)
+    std::uint64_t dist  = diyfp::sub(M_plus, w      ).f; // (significand of (M+ - w ), implicit exponent is e)
+
+    // Split M+ = f * 2^e into two parts p1 and p2 (note: e < 0):
+    //
+    //      M+ = f * 2^e
+    //         = ((f div 2^-e) * 2^-e + (f mod 2^-e)) * 2^e
+    //         = ((p1        ) * 2^-e + (p2        )) * 2^e
+    //         = p1 + p2 * 2^e
+
+    const diyfp one(std::uint64_t{1} << -M_plus.e, M_plus.e);
+
+    auto p1 = static_cast<std::uint32_t>(M_plus.f >> -one.e); // p1 = f div 2^-e (Since -e >= 32, p1 fits into a 32-bit int.)
+    std::uint64_t p2 = M_plus.f & (one.f - 1);                    // p2 = f mod 2^-e
+
+    // 1)
+    //
+    // Generate the digits of the integral part p1 = d[n-1]...d[1]d[0]
+
+    JSON_ASSERT(p1 > 0);
+
+    std::uint32_t pow10{};
+    const int k = find_largest_pow10(p1, pow10);
+
+    //      10^(k-1) <= p1 < 10^k, pow10 = 10^(k-1)
+    //
+    //      p1 = (p1 div 10^(k-1)) * 10^(k-1) + (p1 mod 10^(k-1))
+    //         = (d[k-1]         ) * 10^(k-1) + (p1 mod 10^(k-1))
+    //
+    //      M+ = p1                                             + p2 * 2^e
+    //         = d[k-1] * 10^(k-1) + (p1 mod 10^(k-1))          + p2 * 2^e
+    //         = d[k-1] * 10^(k-1) + ((p1 mod 10^(k-1)) * 2^-e + p2) * 2^e
+    //         = d[k-1] * 10^(k-1) + (                         rest) * 2^e
+    //
+    // Now generate the digits d[n] of p1 from left to right (n = k-1,...,0)
+    //
+    //      p1 = d[k-1]...d[n] * 10^n + d[n-1]...d[0]
+    //
+    // but stop as soon as
+    //
+    //      rest * 2^e = (d[n-1]...d[0] * 2^-e + p2) * 2^e <= delta * 2^e
+
+    int n = k;
+    while (n > 0)
+    {
+        // Invariants:
+        //      M+ = buffer * 10^n + (p1 + p2 * 2^e)    (buffer = 0 for n = k)
+        //      pow10 = 10^(n-1) <= p1 < 10^n
+        //
+        const std::uint32_t d = p1 / pow10;  // d = p1 div 10^(n-1)
+        const std::uint32_t r = p1 % pow10;  // r = p1 mod 10^(n-1)
+        //
+        //      M+ = buffer * 10^n + (d * 10^(n-1) + r) + p2 * 2^e
+        //         = (buffer * 10 + d) * 10^(n-1) + (r + p2 * 2^e)
+        //
+        JSON_ASSERT(d <= 9);
+        buffer[length++] = static_cast<char>('0' + d); // buffer := buffer * 10 + d
+        //
+        //      M+ = buffer * 10^(n-1) + (r + p2 * 2^e)
+        //
+        p1 = r;
+        n--;
+        //
+        //      M+ = buffer * 10^n + (p1 + p2 * 2^e)
+        //      pow10 = 10^n
+        //
+
+        // Now check if enough digits have been generated.
+        // Compute
+        //
+        //      p1 + p2 * 2^e = (p1 * 2^-e + p2) * 2^e = rest * 2^e
+        //
+        // Note:
+        // Since rest and delta share the same exponent e, it suffices to
+        // compare the significands.
+        const std::uint64_t rest = (std::uint64_t{p1} << -one.e) + p2;
+        if (rest <= delta)
+        {
+            // V = buffer * 10^n, with M- <= V <= M+.
+
+            decimal_exponent += n;
+
+            // We may now just stop. But instead look if the buffer could be
+            // decremented to bring V closer to w.
+            //
+            // pow10 = 10^n is now 1 ulp in the decimal representation V.
+            // The rounding procedure works with diyfp's with an implicit
+            // exponent of e.
+            //
+            //      10^n = (10^n * 2^-e) * 2^e = ulp * 2^e
+            //
+            const std::uint64_t ten_n = std::uint64_t{pow10} << -one.e;
+            grisu2_round(buffer, length, dist, delta, rest, ten_n);
+
+            return;
+        }
+
+        pow10 /= 10;
+        //
+        //      pow10 = 10^(n-1) <= p1 < 10^n
+        // Invariants restored.
+    }
+
+    // 2)
+    //
+    // The digits of the integral part have been generated:
+    //
+    //      M+ = d[k-1]...d[1]d[0] + p2 * 2^e
+    //         = buffer            + p2 * 2^e
+    //
+    // Now generate the digits of the fractional part p2 * 2^e.
+    //
+    // Note:
+    // No decimal point is generated: the exponent is adjusted instead.
+    //
+    // p2 actually represents the fraction
+    //
+    //      p2 * 2^e
+    //          = p2 / 2^-e
+    //          = d[-1] / 10^1 + d[-2] / 10^2 + ...
+    //
+    // Now generate the digits d[-m] of p1 from left to right (m = 1,2,...)
+    //
+    //      p2 * 2^e = d[-1]d[-2]...d[-m] * 10^-m
+    //                      + 10^-m * (d[-m-1] / 10^1 + d[-m-2] / 10^2 + ...)
+    //
+    // using
+    //
+    //      10^m * p2 = ((10^m * p2) div 2^-e) * 2^-e + ((10^m * p2) mod 2^-e)
+    //                = (                   d) * 2^-e + (                   r)
+    //
+    // or
+    //      10^m * p2 * 2^e = d + r * 2^e
+    //
+    // i.e.
+    //
+    //      M+ = buffer + p2 * 2^e
+    //         = buffer + 10^-m * (d + r * 2^e)
+    //         = (buffer * 10^m + d) * 10^-m + 10^-m * r * 2^e
+    //
+    // and stop as soon as 10^-m * r * 2^e <= delta * 2^e
+
+    JSON_ASSERT(p2 > delta);
+
+    int m = 0;
+    for (;;)
+    {
+        // Invariant:
+        //      M+ = buffer * 10^-m + 10^-m * (d[-m-1] / 10 + d[-m-2] / 10^2 + ...) * 2^e
+        //         = buffer * 10^-m + 10^-m * (p2                                 ) * 2^e
+        //         = buffer * 10^-m + 10^-m * (1/10 * (10 * p2)                   ) * 2^e
+        //         = buffer * 10^-m + 10^-m * (1/10 * ((10*p2 div 2^-e) * 2^-e + (10*p2 mod 2^-e)) * 2^e
+        //
+        JSON_ASSERT(p2 <= (std::numeric_limits<std::uint64_t>::max)() / 10);
+        p2 *= 10;
+        const std::uint64_t d = p2 >> -one.e;     // d = (10 * p2) div 2^-e
+        const std::uint64_t r = p2 & (one.f - 1); // r = (10 * p2) mod 2^-e
+        //
+        //      M+ = buffer * 10^-m + 10^-m * (1/10 * (d * 2^-e + r) * 2^e
+        //         = buffer * 10^-m + 10^-m * (1/10 * (d + r * 2^e))
+        //         = (buffer * 10 + d) * 10^(-m-1) + 10^(-m-1) * r * 2^e
+        //
+        JSON_ASSERT(d <= 9);
+        buffer[length++] = static_cast<char>('0' + d); // buffer := buffer * 10 + d
+        //
+        //      M+ = buffer * 10^(-m-1) + 10^(-m-1) * r * 2^e
+        //
+        p2 = r;
+        m++;
+        //
+        //      M+ = buffer * 10^-m + 10^-m * p2 * 2^e
+        // Invariant restored.
+
+        // Check if enough digits have been generated.
+        //
+        //      10^-m * p2 * 2^e <= delta * 2^e
+        //              p2 * 2^e <= 10^m * delta * 2^e
+        //                    p2 <= 10^m * delta
+        delta *= 10;
+        dist  *= 10;
+        if (p2 <= delta)
+        {
+            break;
+        }
+    }
+
+    // V = buffer * 10^-m, with M- <= V <= M+.
+
+    decimal_exponent -= m;
+
+    // 1 ulp in the decimal representation is now 10^-m.
+    // Since delta and dist are now scaled by 10^m, we need to do the
+    // same with ulp in order to keep the units in sync.
+    //
+    //      10^m * 10^-m = 1 = 2^-e * 2^e = ten_m * 2^e
+    //
+    const std::uint64_t ten_m = one.f;
+    grisu2_round(buffer, length, dist, delta, p2, ten_m);
+
+    // By construction this algorithm generates the shortest possible decimal
+    // number (Loitsch, Theorem 6.2) which rounds back to w.
+    // For an input number of precision p, at least
+    //
+    //      N = 1 + ceil(p * log_10(2))
+    //
+    // decimal digits are sufficient to identify all binary floating-point
+    // numbers (Matula, "In-and-Out conversions").
+    // This implies that the algorithm does not produce more than N decimal
+    // digits.
+    //
+    //      N = 17 for p = 53 (IEEE double precision)
+    //      N = 9  for p = 24 (IEEE single precision)
+}
+
+/*!
+v = buf * 10^decimal_exponent
+len is the length of the buffer (number of decimal digits)
+The buffer must be large enough, i.e. >= max_digits10.
+*/
+JSON_HEDLEY_NON_NULL(1)
+inline void grisu2(char* buf, int& len, int& decimal_exponent,
+                   diyfp m_minus, diyfp v, diyfp m_plus)
+{
+    JSON_ASSERT(m_plus.e == m_minus.e);
+    JSON_ASSERT(m_plus.e == v.e);
+
+    //  --------(-----------------------+-----------------------)--------    (A)
+    //          m-                      v                       m+
+    //
+    //  --------------------(-----------+-----------------------)--------    (B)
+    //                      m-          v                       m+
+    //
+    // First scale v (and m- and m+) such that the exponent is in the range
+    // [alpha, gamma].
+
+    const cached_power cached = get_cached_power_for_binary_exponent(m_plus.e);
+
+    const diyfp c_minus_k(cached.f, cached.e); // = c ~= 10^-k
+
+    // The exponent of the products is = v.e + c_minus_k.e + q and is in the range [alpha,gamma]
+    const diyfp w       = diyfp::mul(v,       c_minus_k);
+    const diyfp w_minus = diyfp::mul(m_minus, c_minus_k);
+    const diyfp w_plus  = diyfp::mul(m_plus,  c_minus_k);
+
+    //  ----(---+---)---------------(---+---)---------------(---+---)----
+    //          w-                      w                       w+
+    //          = c*m-                  = c*v                   = c*m+
+    //
+    // diyfp::mul rounds its result and c_minus_k is approximated too. w, w- and
+    // w+ are now off by a small amount.
+    // In fact:
+    //
+    //      w - v * 10^k < 1 ulp
+    //
+    // To account for this inaccuracy, add resp. subtract 1 ulp.
+    //
+    //  --------+---[---------------(---+---)---------------]---+--------
+    //          w-  M-                  w                   M+  w+
+    //
+    // Now any number in [M-, M+] (bounds included) will round to w when input,
+    // regardless of how the input rounding algorithm breaks ties.
+    //
+    // And digit_gen generates the shortest possible such number in [M-, M+].
+    // Note that this does not mean that Grisu2 always generates the shortest
+    // possible number in the interval (m-, m+).
+    const diyfp M_minus(w_minus.f + 1, w_minus.e);
+    const diyfp M_plus (w_plus.f  - 1, w_plus.e );
+
+    decimal_exponent = -cached.k; // = -(-k) = k
+
+    grisu2_digit_gen(buf, len, decimal_exponent, M_minus, w, M_plus);
+}
+
+/*!
+v = buf * 10^decimal_exponent
+len is the length of the buffer (number of decimal digits)
+The buffer must be large enough, i.e. >= max_digits10.
+*/
+template<typename FloatType>
+JSON_HEDLEY_NON_NULL(1)
+void grisu2(char* buf, int& len, int& decimal_exponent, FloatType value)
+{
+    static_assert(diyfp::kPrecision >= std::numeric_limits<FloatType>::digits + 3,
+                  "internal error: not enough precision");
+
+    JSON_ASSERT(std::isfinite(value));
+    JSON_ASSERT(value > 0);
+
+    // If the neighbors (and boundaries) of 'value' are always computed for double-precision
+    // numbers, all float's can be recovered using strtod (and strtof). However, the resulting
+    // decimal representations are not exactly "short".
+    //
+    // The documentation for 'std::to_chars' (https://en.cppreference.com/w/cpp/utility/to_chars)
+    // says "value is converted to a string as if by std::sprintf in the default ("C") locale"
+    // and since sprintf promotes floats to doubles, I think this is exactly what 'std::to_chars'
+    // does.
+    // On the other hand, the documentation for 'std::to_chars' requires that "parsing the
+    // representation using the corresponding std::from_chars function recovers value exactly". That
+    // indicates that single precision floating-point numbers should be recovered using
+    // 'std::strtof'.
+    //
+    // NB: If the neighbors are computed for single-precision numbers, there is a single float
+    //     (7.0385307e-26f) which can't be recovered using strtod. The resulting double precision
+    //     value is off by 1 ulp.
+#if 0 // NOLINT(readability-avoid-unconditional-preprocessor-if)
+    const boundaries w = compute_boundaries(static_cast<double>(value));
+#else
+    const boundaries w = compute_boundaries(value);
+#endif
+
+    grisu2(buf, len, decimal_exponent, w.minus, w.w, w.plus);
+}
+
+/*!
+@brief appends a decimal representation of e to buf
+@return a pointer to the element following the exponent.
+@pre -1000 < e < 1000
+*/
+JSON_HEDLEY_NON_NULL(1)
+JSON_HEDLEY_RETURNS_NON_NULL
+inline char* append_exponent(char* buf, int e)
+{
+    JSON_ASSERT(e > -1000);
+    JSON_ASSERT(e <  1000);
+
+    if (e < 0)
+    {
+        e = -e;
+        *buf++ = '-';
+    }
+    else
+    {
+        *buf++ = '+';
+    }
+
+    auto k = static_cast<std::uint32_t>(e);
+    if (k < 10)
+    {
+        // Always print at least two digits in the exponent.
+        // This is for compatibility with printf("%g").
+        *buf++ = '0';
+        *buf++ = static_cast<char>('0' + k);
+    }
+    else if (k < 100)
+    {
+        *buf++ = static_cast<char>('0' + k / 10);
+        k %= 10;
+        *buf++ = static_cast<char>('0' + k);
+    }
+    else
+    {
+        *buf++ = static_cast<char>('0' + k / 100);
+        k %= 100;
+        *buf++ = static_cast<char>('0' + k / 10);
+        k %= 10;
+        *buf++ = static_cast<char>('0' + k);
+    }
+
+    return buf;
+}
+
+/*!
+@brief prettify v = buf * 10^decimal_exponent
+
+If v is in the range [10^min_exp, 10^max_exp) it will be printed in fixed-point
+notation. Otherwise it will be printed in exponential notation.
+
+@pre min_exp < 0
+@pre max_exp > 0
+*/
+JSON_HEDLEY_NON_NULL(1)
+JSON_HEDLEY_RETURNS_NON_NULL
+inline char* format_buffer(char* buf, int len, int decimal_exponent,
+                           int min_exp, int max_exp)
+{
+    JSON_ASSERT(min_exp < 0);
+    JSON_ASSERT(max_exp > 0);
+
+    const int k = len;
+    const int n = len + decimal_exponent;
+
+    // v = buf * 10^(n-k)
+    // k is the length of the buffer (number of decimal digits)
+    // n is the position of the decimal point relative to the start of the buffer.
+
+    if (k <= n && n <= max_exp)
+    {
+        // digits[000]
+        // len <= max_exp + 2
+
+        std::memset(buf + k, '0', static_cast<size_t>(n) - static_cast<size_t>(k));
+        // Make it look like a floating-point number (#362, #378)
+        buf[n + 0] = '.';
+        buf[n + 1] = '0';
+        return buf + (static_cast<size_t>(n) + 2);
+    }
+
+    if (0 < n && n <= max_exp)
+    {
+        // dig.its
+        // len <= max_digits10 + 1
+
+        JSON_ASSERT(k > n);
+
+        std::memmove(buf + (static_cast<size_t>(n) + 1), buf + n, static_cast<size_t>(k) - static_cast<size_t>(n));
+        buf[n] = '.';
+        return buf + (static_cast<size_t>(k) + 1U);
+    }
+
+    if (min_exp < n && n <= 0)
+    {
+        // 0.[000]digits
+        // len <= 2 + (-min_exp - 1) + max_digits10
+
+        std::memmove(buf + (2 + static_cast<size_t>(-n)), buf, static_cast<size_t>(k));
+        buf[0] = '0';
+        buf[1] = '.';
+        std::memset(buf + 2, '0', static_cast<size_t>(-n));
+        return buf + (2U + static_cast<size_t>(-n) + static_cast<size_t>(k));
+    }
+
+    if (k == 1)
+    {
+        // dE+123
+        // len <= 1 + 5
+
+        buf += 1;
+    }
+    else
+    {
+        // d.igitsE+123
+        // len <= max_digits10 + 1 + 5
+
+        std::memmove(buf + 2, buf + 1, static_cast<size_t>(k) - 1);
+        buf[1] = '.';
+        buf += 1 + static_cast<size_t>(k);
+    }
+
+    *buf++ = 'e';
+    return append_exponent(buf, n - 1);
+}
+
+}  // namespace dtoa_impl
+
+/*!
+@brief generates a decimal representation of the floating-point number value in [first, last).
+
+The format of the resulting decimal representation is similar to printf's %g
+format. Returns an iterator pointing past-the-end of the decimal representation.
+
+@note The input number must be finite, i.e. NaN's and Inf's are not supported.
+@note The buffer must be large enough.
+@note The result is NOT null-terminated.
+*/
+template<typename FloatType>
+JSON_HEDLEY_NON_NULL(1, 2)
+JSON_HEDLEY_RETURNS_NON_NULL
+char* to_chars(char* first, const char* last, FloatType value)
+{
+    static_cast<void>(last); // maybe unused - fix warning
+    JSON_ASSERT(std::isfinite(value));
+
+    // Use signbit(value) instead of (value < 0) since signbit works for -0.
+    if (std::signbit(value))
+    {
+        value = -value;
+        *first++ = '-';
+    }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+    if (value == 0) // +-0
+    {
+        *first++ = '0';
+        // Make it look like a floating-point number (#362, #378)
+        *first++ = '.';
+        *first++ = '0';
+        return first;
+    }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+    JSON_ASSERT(last - first >= std::numeric_limits<FloatType>::max_digits10);
+
+    // Compute v = buffer * 10^decimal_exponent.
+    // The decimal digits are stored in the buffer, which needs to be interpreted
+    // as an unsigned decimal integer.
+    // len is the length of the buffer, i.e. the number of decimal digits.
+    int len = 0;
+    int decimal_exponent = 0;
+    dtoa_impl::grisu2(first, len, decimal_exponent, value);
+
+    JSON_ASSERT(len <= std::numeric_limits<FloatType>::max_digits10);
+
+    // Format the buffer like printf("%.*g", prec, value)
+    constexpr int kMinExp = -4;
+    // Use digits10 here to increase compatibility with version 2.
+    constexpr int kMaxExp = std::numeric_limits<FloatType>::digits10;
+
+    JSON_ASSERT(last - first >= kMaxExp + 2);
+    JSON_ASSERT(last - first >= 2 + (-kMinExp - 1) + std::numeric_limits<FloatType>::max_digits10);
+    JSON_ASSERT(last - first >= std::numeric_limits<FloatType>::max_digits10 + 6);
+
+    return dtoa_impl::format_buffer(first, len, decimal_exponent, kMinExp, kMaxExp);
+}
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/exceptions.hpp>
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/cpp_future.hpp>
+
+// #include <nlohmann/detail/output/binary_writer.hpp>
+
+// #include <nlohmann/detail/output/output_adapters.hpp>
+
+// #include <nlohmann/detail/string_concat.hpp>
+
+// #include <nlohmann/detail/value_t.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail
+{
+
+///////////////////
+// serialization //
+///////////////////
+
+/// how to treat decoding errors
+enum class error_handler_t
+{
+    strict,  ///< throw a type_error exception in case of invalid UTF-8
+    replace, ///< replace invalid UTF-8 sequences with U+FFFD
+    ignore   ///< ignore invalid UTF-8 sequences
+};
+
+template<typename BasicJsonType>
+class serializer
+{
+    using string_t = typename BasicJsonType::string_t;
+    using number_float_t = typename BasicJsonType::number_float_t;
+    using number_integer_t = typename BasicJsonType::number_integer_t;
+    using number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+    using binary_char_t = typename BasicJsonType::binary_t::value_type;
+    static constexpr std::uint8_t UTF8_ACCEPT = 0;
+    static constexpr std::uint8_t UTF8_REJECT = 1;
+
+  public:
+    /*!
+    @param[in] s  output stream to serialize to
+    @param[in] ichar  indentation character to use
+    @param[in] error_handler_  how to react on decoding errors
+    */
+    serializer(output_adapter_t<char> s, const char ichar,
+               error_handler_t error_handler_ = error_handler_t::strict)
+        : o(std::move(s))
+        , loc(std::localeconv())
+        , thousands_sep(loc->thousands_sep == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->thousands_sep)))
+        , decimal_point(loc->decimal_point == nullptr ? '\0' : std::char_traits<char>::to_char_type(* (loc->decimal_point)))
+        , indent_char(ichar)
+        , indent_string(512, indent_char)
+        , error_handler(error_handler_)
+    {}
+
+    // delete because of pointer members
+    serializer(const serializer&) = delete;
+    serializer& operator=(const serializer&) = delete;
+    serializer(serializer&&) = delete;
+    serializer& operator=(serializer&&) = delete;
+    ~serializer() = default;
+
+    /*!
+    @brief internal implementation of the serialization function
+
+    This function is called by the public member function dump and organizes
+    the serialization internally. The indentation level is propagated as
+    additional parameter. In case of arrays and objects, the function is
+    called recursively.
+
+    - strings and object keys are escaped using `escape_string()`
+    - integer numbers are converted implicitly via `operator<<`
+    - floating-point numbers are converted to a string using `"%g"` format
+    - binary values are serialized as objects containing the subtype and the
+      byte array
+
+    @param[in] val               value to serialize
+    @param[in] pretty_print      whether the output shall be pretty-printed
+    @param[in] ensure_ascii If @a ensure_ascii is true, all non-ASCII characters
+    in the output are escaped with `\uXXXX` sequences, and the result consists
+    of ASCII characters only.
+    @param[in] indent_step       the indent level
+    @param[in] current_indent    the current indent level (only used internally)
+    */
+    void dump(const BasicJsonType& val,
+              const bool pretty_print,
+              const bool ensure_ascii,
+              const unsigned int indent_step,
+              const unsigned int current_indent = 0)
+    {
+        switch (val.m_data.m_type)
+        {
+            case value_t::object:
+            {
+                if (val.m_data.m_value.object->empty())
+                {
+                    o->write_characters("{}", 2);
+                    return;
+                }
+
+                if (pretty_print)
+                {
+                    o->write_characters("{\n", 2);
+
+                    // variable to hold indentation for recursive calls
+                    const auto new_indent = current_indent + indent_step;
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    {
+                        indent_string.resize(indent_string.size() * 2, ' ');
+                    }
+
+                    // first n-1 elements
+                    auto i = val.m_data.m_value.object->cbegin();
+                    for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
+                    {
+                        o->write_characters(indent_string.c_str(), new_indent);
+                        o->write_character('\"');
+                        dump_escaped(i->first, ensure_ascii);
+                        o->write_characters("\": ", 3);
+                        dump(i->second, true, ensure_ascii, indent_step, new_indent);
+                        o->write_characters(",\n", 2);
+                    }
+
+                    // last element
+                    JSON_ASSERT(i != val.m_data.m_value.object->cend());
+                    JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
+                    o->write_characters(indent_string.c_str(), new_indent);
+                    o->write_character('\"');
+                    dump_escaped(i->first, ensure_ascii);
+                    o->write_characters("\": ", 3);
+                    dump(i->second, true, ensure_ascii, indent_step, new_indent);
+
+                    o->write_character('\n');
+                    o->write_characters(indent_string.c_str(), current_indent);
+                    o->write_character('}');
+                }
+                else
+                {
+                    o->write_character('{');
+
+                    // first n-1 elements
+                    auto i = val.m_data.m_value.object->cbegin();
+                    for (std::size_t cnt = 0; cnt < val.m_data.m_value.object->size() - 1; ++cnt, ++i)
+                    {
+                        o->write_character('\"');
+                        dump_escaped(i->first, ensure_ascii);
+                        o->write_characters("\":", 2);
+                        dump(i->second, false, ensure_ascii, indent_step, current_indent);
+                        o->write_character(',');
+                    }
+
+                    // last element
+                    JSON_ASSERT(i != val.m_data.m_value.object->cend());
+                    JSON_ASSERT(std::next(i) == val.m_data.m_value.object->cend());
+                    o->write_character('\"');
+                    dump_escaped(i->first, ensure_ascii);
+                    o->write_characters("\":", 2);
+                    dump(i->second, false, ensure_ascii, indent_step, current_indent);
+
+                    o->write_character('}');
+                }
+
+                return;
+            }
+
+            case value_t::array:
+            {
+                if (val.m_data.m_value.array->empty())
+                {
+                    o->write_characters("[]", 2);
+                    return;
+                }
+
+                if (pretty_print)
+                {
+                    o->write_characters("[\n", 2);
+
+                    // variable to hold indentation for recursive calls
+                    const auto new_indent = current_indent + indent_step;
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    {
+                        indent_string.resize(indent_string.size() * 2, ' ');
+                    }
+
+                    // first n-1 elements
+                    for (auto i = val.m_data.m_value.array->cbegin();
+                            i != val.m_data.m_value.array->cend() - 1; ++i)
+                    {
+                        o->write_characters(indent_string.c_str(), new_indent);
+                        dump(*i, true, ensure_ascii, indent_step, new_indent);
+                        o->write_characters(",\n", 2);
+                    }
+
+                    // last element
+                    JSON_ASSERT(!val.m_data.m_value.array->empty());
+                    o->write_characters(indent_string.c_str(), new_indent);
+                    dump(val.m_data.m_value.array->back(), true, ensure_ascii, indent_step, new_indent);
+
+                    o->write_character('\n');
+                    o->write_characters(indent_string.c_str(), current_indent);
+                    o->write_character(']');
+                }
+                else
+                {
+                    o->write_character('[');
+
+                    // first n-1 elements
+                    for (auto i = val.m_data.m_value.array->cbegin();
+                            i != val.m_data.m_value.array->cend() - 1; ++i)
+                    {
+                        dump(*i, false, ensure_ascii, indent_step, current_indent);
+                        o->write_character(',');
+                    }
+
+                    // last element
+                    JSON_ASSERT(!val.m_data.m_value.array->empty());
+                    dump(val.m_data.m_value.array->back(), false, ensure_ascii, indent_step, current_indent);
+
+                    o->write_character(']');
+                }
+
+                return;
+            }
+
+            case value_t::string:
+            {
+                o->write_character('\"');
+                dump_escaped(*val.m_data.m_value.string, ensure_ascii);
+                o->write_character('\"');
+                return;
+            }
+
+            case value_t::binary:
+            {
+                if (pretty_print)
+                {
+                    o->write_characters("{\n", 2);
+
+                    // variable to hold indentation for recursive calls
+                    const auto new_indent = current_indent + indent_step;
+                    if (JSON_HEDLEY_UNLIKELY(indent_string.size() < new_indent))
+                    {
+                        indent_string.resize(indent_string.size() * 2, ' ');
+                    }
+
+                    o->write_characters(indent_string.c_str(), new_indent);
+
+                    o->write_characters("\"bytes\": [", 10);
+
+                    if (!val.m_data.m_value.binary->empty())
+                    {
+                        for (auto i = val.m_data.m_value.binary->cbegin();
+                                i != val.m_data.m_value.binary->cend() - 1; ++i)
+                        {
+                            dump_integer(*i);
+                            o->write_characters(", ", 2);
+                        }
+                        dump_integer(val.m_data.m_value.binary->back());
+                    }
+
+                    o->write_characters("],\n", 3);
+                    o->write_characters(indent_string.c_str(), new_indent);
+
+                    o->write_characters("\"subtype\": ", 11);
+                    if (val.m_data.m_value.binary->has_subtype())
+                    {
+                        dump_integer(val.m_data.m_value.binary->subtype());
+                    }
+                    else
+                    {
+                        o->write_characters("null", 4);
+                    }
+                    o->write_character('\n');
+                    o->write_characters(indent_string.c_str(), current_indent);
+                    o->write_character('}');
+                }
+                else
+                {
+                    o->write_characters("{\"bytes\":[", 10);
+
+                    if (!val.m_data.m_value.binary->empty())
+                    {
+                        for (auto i = val.m_data.m_value.binary->cbegin();
+                                i != val.m_data.m_value.binary->cend() - 1; ++i)
+                        {
+                            dump_integer(*i);
+                            o->write_character(',');
+                        }
+                        dump_integer(val.m_data.m_value.binary->back());
+                    }
+
+                    o->write_characters("],\"subtype\":", 12);
+                    if (val.m_data.m_value.binary->has_subtype())
+                    {
+                        dump_integer(val.m_data.m_value.binary->subtype());
+                        o->write_character('}');
+                    }
+                    else
+                    {
+                        o->write_characters("null}", 5);
+                    }
+                }
+                return;
+            }
+
+            case value_t::boolean:
+            {
+                if (val.m_data.m_value.boolean)
+                {
+                    o->write_characters("true", 4);
+                }
+                else
+                {
+                    o->write_characters("false", 5);
+                }
+                return;
+            }
+
+            case value_t::number_integer:
+            {
+                dump_integer(val.m_data.m_value.number_integer);
+                return;
+            }
+
+            case value_t::number_unsigned:
+            {
+                dump_integer(val.m_data.m_value.number_unsigned);
+                return;
+            }
+
+            case value_t::number_float:
+            {
+                dump_float(val.m_data.m_value.number_float);
+                return;
+            }
+
+            case value_t::discarded:
+            {
+                o->write_characters("<discarded>", 11);
+                return;
+            }
+
+            case value_t::null:
+            {
+                o->write_characters("null", 4);
+                return;
+            }
+
+            default:            // LCOV_EXCL_LINE
+                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+        }
+    }
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    /*!
+    @brief dump escaped string
+
+    Escape a string by replacing certain special characters by a sequence of an
+    escape character (backslash) and another character and other control
+    characters by a sequence of "\u" followed by a four-digit hex
+    representation. The escaped string is written to output stream @a o.
+
+    @param[in] s  the string to escape
+    @param[in] ensure_ascii  whether to escape non-ASCII characters with
+                             \uXXXX sequences
+
+    @complexity Linear in the length of string @a s.
+    */
+    void dump_escaped(const string_t& s, const bool ensure_ascii)
+    {
+        std::uint32_t codepoint{};
+        std::uint8_t state = UTF8_ACCEPT;
+        std::size_t bytes = 0;  // number of bytes written to string_buffer
+
+        // number of bytes written at the point of the last valid byte
+        std::size_t bytes_after_last_accept = 0;
+        std::size_t undumped_chars = 0;
+
+        for (std::size_t i = 0; i < s.size(); ++i)
+        {
+            const auto byte = static_cast<std::uint8_t>(s[i]);
+
+            switch (decode(state, codepoint, byte))
+            {
+                case UTF8_ACCEPT:  // decode found a new code point
+                {
+                    switch (codepoint)
+                    {
+                        case 0x08: // backspace
+                        {
+                            string_buffer[bytes++] = '\\';
+                            string_buffer[bytes++] = 'b';
+                            break;
+                        }
+
+                        case 0x09: // horizontal tab
+                        {
+                            string_buffer[bytes++] = '\\';
+                            string_buffer[bytes++] = 't';
+                            break;
+                        }
+
+                        case 0x0A: // newline
+                        {
+                            string_buffer[bytes++] = '\\';
+                            string_buffer[bytes++] = 'n';
+                            break;
+                        }
+
+                        case 0x0C: // formfeed
+                        {
+                            string_buffer[bytes++] = '\\';
+                            string_buffer[bytes++] = 'f';
+                            break;
+                        }
+
+                        case 0x0D: // carriage return
+                        {
+                            string_buffer[bytes++] = '\\';
+                            string_buffer[bytes++] = 'r';
+                            break;
+                        }
+
+                        case 0x22: // quotation mark
+                        {
+                            string_buffer[bytes++] = '\\';
+                            string_buffer[bytes++] = '\"';
+                            break;
+                        }
+
+                        case 0x5C: // reverse solidus
+                        {
+                            string_buffer[bytes++] = '\\';
+                            string_buffer[bytes++] = '\\';
+                            break;
+                        }
+
+                        default:
+                        {
+                            // escape control characters (0x00..0x1F) or, if
+                            // ensure_ascii parameter is used, non-ASCII characters
+                            if ((codepoint <= 0x1F) || (ensure_ascii && (codepoint >= 0x7F)))
+                            {
+                                if (codepoint <= 0xFFFF)
+                                {
+                                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+                                    static_cast<void>((std::snprintf)(string_buffer.data() + bytes, 7, "\\u%04x",
+                                                                      static_cast<std::uint16_t>(codepoint)));
+                                    bytes += 6;
+                                }
+                                else
+                                {
+                                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+                                    static_cast<void>((std::snprintf)(string_buffer.data() + bytes, 13, "\\u%04x\\u%04x",
+                                                                      static_cast<std::uint16_t>(0xD7C0u + (codepoint >> 10u)),
+                                                                      static_cast<std::uint16_t>(0xDC00u + (codepoint & 0x3FFu))));
+                                    bytes += 12;
+                                }
+                            }
+                            else
+                            {
+                                // copy byte to buffer (all previous bytes
+                                // been copied have in default case above)
+                                string_buffer[bytes++] = s[i];
+                            }
+                            break;
+                        }
+                    }
+
+                    // write buffer and reset index; there must be 13 bytes
+                    // left, as this is the maximal number of bytes to be
+                    // written ("\uxxxx\uxxxx\0") for one code point
+                    if (string_buffer.size() - bytes < 13)
+                    {
+                        o->write_characters(string_buffer.data(), bytes);
+                        bytes = 0;
+                    }
+
+                    // remember the byte position of this accept
+                    bytes_after_last_accept = bytes;
+                    undumped_chars = 0;
+                    break;
+                }
+
+                case UTF8_REJECT:  // decode found invalid UTF-8 byte
+                {
+                    switch (error_handler)
+                    {
+                        case error_handler_t::strict:
+                        {
+                            JSON_THROW(type_error::create(316, concat("invalid UTF-8 byte at index ", std::to_string(i), ": 0x", hex_bytes(byte | 0)), nullptr));
+                        }
+
+                        case error_handler_t::ignore:
+                        case error_handler_t::replace:
+                        {
+                            // in case we saw this character the first time, we
+                            // would like to read it again, because the byte
+                            // may be OK for itself, but just not OK for the
+                            // previous sequence
+                            if (undumped_chars > 0)
+                            {
+                                --i;
+                            }
+
+                            // reset length buffer to the last accepted index;
+                            // thus removing/ignoring the invalid characters
+                            bytes = bytes_after_last_accept;
+
+                            if (error_handler == error_handler_t::replace)
+                            {
+                                // add a replacement character
+                                if (ensure_ascii)
+                                {
+                                    string_buffer[bytes++] = '\\';
+                                    string_buffer[bytes++] = 'u';
+                                    string_buffer[bytes++] = 'f';
+                                    string_buffer[bytes++] = 'f';
+                                    string_buffer[bytes++] = 'f';
+                                    string_buffer[bytes++] = 'd';
+                                }
+                                else
+                                {
+                                    string_buffer[bytes++] = detail::binary_writer<BasicJsonType, char>::to_char_type('\xEF');
+                                    string_buffer[bytes++] = detail::binary_writer<BasicJsonType, char>::to_char_type('\xBF');
+                                    string_buffer[bytes++] = detail::binary_writer<BasicJsonType, char>::to_char_type('\xBD');
+                                }
+
+                                // write buffer and reset index; there must be 13 bytes
+                                // left, as this is the maximal number of bytes to be
+                                // written ("\uxxxx\uxxxx\0") for one code point
+                                if (string_buffer.size() - bytes < 13)
+                                {
+                                    o->write_characters(string_buffer.data(), bytes);
+                                    bytes = 0;
+                                }
+
+                                bytes_after_last_accept = bytes;
+                            }
+
+                            undumped_chars = 0;
+
+                            // continue processing the string
+                            state = UTF8_ACCEPT;
+                            break;
+                        }
+
+                        default:            // LCOV_EXCL_LINE
+                            JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+                    }
+                    break;
+                }
+
+                default:  // decode found yet incomplete multi-byte code point
+                {
+                    if (!ensure_ascii)
+                    {
+                        // code point will not be escaped - copy byte to buffer
+                        string_buffer[bytes++] = s[i];
+                    }
+                    ++undumped_chars;
+                    break;
+                }
+            }
+        }
+
+        // we finished processing the string
+        if (JSON_HEDLEY_LIKELY(state == UTF8_ACCEPT))
+        {
+            // write buffer
+            if (bytes > 0)
+            {
+                o->write_characters(string_buffer.data(), bytes);
+            }
+        }
+        else
+        {
+            // we finish reading, but do not accept: string was incomplete
+            switch (error_handler)
+            {
+                case error_handler_t::strict:
+                {
+                    JSON_THROW(type_error::create(316, concat("incomplete UTF-8 string; last byte: 0x", hex_bytes(static_cast<std::uint8_t>(s.back() | 0))), nullptr));
+                }
+
+                case error_handler_t::ignore:
+                {
+                    // write all accepted bytes
+                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
+                    break;
+                }
+
+                case error_handler_t::replace:
+                {
+                    // write all accepted bytes
+                    o->write_characters(string_buffer.data(), bytes_after_last_accept);
+                    // add a replacement character
+                    if (ensure_ascii)
+                    {
+                        o->write_characters("\\ufffd", 6);
+                    }
+                    else
+                    {
+                        o->write_characters("\xEF\xBF\xBD", 3);
+                    }
+                    break;
+                }
+
+                default:            // LCOV_EXCL_LINE
+                    JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+            }
+        }
+    }
+
+  private:
+    /*!
+    @brief count digits
+
+    Count the number of decimal (base 10) digits for an input unsigned integer.
+
+    @param[in] x  unsigned integer number to count its digits
+    @return    number of decimal digits
+    */
+    inline unsigned int count_digits(number_unsigned_t x) noexcept
+    {
+        unsigned int n_digits = 1;
+        for (;;)
+        {
+            if (x < 10)
+            {
+                return n_digits;
+            }
+            if (x < 100)
+            {
+                return n_digits + 1;
+            }
+            if (x < 1000)
+            {
+                return n_digits + 2;
+            }
+            if (x < 10000)
+            {
+                return n_digits + 3;
+            }
+            x = x / 10000u;
+            n_digits += 4;
+        }
+    }
+
+    /*!
+     * @brief convert a byte to a uppercase hex representation
+     * @param[in] byte byte to represent
+     * @return representation ("00".."FF")
+     */
+    static std::string hex_bytes(std::uint8_t byte)
+    {
+        std::string result = "FF";
+        constexpr const char* nibble_to_hex = "0123456789ABCDEF";
+        result[0] = nibble_to_hex[byte / 16];
+        result[1] = nibble_to_hex[byte % 16];
+        return result;
+    }
+
+    // templates to avoid warnings about useless casts
+    template <typename NumberType, enable_if_t<std::is_signed<NumberType>::value, int> = 0>
+    bool is_negative_number(NumberType x)
+    {
+        return x < 0;
+    }
+
+    template < typename NumberType, enable_if_t <std::is_unsigned<NumberType>::value, int > = 0 >
+    bool is_negative_number(NumberType /*unused*/)
+    {
+        return false;
+    }
+
+    /*!
+    @brief dump an integer
+
+    Dump a given integer to output stream @a o. Works internally with
+    @a number_buffer.
+
+    @param[in] x  integer number (signed or unsigned) to dump
+    @tparam NumberType either @a number_integer_t or @a number_unsigned_t
+    */
+    template < typename NumberType, detail::enable_if_t <
+                   std::is_integral<NumberType>::value ||
+                   std::is_same<NumberType, number_unsigned_t>::value ||
+                   std::is_same<NumberType, number_integer_t>::value ||
+                   std::is_same<NumberType, binary_char_t>::value,
+                   int > = 0 >
+    void dump_integer(NumberType x)
+    {
+        static constexpr std::array<std::array<char, 2>, 100> digits_to_99
+        {
+            {
+                {{'0', '0'}}, {{'0', '1'}}, {{'0', '2'}}, {{'0', '3'}}, {{'0', '4'}}, {{'0', '5'}}, {{'0', '6'}}, {{'0', '7'}}, {{'0', '8'}}, {{'0', '9'}},
+                {{'1', '0'}}, {{'1', '1'}}, {{'1', '2'}}, {{'1', '3'}}, {{'1', '4'}}, {{'1', '5'}}, {{'1', '6'}}, {{'1', '7'}}, {{'1', '8'}}, {{'1', '9'}},
+                {{'2', '0'}}, {{'2', '1'}}, {{'2', '2'}}, {{'2', '3'}}, {{'2', '4'}}, {{'2', '5'}}, {{'2', '6'}}, {{'2', '7'}}, {{'2', '8'}}, {{'2', '9'}},
+                {{'3', '0'}}, {{'3', '1'}}, {{'3', '2'}}, {{'3', '3'}}, {{'3', '4'}}, {{'3', '5'}}, {{'3', '6'}}, {{'3', '7'}}, {{'3', '8'}}, {{'3', '9'}},
+                {{'4', '0'}}, {{'4', '1'}}, {{'4', '2'}}, {{'4', '3'}}, {{'4', '4'}}, {{'4', '5'}}, {{'4', '6'}}, {{'4', '7'}}, {{'4', '8'}}, {{'4', '9'}},
+                {{'5', '0'}}, {{'5', '1'}}, {{'5', '2'}}, {{'5', '3'}}, {{'5', '4'}}, {{'5', '5'}}, {{'5', '6'}}, {{'5', '7'}}, {{'5', '8'}}, {{'5', '9'}},
+                {{'6', '0'}}, {{'6', '1'}}, {{'6', '2'}}, {{'6', '3'}}, {{'6', '4'}}, {{'6', '5'}}, {{'6', '6'}}, {{'6', '7'}}, {{'6', '8'}}, {{'6', '9'}},
+                {{'7', '0'}}, {{'7', '1'}}, {{'7', '2'}}, {{'7', '3'}}, {{'7', '4'}}, {{'7', '5'}}, {{'7', '6'}}, {{'7', '7'}}, {{'7', '8'}}, {{'7', '9'}},
+                {{'8', '0'}}, {{'8', '1'}}, {{'8', '2'}}, {{'8', '3'}}, {{'8', '4'}}, {{'8', '5'}}, {{'8', '6'}}, {{'8', '7'}}, {{'8', '8'}}, {{'8', '9'}},
+                {{'9', '0'}}, {{'9', '1'}}, {{'9', '2'}}, {{'9', '3'}}, {{'9', '4'}}, {{'9', '5'}}, {{'9', '6'}}, {{'9', '7'}}, {{'9', '8'}}, {{'9', '9'}},
+            }
+        };
+
+        // special case for "0"
+        if (x == 0)
+        {
+            o->write_character('0');
+            return;
+        }
+
+        // use a pointer to fill the buffer
+        auto buffer_ptr = number_buffer.begin(); // NOLINT(llvm-qualified-auto,readability-qualified-auto,cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+
+        number_unsigned_t abs_value;
+
+        unsigned int n_chars{};
+
+        if (is_negative_number(x))
+        {
+            *buffer_ptr = '-';
+            abs_value = remove_sign(static_cast<number_integer_t>(x));
+
+            // account one more byte for the minus sign
+            n_chars = 1 + count_digits(abs_value);
+        }
+        else
+        {
+            abs_value = static_cast<number_unsigned_t>(x);
+            n_chars = count_digits(abs_value);
+        }
+
+        // spare 1 byte for '\0'
+        JSON_ASSERT(n_chars < number_buffer.size() - 1);
+
+        // jump to the end to generate the string from backward,
+        // so we later avoid reversing the result
+        buffer_ptr += n_chars;
+
+        // Fast int2ascii implementation inspired by "Fastware" talk by Andrei Alexandrescu
+        // See: https://www.youtube.com/watch?v=o4-CwDo2zpg
+        while (abs_value >= 100)
+        {
+            const auto digits_index = static_cast<unsigned>((abs_value % 100));
+            abs_value /= 100;
+            *(--buffer_ptr) = digits_to_99[digits_index][1];
+            *(--buffer_ptr) = digits_to_99[digits_index][0];
+        }
+
+        if (abs_value >= 10)
+        {
+            const auto digits_index = static_cast<unsigned>(abs_value);
+            *(--buffer_ptr) = digits_to_99[digits_index][1];
+            *(--buffer_ptr) = digits_to_99[digits_index][0];
+        }
+        else
+        {
+            *(--buffer_ptr) = static_cast<char>('0' + abs_value);
+        }
+
+        o->write_characters(number_buffer.data(), n_chars);
+    }
+
+    /*!
+    @brief dump a floating-point number
+
+    Dump a given floating-point number to output stream @a o. Works internally
+    with @a number_buffer.
+
+    @param[in] x  floating-point number to dump
+    */
+    void dump_float(number_float_t x)
+    {
+        // NaN / inf
+        if (!std::isfinite(x))
+        {
+            o->write_characters("null", 4);
+            return;
+        }
+
+        // If number_float_t is an IEEE-754 single or double precision number,
+        // use the Grisu2 algorithm to produce short numbers which are
+        // guaranteed to round-trip, using strtof and strtod, resp.
+        //
+        // NB: The test below works if <long double> == <double>.
+        static constexpr bool is_ieee_single_or_double
+            = (std::numeric_limits<number_float_t>::is_iec559 && std::numeric_limits<number_float_t>::digits == 24 && std::numeric_limits<number_float_t>::max_exponent == 128) ||
+              (std::numeric_limits<number_float_t>::is_iec559 && std::numeric_limits<number_float_t>::digits == 53 && std::numeric_limits<number_float_t>::max_exponent == 1024);
+
+        dump_float(x, std::integral_constant<bool, is_ieee_single_or_double>());
+    }
+
+    void dump_float(number_float_t x, std::true_type /*is_ieee_single_or_double*/)
+    {
+        auto* begin = number_buffer.data();
+        auto* end = ::nlohmann::detail::to_chars(begin, begin + number_buffer.size(), x);
+
+        o->write_characters(begin, static_cast<size_t>(end - begin));
+    }
+
+    void dump_float(number_float_t x, std::false_type /*is_ieee_single_or_double*/)
+    {
+        // get number of digits for a float -> text -> float round-trip
+        static constexpr auto d = std::numeric_limits<number_float_t>::max_digits10;
+
+        // the actual conversion
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+        std::ptrdiff_t len = (std::snprintf)(number_buffer.data(), number_buffer.size(), "%.*g", d, x);
+
+        // negative value indicates an error
+        JSON_ASSERT(len > 0);
+        // check if buffer was large enough
+        JSON_ASSERT(static_cast<std::size_t>(len) < number_buffer.size());
+
+        // erase thousands separator
+        if (thousands_sep != '\0')
+        {
+            // NOLINTNEXTLINE(readability-qualified-auto,llvm-qualified-auto): std::remove returns an iterator, see https://github.com/nlohmann/json/issues/3081
+            const auto end = std::remove(number_buffer.begin(), number_buffer.begin() + len, thousands_sep);
+            std::fill(end, number_buffer.end(), '\0');
+            JSON_ASSERT((end - number_buffer.begin()) <= len);
+            len = (end - number_buffer.begin());
+        }
+
+        // convert decimal point to '.'
+        if (decimal_point != '\0' && decimal_point != '.')
+        {
+            // NOLINTNEXTLINE(readability-qualified-auto,llvm-qualified-auto): std::find returns an iterator, see https://github.com/nlohmann/json/issues/3081
+            const auto dec_pos = std::find(number_buffer.begin(), number_buffer.end(), decimal_point);
+            if (dec_pos != number_buffer.end())
+            {
+                *dec_pos = '.';
+            }
+        }
+
+        o->write_characters(number_buffer.data(), static_cast<std::size_t>(len));
+
+        // determine if we need to append ".0"
+        const bool value_is_int_like =
+            std::none_of(number_buffer.begin(), number_buffer.begin() + len + 1,
+                         [](char c)
+        {
+            return c == '.' || c == 'e';
+        });
+
+        if (value_is_int_like)
+        {
+            o->write_characters(".0", 2);
+        }
+    }
+
+    /*!
+    @brief check whether a string is UTF-8 encoded
+
+    The function checks each byte of a string whether it is UTF-8 encoded. The
+    result of the check is stored in the @a state parameter. The function must
+    be called initially with state 0 (accept). State 1 means the string must
+    be rejected, because the current byte is not allowed. If the string is
+    completely processed, but the state is non-zero, the string ended
+    prematurely; that is, the last byte indicated more bytes should have
+    followed.
+
+    @param[in,out] state  the state of the decoding
+    @param[in,out] codep  codepoint (valid only if resulting state is UTF8_ACCEPT)
+    @param[in] byte       next byte to decode
+    @return               new state
+
+    @note The function has been edited: a std::array is used.
+
+    @copyright Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+    @sa http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+    */
+    static std::uint8_t decode(std::uint8_t& state, std::uint32_t& codep, const std::uint8_t byte) noexcept
+    {
+        static const std::array<std::uint8_t, 400> utf8d =
+        {
+            {
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 00..1F
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 20..3F
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 40..5F
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 60..7F
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, // 80..9F
+                7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, // A0..BF
+                8, 8, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // C0..DF
+                0xA, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x3, 0x4, 0x3, 0x3, // E0..EF
+                0xB, 0x6, 0x6, 0x6, 0x5, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, 0x8, // F0..FF
+                0x0, 0x1, 0x2, 0x3, 0x5, 0x8, 0x7, 0x1, 0x1, 0x1, 0x4, 0x6, 0x1, 0x1, 0x1, 0x1, // s0..s0
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, // s1..s2
+                1, 2, 1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, // s3..s4
+                1, 2, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, // s5..s6
+                1, 3, 1, 1, 1, 1, 1, 3, 1, 3, 1, 1, 1, 1, 1, 1, 1, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 // s7..s8
+            }
+        };
+
+        JSON_ASSERT(byte < utf8d.size());
+        const std::uint8_t type = utf8d[byte];
+
+        codep = (state != UTF8_ACCEPT)
+                ? (byte & 0x3fu) | (codep << 6u)
+                : (0xFFu >> type) & (byte);
+
+        const std::size_t index = 256u + static_cast<size_t>(state) * 16u + static_cast<size_t>(type);
+        JSON_ASSERT(index < utf8d.size());
+        state = utf8d[index];
+        return state;
+    }
+
+    /*
+     * Overload to make the compiler happy while it is instantiating
+     * dump_integer for number_unsigned_t.
+     * Must never be called.
+     */
+    number_unsigned_t remove_sign(number_unsigned_t x)
+    {
+        JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+        return x; // LCOV_EXCL_LINE
+    }
+
+    /*
+     * Helper function for dump_integer
+     *
+     * This function takes a negative signed integer and returns its absolute
+     * value as unsigned integer. The plus/minus shuffling is necessary as we can
+     * not directly remove the sign of an arbitrary signed integer as the
+     * absolute values of INT_MIN and INT_MAX are usually not the same. See
+     * #1708 for details.
+     */
+    inline number_unsigned_t remove_sign(number_integer_t x) noexcept
+    {
+        JSON_ASSERT(x < 0 && x < (std::numeric_limits<number_integer_t>::max)()); // NOLINT(misc-redundant-expression)
+        return static_cast<number_unsigned_t>(-(x + 1)) + 1;
+    }
+
+  private:
+    /// the output of the serializer
+    output_adapter_t<char> o = nullptr;
+
+    /// a (hopefully) large enough character buffer
+    std::array<char, 64> number_buffer{{}};
+
+    /// the locale
+    const std::lconv* loc = nullptr;
+    /// the locale's thousand separator character
+    const char thousands_sep = '\0';
+    /// the locale's decimal point character
+    const char decimal_point = '\0';
+
+    /// string buffer
+    std::array<char, 512> string_buffer{{}};
+
+    /// the indentation character
+    const char indent_char;
+    /// the indentation string
+    string_t indent_string;
+
+    /// error_handler how to react on decoding errors
+    const error_handler_t error_handler;
+};
+
+}  // namespace detail
+NLOHMANN_JSON_NAMESPACE_END
+
+// #include <nlohmann/detail/value_t.hpp>
+
+// #include <nlohmann/json_fwd.hpp>
+
+// #include <nlohmann/ordered_map.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#include <functional> // equal_to, less
+#include <initializer_list> // initializer_list
+#include <iterator> // input_iterator_tag, iterator_traits
+#include <memory> // allocator
+#include <stdexcept> // for out_of_range
+#include <type_traits> // enable_if, is_convertible
+#include <utility> // pair
+#include <vector> // vector
+
+// #include <nlohmann/detail/macro_scope.hpp>
+
+// #include <nlohmann/detail/meta/type_traits.hpp>
+
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+
+/// ordered_map: a minimal map-like container that preserves insertion order
+/// for use within nlohmann::basic_json<ordered_map>
+template <class Key, class T, class IgnoredLess = std::less<Key>,
+          class Allocator = std::allocator<std::pair<const Key, T>>>
+                  struct ordered_map : std::vector<std::pair<const Key, T>, Allocator>
+{
+    using key_type = Key;
+    using mapped_type = T;
+    using Container = std::vector<std::pair<const Key, T>, Allocator>;
+    using iterator = typename Container::iterator;
+    using const_iterator = typename Container::const_iterator;
+    using size_type = typename Container::size_type;
+    using value_type = typename Container::value_type;
+#ifdef JSON_HAS_CPP_14
+    using key_compare = std::equal_to<>;
+#else
+    using key_compare = std::equal_to<Key>;
+#endif
+
+    // Explicit constructors instead of `using Container::Container`
+    // otherwise older compilers choke on it (GCC <= 5.5, xcode <= 9.4)
+    ordered_map() noexcept(noexcept(Container())) : Container{} {}
+    explicit ordered_map(const Allocator& alloc) noexcept(noexcept(Container(alloc))) : Container{alloc} {}
+    template <class It>
+    ordered_map(It first, It last, const Allocator& alloc = Allocator())
+        : Container{first, last, alloc} {}
+    ordered_map(std::initializer_list<value_type> init, const Allocator& alloc = Allocator() )
+        : Container{init, alloc} {}
+
+    std::pair<iterator, bool> emplace(const key_type& key, T&& t)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return {it, false};
+            }
+        }
+        Container::emplace_back(key, std::forward<T>(t));
+        return {std::prev(this->end()), true};
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    std::pair<iterator, bool> emplace(KeyType && key, T && t)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return {it, false};
+            }
+        }
+        Container::emplace_back(std::forward<KeyType>(key), std::forward<T>(t));
+        return {std::prev(this->end()), true};
+    }
+
+    T& operator[](const key_type& key)
+    {
+        return emplace(key, T{}).first->second;
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    T & operator[](KeyType && key)
+    {
+        return emplace(std::forward<KeyType>(key), T{}).first->second;
+    }
+
+    const T& operator[](const key_type& key) const
+    {
+        return at(key);
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    const T & operator[](KeyType && key) const
+    {
+        return at(std::forward<KeyType>(key));
+    }
+
+    T& at(const key_type& key)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it->second;
+            }
+        }
+
+        JSON_THROW(std::out_of_range("key not found"));
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    T & at(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it->second;
+            }
+        }
+
+        JSON_THROW(std::out_of_range("key not found"));
+    }
+
+    const T& at(const key_type& key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it->second;
+            }
+        }
+
+        JSON_THROW(std::out_of_range("key not found"));
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    const T & at(KeyType && key) const // NOLINT(cppcoreguidelines-missing-std-forward)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it->second;
+            }
+        }
+
+        JSON_THROW(std::out_of_range("key not found"));
+    }
+
+    size_type erase(const key_type& key)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                // Since we cannot move const Keys, re-construct them in place
+                for (auto next = it; ++next != this->end(); ++it)
+                {
+                    it->~value_type(); // Destroy but keep allocation
+                    new (&*it) value_type{std::move(*next)};
+                }
+                Container::pop_back();
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    size_type erase(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                // Since we cannot move const Keys, re-construct them in place
+                for (auto next = it; ++next != this->end(); ++it)
+                {
+                    it->~value_type(); // Destroy but keep allocation
+                    new (&*it) value_type{std::move(*next)};
+                }
+                Container::pop_back();
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    iterator erase(iterator pos)
+    {
+        return erase(pos, std::next(pos));
+    }
+
+    iterator erase(iterator first, iterator last)
+    {
+        if (first == last)
+        {
+            return first;
+        }
+
+        const auto elements_affected = std::distance(first, last);
+        const auto offset = std::distance(Container::begin(), first);
+
+        // This is the start situation. We need to delete elements_affected
+        // elements (3 in this example: e, f, g), and need to return an
+        // iterator past the last deleted element (h in this example).
+        // Note that offset is the distance from the start of the vector
+        // to first. We will need this later.
+
+        // [ a, b, c, d, e, f, g, h, i, j ]
+        //               ^        ^
+        //             first    last
+
+        // Since we cannot move const Keys, we re-construct them in place.
+        // We start at first and re-construct (viz. copy) the elements from
+        // the back of the vector. Example for first iteration:
+
+        //               ,--------.
+        //               v        |   destroy e and re-construct with h
+        // [ a, b, c, d, e, f, g, h, i, j ]
+        //               ^        ^
+        //               it       it + elements_affected
+
+        for (auto it = first; std::next(it, elements_affected) != Container::end(); ++it)
+        {
+            it->~value_type(); // destroy but keep allocation
+            new (&*it) value_type{std::move(*std::next(it, elements_affected))}; // "move" next element to it
+        }
+
+        // [ a, b, c, d, h, i, j, h, i, j ]
+        //               ^        ^
+        //             first    last
+
+        // remove the unneeded elements at the end of the vector
+        Container::resize(this->size() - static_cast<size_type>(elements_affected));
+
+        // [ a, b, c, d, h, i, j ]
+        //               ^        ^
+        //             first    last
+
+        // first is now pointing past the last deleted element, but we cannot
+        // use this iterator, because it may have been invalidated by the
+        // resize call. Instead, we can return begin() + offset.
+        return Container::begin() + offset;
+    }
+
+    size_type count(const key_type& key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    size_type count(KeyType && key) const // NOLINT(cppcoreguidelines-missing-std-forward)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    iterator find(const key_type& key)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it;
+            }
+        }
+        return Container::end();
+    }
+
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_key_type<key_compare, key_type, KeyType>::value, int> = 0>
+    iterator find(KeyType && key) // NOLINT(cppcoreguidelines-missing-std-forward)
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it;
+            }
+        }
+        return Container::end();
+    }
+
+    const_iterator find(const key_type& key) const
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, key))
+            {
+                return it;
+            }
+        }
+        return Container::end();
+    }
+
+    std::pair<iterator, bool> insert( value_type&& value )
+    {
+        return emplace(value.first, std::move(value.second));
+    }
+
+    std::pair<iterator, bool> insert( const value_type& value )
+    {
+        for (auto it = this->begin(); it != this->end(); ++it)
+        {
+            if (m_compare(it->first, value.first))
+            {
+                return {it, false};
+            }
+        }
+        Container::push_back(value);
+        return {--this->end(), true};
+    }
+
+    template<typename InputIt>
+    using require_input_iter = typename std::enable_if<std::is_convertible<typename std::iterator_traits<InputIt>::iterator_category,
+            std::input_iterator_tag>::value>::type;
+
+    template<typename InputIt, typename = require_input_iter<InputIt>>
+    void insert(InputIt first, InputIt last)
+    {
+        for (auto it = first; it != last; ++it)
+        {
+            insert(*it);
+        }
+    }
+
+private:
+    JSON_NO_UNIQUE_ADDRESS key_compare m_compare = key_compare();
+};
+
+NLOHMANN_JSON_NAMESPACE_END
+
+
+#if defined(JSON_HAS_CPP_17)
+    #if JSON_HAS_STATIC_RTTI
+        #include <any>
+    #endif
+    #include <string_view>
+#endif
+
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+NLOHMANN_JSON_NAMESPACE_BEGIN
+
+/*!
+@brief a class to store JSON values
+
+@internal
+@invariant The member variables @a m_value and @a m_type have the following
+relationship:
+- If `m_type == value_t::object`, then `m_value.object != nullptr`.
+- If `m_type == value_t::array`, then `m_value.array != nullptr`.
+- If `m_type == value_t::string`, then `m_value.string != nullptr`.
+The invariants are checked by member function assert_invariant().
+
+@note ObjectType trick from https://stackoverflow.com/a/9860911
+@endinternal
+
+@since version 1.0.0
+
+@nosubgrouping
+*/
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)
+    : public ::nlohmann::detail::json_base_class<CustomBaseClass>
+{
+  private:
+    template<detail::value_t> friend struct detail::external_constructor;
+
+    template<typename>
+    friend class ::nlohmann::json_pointer;
+    // can be restored when json_pointer backwards compatibility is removed
+    // friend ::nlohmann::json_pointer<StringType>;
+
+    template<typename BasicJsonType, typename InputType>
+    friend class ::nlohmann::detail::parser;
+    friend ::nlohmann::detail::serializer<basic_json>;
+    template<typename BasicJsonType>
+    friend class ::nlohmann::detail::iter_impl;
+    template<typename BasicJsonType, typename CharType>
+    friend class ::nlohmann::detail::binary_writer;
+    template<typename BasicJsonType, typename InputType, typename SAX>
+    friend class ::nlohmann::detail::binary_reader;
+    template<typename BasicJsonType>
+    friend class ::nlohmann::detail::json_sax_dom_parser;
+    template<typename BasicJsonType>
+    friend class ::nlohmann::detail::json_sax_dom_callback_parser;
+    friend class ::nlohmann::detail::exception;
+
+    /// workaround type for MSVC
+    using basic_json_t = NLOHMANN_BASIC_JSON_TPL;
+    using json_base_class_t = ::nlohmann::detail::json_base_class<CustomBaseClass>;
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    // convenience aliases for types residing in namespace detail;
+    using lexer = ::nlohmann::detail::lexer_base<basic_json>;
+
+    template<typename InputAdapterType>
+    static ::nlohmann::detail::parser<basic_json, InputAdapterType> parser(
+        InputAdapterType adapter,
+        detail::parser_callback_t<basic_json>cb = nullptr,
+        const bool allow_exceptions = true,
+        const bool ignore_comments = false
+                                 )
+    {
+        return ::nlohmann::detail::parser<basic_json, InputAdapterType>(std::move(adapter),
+                std::move(cb), allow_exceptions, ignore_comments);
+    }
+
+  private:
+    using primitive_iterator_t = ::nlohmann::detail::primitive_iterator_t;
+    template<typename BasicJsonType>
+    using internal_iterator = ::nlohmann::detail::internal_iterator<BasicJsonType>;
+    template<typename BasicJsonType>
+    using iter_impl = ::nlohmann::detail::iter_impl<BasicJsonType>;
+    template<typename Iterator>
+    using iteration_proxy = ::nlohmann::detail::iteration_proxy<Iterator>;
+    template<typename Base> using json_reverse_iterator = ::nlohmann::detail::json_reverse_iterator<Base>;
+
+    template<typename CharType>
+    using output_adapter_t = ::nlohmann::detail::output_adapter_t<CharType>;
+
+    template<typename InputType>
+    using binary_reader = ::nlohmann::detail::binary_reader<basic_json, InputType>;
+    template<typename CharType> using binary_writer = ::nlohmann::detail::binary_writer<basic_json, CharType>;
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    using serializer = ::nlohmann::detail::serializer<basic_json>;
+
+  public:
+    using value_t = detail::value_t;
+    /// JSON Pointer, see @ref nlohmann::json_pointer
+    using json_pointer = ::nlohmann::json_pointer<StringType>;
+    template<typename T, typename SFINAE>
+    using json_serializer = JSONSerializer<T, SFINAE>;
+    /// how to treat decoding errors
+    using error_handler_t = detail::error_handler_t;
+    /// how to treat CBOR tags
+    using cbor_tag_handler_t = detail::cbor_tag_handler_t;
+    /// helper type for initializer lists of basic_json values
+    using initializer_list_t = std::initializer_list<detail::json_ref<basic_json>>;
+
+    using input_format_t = detail::input_format_t;
+    /// SAX interface type, see @ref nlohmann::json_sax
+    using json_sax_t = json_sax<basic_json>;
+
+    ////////////////
+    // exceptions //
+    ////////////////
+
+    /// @name exceptions
+    /// Classes to implement user-defined exceptions.
+    /// @{
+
+    using exception = detail::exception;
+    using parse_error = detail::parse_error;
+    using invalid_iterator = detail::invalid_iterator;
+    using type_error = detail::type_error;
+    using out_of_range = detail::out_of_range;
+    using other_error = detail::other_error;
+
+    /// @}
+
+    /////////////////////
+    // container types //
+    /////////////////////
+
+    /// @name container types
+    /// The canonic container types to use @ref basic_json like any other STL
+    /// container.
+    /// @{
+
+    /// the type of elements in a basic_json container
+    using value_type = basic_json;
+
+    /// the type of an element reference
+    using reference = value_type&;
+    /// the type of an element const reference
+    using const_reference = const value_type&;
+
+    /// a type to represent differences between iterators
+    using difference_type = std::ptrdiff_t;
+    /// a type to represent container sizes
+    using size_type = std::size_t;
+
+    /// the allocator type
+    using allocator_type = AllocatorType<basic_json>;
+
+    /// the type of an element pointer
+    using pointer = typename std::allocator_traits<allocator_type>::pointer;
+    /// the type of an element const pointer
+    using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
+
+    /// an iterator for a basic_json container
+    using iterator = iter_impl<basic_json>;
+    /// a const iterator for a basic_json container
+    using const_iterator = iter_impl<const basic_json>;
+    /// a reverse iterator for a basic_json container
+    using reverse_iterator = json_reverse_iterator<typename basic_json::iterator>;
+    /// a const reverse iterator for a basic_json container
+    using const_reverse_iterator = json_reverse_iterator<typename basic_json::const_iterator>;
+
+    /// @}
+
+    /// @brief returns the allocator associated with the container
+    /// @sa https://json.nlohmann.me/api/basic_json/get_allocator/
+    static allocator_type get_allocator()
+    {
+        return allocator_type();
+    }
+
+    /// @brief returns version information on the library
+    /// @sa https://json.nlohmann.me/api/basic_json/meta/
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json meta()
+    {
+        basic_json result;
+
+        result["copyright"] = "(C) 2013-2023 Niels Lohmann";
+        result["name"] = "JSON for Modern C++";
+        result["url"] = "https://github.com/nlohmann/json";
+        result["version"]["string"] =
+            detail::concat(std::to_string(NLOHMANN_JSON_VERSION_MAJOR), '.',
+                           std::to_string(NLOHMANN_JSON_VERSION_MINOR), '.',
+                           std::to_string(NLOHMANN_JSON_VERSION_PATCH));
+        result["version"]["major"] = NLOHMANN_JSON_VERSION_MAJOR;
+        result["version"]["minor"] = NLOHMANN_JSON_VERSION_MINOR;
+        result["version"]["patch"] = NLOHMANN_JSON_VERSION_PATCH;
+
+#ifdef _WIN32
+        result["platform"] = "win32";
+#elif defined __linux__
+        result["platform"] = "linux";
+#elif defined __APPLE__
+        result["platform"] = "apple";
+#elif defined __unix__
+        result["platform"] = "unix";
+#else
+        result["platform"] = "unknown";
+#endif
+
+#if defined(__ICC) || defined(__INTEL_COMPILER)
+        result["compiler"] = {{"family", "icc"}, {"version", __INTEL_COMPILER}};
+#elif defined(__clang__)
+        result["compiler"] = {{"family", "clang"}, {"version", __clang_version__}};
+#elif defined(__GNUC__) || defined(__GNUG__)
+        result["compiler"] = {{"family", "gcc"}, {"version", detail::concat(
+                    std::to_string(__GNUC__), '.',
+                    std::to_string(__GNUC_MINOR__), '.',
+                    std::to_string(__GNUC_PATCHLEVEL__))
+            }
+        };
+#elif defined(__HP_cc) || defined(__HP_aCC)
+        result["compiler"] = "hp"
+#elif defined(__IBMCPP__)
+        result["compiler"] = {{"family", "ilecpp"}, {"version", __IBMCPP__}};
+#elif defined(_MSC_VER)
+        result["compiler"] = {{"family", "msvc"}, {"version", _MSC_VER}};
+#elif defined(__PGI)
+        result["compiler"] = {{"family", "pgcpp"}, {"version", __PGI}};
+#elif defined(__SUNPRO_CC)
+        result["compiler"] = {{"family", "sunpro"}, {"version", __SUNPRO_CC}};
+#else
+        result["compiler"] = {{"family", "unknown"}, {"version", "unknown"}};
+#endif
+
+#if defined(_MSVC_LANG)
+        result["compiler"]["c++"] = std::to_string(_MSVC_LANG);
+#elif defined(__cplusplus)
+        result["compiler"]["c++"] = std::to_string(__cplusplus);
+#else
+        result["compiler"]["c++"] = "unknown";
+#endif
+        return result;
+    }
+
+    ///////////////////////////
+    // JSON value data types //
+    ///////////////////////////
+
+    /// @name JSON value data types
+    /// The data types to store a JSON value. These types are derived from
+    /// the template arguments passed to class @ref basic_json.
+    /// @{
+
+    /// @brief default object key comparator type
+    /// The actual object key comparator type (@ref object_comparator_t) may be
+    /// different.
+    /// @sa https://json.nlohmann.me/api/basic_json/default_object_comparator_t/
+#if defined(JSON_HAS_CPP_14)
+    // use of transparent comparator avoids unnecessary repeated construction of temporaries
+    // in functions involving lookup by key with types other than object_t::key_type (aka. StringType)
+    using default_object_comparator_t = std::less<>;
+#else
+    using default_object_comparator_t = std::less<StringType>;
+#endif
+
+    /// @brief a type for an object
+    /// @sa https://json.nlohmann.me/api/basic_json/object_t/
+    using object_t = ObjectType<StringType,
+          basic_json,
+          default_object_comparator_t,
+          AllocatorType<std::pair<const StringType,
+          basic_json>>>;
+
+    /// @brief a type for an array
+    /// @sa https://json.nlohmann.me/api/basic_json/array_t/
+    using array_t = ArrayType<basic_json, AllocatorType<basic_json>>;
+
+    /// @brief a type for a string
+    /// @sa https://json.nlohmann.me/api/basic_json/string_t/
+    using string_t = StringType;
+
+    /// @brief a type for a boolean
+    /// @sa https://json.nlohmann.me/api/basic_json/boolean_t/
+    using boolean_t = BooleanType;
+
+    /// @brief a type for a number (integer)
+    /// @sa https://json.nlohmann.me/api/basic_json/number_integer_t/
+    using number_integer_t = NumberIntegerType;
+
+    /// @brief a type for a number (unsigned)
+    /// @sa https://json.nlohmann.me/api/basic_json/number_unsigned_t/
+    using number_unsigned_t = NumberUnsignedType;
+
+    /// @brief a type for a number (floating-point)
+    /// @sa https://json.nlohmann.me/api/basic_json/number_float_t/
+    using number_float_t = NumberFloatType;
+
+    /// @brief a type for a packed binary type
+    /// @sa https://json.nlohmann.me/api/basic_json/binary_t/
+    using binary_t = nlohmann::byte_container_with_subtype<BinaryType>;
+
+    /// @brief object key comparator type
+    /// @sa https://json.nlohmann.me/api/basic_json/object_comparator_t/
+    using object_comparator_t = detail::actual_object_comparator_t<basic_json>;
+
+    /// @}
+
+  private:
+
+    /// helper for exception-safe object creation
+    template<typename T, typename... Args>
+    JSON_HEDLEY_RETURNS_NON_NULL
+    static T* create(Args&& ... args)
+    {
+        AllocatorType<T> alloc;
+        using AllocatorTraits = std::allocator_traits<AllocatorType<T>>;
+
+        auto deleter = [&](T * obj)
+        {
+            AllocatorTraits::deallocate(alloc, obj, 1);
+        };
+        std::unique_ptr<T, decltype(deleter)> obj(AllocatorTraits::allocate(alloc, 1), deleter);
+        AllocatorTraits::construct(alloc, obj.get(), std::forward<Args>(args)...);
+        JSON_ASSERT(obj != nullptr);
+        return obj.release();
+    }
+
+    ////////////////////////
+    // JSON value storage //
+    ////////////////////////
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    /*!
+    @brief a JSON value
+
+    The actual storage for a JSON value of the @ref basic_json class. This
+    union combines the different storage types for the JSON value types
+    defined in @ref value_t.
+
+    JSON type | value_t type    | used type
+    --------- | --------------- | ------------------------
+    object    | object          | pointer to @ref object_t
+    array     | array           | pointer to @ref array_t
+    string    | string          | pointer to @ref string_t
+    boolean   | boolean         | @ref boolean_t
+    number    | number_integer  | @ref number_integer_t
+    number    | number_unsigned | @ref number_unsigned_t
+    number    | number_float    | @ref number_float_t
+    binary    | binary          | pointer to @ref binary_t
+    null      | null            | *no value is stored*
+
+    @note Variable-length types (objects, arrays, and strings) are stored as
+    pointers. The size of the union should not exceed 64 bits if the default
+    value types are used.
+
+    @since version 1.0.0
+    */
+    union json_value
+    {
+        /// object (stored with pointer to save storage)
+        object_t* object;
+        /// array (stored with pointer to save storage)
+        array_t* array;
+        /// string (stored with pointer to save storage)
+        string_t* string;
+        /// binary (stored with pointer to save storage)
+        binary_t* binary;
+        /// boolean
+        boolean_t boolean;
+        /// number (integer)
+        number_integer_t number_integer;
+        /// number (unsigned integer)
+        number_unsigned_t number_unsigned;
+        /// number (floating-point)
+        number_float_t number_float;
+
+        /// default constructor (for null values)
+        json_value() = default;
+        /// constructor for booleans
+        json_value(boolean_t v) noexcept : boolean(v) {}
+        /// constructor for numbers (integer)
+        json_value(number_integer_t v) noexcept : number_integer(v) {}
+        /// constructor for numbers (unsigned)
+        json_value(number_unsigned_t v) noexcept : number_unsigned(v) {}
+        /// constructor for numbers (floating-point)
+        json_value(number_float_t v) noexcept : number_float(v) {}
+        /// constructor for empty values of a given type
+        json_value(value_t t)
+        {
+            switch (t)
+            {
+                case value_t::object:
+                {
+                    object = create<object_t>();
+                    break;
+                }
+
+                case value_t::array:
+                {
+                    array = create<array_t>();
+                    break;
+                }
+
+                case value_t::string:
+                {
+                    string = create<string_t>("");
+                    break;
+                }
+
+                case value_t::binary:
+                {
+                    binary = create<binary_t>();
+                    break;
+                }
+
+                case value_t::boolean:
+                {
+                    boolean = static_cast<boolean_t>(false);
+                    break;
+                }
+
+                case value_t::number_integer:
+                {
+                    number_integer = static_cast<number_integer_t>(0);
+                    break;
+                }
+
+                case value_t::number_unsigned:
+                {
+                    number_unsigned = static_cast<number_unsigned_t>(0);
+                    break;
+                }
+
+                case value_t::number_float:
+                {
+                    number_float = static_cast<number_float_t>(0.0);
+                    break;
+                }
+
+                case value_t::null:
+                {
+                    object = nullptr;  // silence warning, see #821
+                    break;
+                }
+
+                case value_t::discarded:
+                default:
+                {
+                    object = nullptr;  // silence warning, see #821
+                    if (JSON_HEDLEY_UNLIKELY(t == value_t::null))
+                    {
+                        JSON_THROW(other_error::create(500, "961c151d2e87f2686a955a9be24d316f1362bf21 3.11.3", nullptr)); // LCOV_EXCL_LINE
+                    }
+                    break;
+                }
+            }
+        }
+
+        /// constructor for strings
+        json_value(const string_t& value) : string(create<string_t>(value)) {}
+
+        /// constructor for rvalue strings
+        json_value(string_t&& value) : string(create<string_t>(std::move(value))) {}
+
+        /// constructor for objects
+        json_value(const object_t& value) : object(create<object_t>(value)) {}
+
+        /// constructor for rvalue objects
+        json_value(object_t&& value) : object(create<object_t>(std::move(value))) {}
+
+        /// constructor for arrays
+        json_value(const array_t& value) : array(create<array_t>(value)) {}
+
+        /// constructor for rvalue arrays
+        json_value(array_t&& value) : array(create<array_t>(std::move(value))) {}
+
+        /// constructor for binary arrays
+        json_value(const typename binary_t::container_type& value) : binary(create<binary_t>(value)) {}
+
+        /// constructor for rvalue binary arrays
+        json_value(typename binary_t::container_type&& value) : binary(create<binary_t>(std::move(value))) {}
+
+        /// constructor for binary arrays (internal type)
+        json_value(const binary_t& value) : binary(create<binary_t>(value)) {}
+
+        /// constructor for rvalue binary arrays (internal type)
+        json_value(binary_t&& value) : binary(create<binary_t>(std::move(value))) {}
+
+        void destroy(value_t t)
+        {
+            if (
+                (t == value_t::object && object == nullptr) ||
+                (t == value_t::array && array == nullptr) ||
+                (t == value_t::string && string == nullptr) ||
+                (t == value_t::binary && binary == nullptr)
+            )
+            {
+                //not initialized (e.g. due to exception in the ctor)
+                return;
+            }
+            if (t == value_t::array || t == value_t::object)
+            {
+                // flatten the current json_value to a heap-allocated stack
+                std::vector<basic_json> stack;
+
+                // move the top-level items to stack
+                if (t == value_t::array)
+                {
+                    stack.reserve(array->size());
+                    std::move(array->begin(), array->end(), std::back_inserter(stack));
+                }
+                else
+                {
+                    stack.reserve(object->size());
+                    for (auto&& it : *object)
+                    {
+                        stack.push_back(std::move(it.second));
+                    }
+                }
+
+                while (!stack.empty())
+                {
+                    // move the last item to local variable to be processed
+                    basic_json current_item(std::move(stack.back()));
+                    stack.pop_back();
+
+                    // if current_item is array/object, move
+                    // its children to the stack to be processed later
+                    if (current_item.is_array())
+                    {
+                        std::move(current_item.m_data.m_value.array->begin(), current_item.m_data.m_value.array->end(), std::back_inserter(stack));
+
+                        current_item.m_data.m_value.array->clear();
+                    }
+                    else if (current_item.is_object())
+                    {
+                        for (auto&& it : *current_item.m_data.m_value.object)
+                        {
+                            stack.push_back(std::move(it.second));
+                        }
+
+                        current_item.m_data.m_value.object->clear();
+                    }
+
+                    // it's now safe that current_item get destructed
+                    // since it doesn't have any children
+                }
+            }
+
+            switch (t)
+            {
+                case value_t::object:
+                {
+                    AllocatorType<object_t> alloc;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, object);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, object, 1);
+                    break;
+                }
+
+                case value_t::array:
+                {
+                    AllocatorType<array_t> alloc;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, array);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, array, 1);
+                    break;
+                }
+
+                case value_t::string:
+                {
+                    AllocatorType<string_t> alloc;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, string);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, string, 1);
+                    break;
+                }
+
+                case value_t::binary:
+                {
+                    AllocatorType<binary_t> alloc;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, binary);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, binary, 1);
+                    break;
+                }
+
+                case value_t::null:
+                case value_t::boolean:
+                case value_t::number_integer:
+                case value_t::number_unsigned:
+                case value_t::number_float:
+                case value_t::discarded:
+                default:
+                {
+                    break;
+                }
+            }
+        }
+    };
+
+  private:
+    /*!
+    @brief checks the class invariants
+
+    This function asserts the class invariants. It needs to be called at the
+    end of every constructor to make sure that created objects respect the
+    invariant. Furthermore, it has to be called each time the type of a JSON
+    value is changed, because the invariant expresses a relationship between
+    @a m_type and @a m_value.
+
+    Furthermore, the parent relation is checked for arrays and objects: If
+    @a check_parents true and the value is an array or object, then the
+    container's elements must have the current value as parent.
+
+    @param[in] check_parents  whether the parent relation should be checked.
+               The value is true by default and should only be set to false
+               during destruction of objects when the invariant does not
+               need to hold.
+    */
+    void assert_invariant(bool check_parents = true) const noexcept
+    {
+        JSON_ASSERT(m_data.m_type != value_t::object || m_data.m_value.object != nullptr);
+        JSON_ASSERT(m_data.m_type != value_t::array || m_data.m_value.array != nullptr);
+        JSON_ASSERT(m_data.m_type != value_t::string || m_data.m_value.string != nullptr);
+        JSON_ASSERT(m_data.m_type != value_t::binary || m_data.m_value.binary != nullptr);
+
+#if JSON_DIAGNOSTICS
+        JSON_TRY
+        {
+            // cppcheck-suppress assertWithSideEffect
+            JSON_ASSERT(!check_parents || !is_structured() || std::all_of(begin(), end(), [this](const basic_json & j)
+            {
+                return j.m_parent == this;
+            }));
+        }
+        JSON_CATCH(...) {} // LCOV_EXCL_LINE
+#endif
+        static_cast<void>(check_parents);
+    }
+
+    void set_parents()
+    {
+#if JSON_DIAGNOSTICS
+        switch (m_data.m_type)
+        {
+            case value_t::array:
+            {
+                for (auto& element : *m_data.m_value.array)
+                {
+                    element.m_parent = this;
+                }
+                break;
+            }
+
+            case value_t::object:
+            {
+                for (auto& element : *m_data.m_value.object)
+                {
+                    element.second.m_parent = this;
+                }
+                break;
+            }
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+                break;
+        }
+#endif
+    }
+
+    iterator set_parents(iterator it, typename iterator::difference_type count_set_parents)
+    {
+#if JSON_DIAGNOSTICS
+        for (typename iterator::difference_type i = 0; i < count_set_parents; ++i)
+        {
+            (it + i)->m_parent = this;
+        }
+#else
+        static_cast<void>(count_set_parents);
+#endif
+        return it;
+    }
+
+    reference set_parent(reference j, std::size_t old_capacity = static_cast<std::size_t>(-1))
+    {
+#if JSON_DIAGNOSTICS
+        if (old_capacity != static_cast<std::size_t>(-1))
+        {
+            // see https://github.com/nlohmann/json/issues/2838
+            JSON_ASSERT(type() == value_t::array);
+            if (JSON_HEDLEY_UNLIKELY(m_data.m_value.array->capacity() != old_capacity))
+            {
+                // capacity has changed: update all parents
+                set_parents();
+                return j;
+            }
+        }
+
+        // ordered_json uses a vector internally, so pointers could have
+        // been invalidated; see https://github.com/nlohmann/json/issues/2962
+#ifdef JSON_HEDLEY_MSVC_VERSION
+#pragma warning(push )
+#pragma warning(disable : 4127) // ignore warning to replace if with if constexpr
+#endif
+        if (detail::is_ordered_map<object_t>::value)
+        {
+            set_parents();
+            return j;
+        }
+#ifdef JSON_HEDLEY_MSVC_VERSION
+#pragma warning( pop )
+#endif
+
+        j.m_parent = this;
+#else
+        static_cast<void>(j);
+        static_cast<void>(old_capacity);
+#endif
+        return j;
+    }
+
+  public:
+    //////////////////////////
+    // JSON parser callback //
+    //////////////////////////
+
+    /// @brief parser event types
+    /// @sa https://json.nlohmann.me/api/basic_json/parse_event_t/
+    using parse_event_t = detail::parse_event_t;
+
+    /// @brief per-element parser callback type
+    /// @sa https://json.nlohmann.me/api/basic_json/parser_callback_t/
+    using parser_callback_t = detail::parser_callback_t<basic_json>;
+
+    //////////////////
+    // constructors //
+    //////////////////
+
+    /// @name constructors and destructors
+    /// Constructors of class @ref basic_json, copy/move constructor, copy
+    /// assignment, static functions creating objects, and the destructor.
+    /// @{
+
+    /// @brief create an empty value with a given type
+    /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
+    basic_json(const value_t v)
+        : m_data(v)
+    {
+        assert_invariant();
+    }
+
+    /// @brief create a null object
+    /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
+    basic_json(std::nullptr_t = nullptr) noexcept // NOLINT(bugprone-exception-escape)
+        : basic_json(value_t::null)
+    {
+        assert_invariant();
+    }
+
+    /// @brief create a JSON value from compatible types
+    /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
+    template < typename CompatibleType,
+               typename U = detail::uncvref_t<CompatibleType>,
+               detail::enable_if_t <
+                   !detail::is_basic_json<U>::value && detail::is_compatible_type<basic_json_t, U>::value, int > = 0 >
+    basic_json(CompatibleType && val) noexcept(noexcept( // NOLINT(bugprone-forwarding-reference-overload,bugprone-exception-escape)
+                JSONSerializer<U>::to_json(std::declval<basic_json_t&>(),
+                                           std::forward<CompatibleType>(val))))
+    {
+        JSONSerializer<U>::to_json(*this, std::forward<CompatibleType>(val));
+        set_parents();
+        assert_invariant();
+    }
+
+    /// @brief create a JSON value from an existing one
+    /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
+    template < typename BasicJsonType,
+               detail::enable_if_t <
+                   detail::is_basic_json<BasicJsonType>::value&& !std::is_same<basic_json, BasicJsonType>::value, int > = 0 >
+    basic_json(const BasicJsonType& val)
+    {
+        using other_boolean_t = typename BasicJsonType::boolean_t;
+        using other_number_float_t = typename BasicJsonType::number_float_t;
+        using other_number_integer_t = typename BasicJsonType::number_integer_t;
+        using other_number_unsigned_t = typename BasicJsonType::number_unsigned_t;
+        using other_string_t = typename BasicJsonType::string_t;
+        using other_object_t = typename BasicJsonType::object_t;
+        using other_array_t = typename BasicJsonType::array_t;
+        using other_binary_t = typename BasicJsonType::binary_t;
+
+        switch (val.type())
+        {
+            case value_t::boolean:
+                JSONSerializer<other_boolean_t>::to_json(*this, val.template get<other_boolean_t>());
+                break;
+            case value_t::number_float:
+                JSONSerializer<other_number_float_t>::to_json(*this, val.template get<other_number_float_t>());
+                break;
+            case value_t::number_integer:
+                JSONSerializer<other_number_integer_t>::to_json(*this, val.template get<other_number_integer_t>());
+                break;
+            case value_t::number_unsigned:
+                JSONSerializer<other_number_unsigned_t>::to_json(*this, val.template get<other_number_unsigned_t>());
+                break;
+            case value_t::string:
+                JSONSerializer<other_string_t>::to_json(*this, val.template get_ref<const other_string_t&>());
+                break;
+            case value_t::object:
+                JSONSerializer<other_object_t>::to_json(*this, val.template get_ref<const other_object_t&>());
+                break;
+            case value_t::array:
+                JSONSerializer<other_array_t>::to_json(*this, val.template get_ref<const other_array_t&>());
+                break;
+            case value_t::binary:
+                JSONSerializer<other_binary_t>::to_json(*this, val.template get_ref<const other_binary_t&>());
+                break;
+            case value_t::null:
+                *this = nullptr;
+                break;
+            case value_t::discarded:
+                m_data.m_type = value_t::discarded;
+                break;
+            default:            // LCOV_EXCL_LINE
+                JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+        }
+        JSON_ASSERT(m_data.m_type == val.type());
+        set_parents();
+        assert_invariant();
+    }
+
+    /// @brief create a container (array or object) from an initializer list
+    /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
+    basic_json(initializer_list_t init,
+               bool type_deduction = true,
+               value_t manual_type = value_t::array)
+    {
+        // check if each element is an array with two elements whose first
+        // element is a string
+        bool is_an_object = std::all_of(init.begin(), init.end(),
+                                        [](const detail::json_ref<basic_json>& element_ref)
+        {
+            // The cast is to ensure op[size_type] is called, bearing in mind size_type may not be int;
+            // (many string types can be constructed from 0 via its null-pointer guise, so we get a
+            // broken call to op[key_type], the wrong semantics and a 4804 warning on Windows)
+            return element_ref->is_array() && element_ref->size() == 2 && (*element_ref)[static_cast<size_type>(0)].is_string();
+        });
+
+        // adjust type if type deduction is not wanted
+        if (!type_deduction)
+        {
+            // if array is wanted, do not create an object though possible
+            if (manual_type == value_t::array)
+            {
+                is_an_object = false;
+            }
+
+            // if object is wanted but impossible, throw an exception
+            if (JSON_HEDLEY_UNLIKELY(manual_type == value_t::object && !is_an_object))
+            {
+                JSON_THROW(type_error::create(301, "cannot create object from initializer list", nullptr));
+            }
+        }
+
+        if (is_an_object)
+        {
+            // the initializer list is a list of pairs -> create object
+            m_data.m_type = value_t::object;
+            m_data.m_value = value_t::object;
+
+            for (auto& element_ref : init)
+            {
+                auto element = element_ref.moved_or_copied();
+                m_data.m_value.object->emplace(
+                    std::move(*((*element.m_data.m_value.array)[0].m_data.m_value.string)),
+                    std::move((*element.m_data.m_value.array)[1]));
+            }
+        }
+        else
+        {
+            // the initializer list describes an array -> create array
+            m_data.m_type = value_t::array;
+            m_data.m_value.array = create<array_t>(init.begin(), init.end());
+        }
+
+        set_parents();
+        assert_invariant();
+    }
+
+    /// @brief explicitly create a binary array (without subtype)
+    /// @sa https://json.nlohmann.me/api/basic_json/binary/
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json binary(const typename binary_t::container_type& init)
+    {
+        auto res = basic_json();
+        res.m_data.m_type = value_t::binary;
+        res.m_data.m_value = init;
+        return res;
+    }
+
+    /// @brief explicitly create a binary array (with subtype)
+    /// @sa https://json.nlohmann.me/api/basic_json/binary/
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json binary(const typename binary_t::container_type& init, typename binary_t::subtype_type subtype)
+    {
+        auto res = basic_json();
+        res.m_data.m_type = value_t::binary;
+        res.m_data.m_value = binary_t(init, subtype);
+        return res;
+    }
+
+    /// @brief explicitly create a binary array
+    /// @sa https://json.nlohmann.me/api/basic_json/binary/
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json binary(typename binary_t::container_type&& init)
+    {
+        auto res = basic_json();
+        res.m_data.m_type = value_t::binary;
+        res.m_data.m_value = std::move(init);
+        return res;
+    }
+
+    /// @brief explicitly create a binary array (with subtype)
+    /// @sa https://json.nlohmann.me/api/basic_json/binary/
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json binary(typename binary_t::container_type&& init, typename binary_t::subtype_type subtype)
+    {
+        auto res = basic_json();
+        res.m_data.m_type = value_t::binary;
+        res.m_data.m_value = binary_t(std::move(init), subtype);
+        return res;
+    }
+
+    /// @brief explicitly create an array from an initializer list
+    /// @sa https://json.nlohmann.me/api/basic_json/array/
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json array(initializer_list_t init = {})
+    {
+        return basic_json(init, false, value_t::array);
+    }
+
+    /// @brief explicitly create an object from an initializer list
+    /// @sa https://json.nlohmann.me/api/basic_json/object/
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json object(initializer_list_t init = {})
+    {
+        return basic_json(init, false, value_t::object);
+    }
+
+    /// @brief construct an array with count copies of given value
+    /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
+    basic_json(size_type cnt, const basic_json& val):
+        m_data{cnt, val}
+    {
+        set_parents();
+        assert_invariant();
+    }
+
+    /// @brief construct a JSON container given an iterator range
+    /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
+    template < class InputIT, typename std::enable_if <
+                   std::is_same<InputIT, typename basic_json_t::iterator>::value ||
+                   std::is_same<InputIT, typename basic_json_t::const_iterator>::value, int >::type = 0 >
+    basic_json(InputIT first, InputIT last)
+    {
+        JSON_ASSERT(first.m_object != nullptr);
+        JSON_ASSERT(last.m_object != nullptr);
+
+        // make sure iterator fits the current value
+        if (JSON_HEDLEY_UNLIKELY(first.m_object != last.m_object))
+        {
+            JSON_THROW(invalid_iterator::create(201, "iterators are not compatible", nullptr));
+        }
+
+        // copy type from first iterator
+        m_data.m_type = first.m_object->m_data.m_type;
+
+        // check if iterator range is complete for primitive values
+        switch (m_data.m_type)
+        {
+            case value_t::boolean:
+            case value_t::number_float:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::string:
+            {
+                if (JSON_HEDLEY_UNLIKELY(!first.m_it.primitive_iterator.is_begin()
+                                         || !last.m_it.primitive_iterator.is_end()))
+                {
+                    JSON_THROW(invalid_iterator::create(204, "iterators out of range", first.m_object));
+                }
+                break;
+            }
+
+            case value_t::null:
+            case value_t::object:
+            case value_t::array:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+                break;
+        }
+
+        switch (m_data.m_type)
+        {
+            case value_t::number_integer:
+            {
+                m_data.m_value.number_integer = first.m_object->m_data.m_value.number_integer;
+                break;
+            }
+
+            case value_t::number_unsigned:
+            {
+                m_data.m_value.number_unsigned = first.m_object->m_data.m_value.number_unsigned;
+                break;
+            }
+
+            case value_t::number_float:
+            {
+                m_data.m_value.number_float = first.m_object->m_data.m_value.number_float;
+                break;
+            }
+
+            case value_t::boolean:
+            {
+                m_data.m_value.boolean = first.m_object->m_data.m_value.boolean;
+                break;
+            }
+
+            case value_t::string:
+            {
+                m_data.m_value = *first.m_object->m_data.m_value.string;
+                break;
+            }
+
+            case value_t::object:
+            {
+                m_data.m_value.object = create<object_t>(first.m_it.object_iterator,
+                                        last.m_it.object_iterator);
+                break;
+            }
+
+            case value_t::array:
+            {
+                m_data.m_value.array = create<array_t>(first.m_it.array_iterator,
+                                                       last.m_it.array_iterator);
+                break;
+            }
+
+            case value_t::binary:
+            {
+                m_data.m_value = *first.m_object->m_data.m_value.binary;
+                break;
+            }
+
+            case value_t::null:
+            case value_t::discarded:
+            default:
+                JSON_THROW(invalid_iterator::create(206, detail::concat("cannot construct with iterators from ", first.m_object->type_name()), first.m_object));
+        }
+
+        set_parents();
+        assert_invariant();
+    }
+
+    ///////////////////////////////////////
+    // other constructors and destructor //
+    ///////////////////////////////////////
+
+    template<typename JsonRef,
+             detail::enable_if_t<detail::conjunction<detail::is_json_ref<JsonRef>,
+                                 std::is_same<typename JsonRef::value_type, basic_json>>::value, int> = 0 >
+    basic_json(const JsonRef& ref) : basic_json(ref.moved_or_copied()) {}
+
+    /// @brief copy constructor
+    /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
+    basic_json(const basic_json& other)
+        : json_base_class_t(other)
+    {
+        m_data.m_type = other.m_data.m_type;
+        // check of passed value is valid
+        other.assert_invariant();
+
+        switch (m_data.m_type)
+        {
+            case value_t::object:
+            {
+                m_data.m_value = *other.m_data.m_value.object;
+                break;
+            }
+
+            case value_t::array:
+            {
+                m_data.m_value = *other.m_data.m_value.array;
+                break;
+            }
+
+            case value_t::string:
+            {
+                m_data.m_value = *other.m_data.m_value.string;
+                break;
+            }
+
+            case value_t::boolean:
+            {
+                m_data.m_value = other.m_data.m_value.boolean;
+                break;
+            }
+
+            case value_t::number_integer:
+            {
+                m_data.m_value = other.m_data.m_value.number_integer;
+                break;
+            }
+
+            case value_t::number_unsigned:
+            {
+                m_data.m_value = other.m_data.m_value.number_unsigned;
+                break;
+            }
+
+            case value_t::number_float:
+            {
+                m_data.m_value = other.m_data.m_value.number_float;
+                break;
+            }
+
+            case value_t::binary:
+            {
+                m_data.m_value = *other.m_data.m_value.binary;
+                break;
+            }
+
+            case value_t::null:
+            case value_t::discarded:
+            default:
+                break;
+        }
+
+        set_parents();
+        assert_invariant();
+    }
+
+    /// @brief move constructor
+    /// @sa https://json.nlohmann.me/api/basic_json/basic_json/
+    basic_json(basic_json&& other) noexcept
+        : json_base_class_t(std::forward<json_base_class_t>(other)),
+          m_data(std::move(other.m_data))
+    {
+        // check that passed value is valid
+        other.assert_invariant(false);
+
+        // invalidate payload
+        other.m_data.m_type = value_t::null;
+        other.m_data.m_value = {};
+
+        set_parents();
+        assert_invariant();
+    }
+
+    /// @brief copy assignment
+    /// @sa https://json.nlohmann.me/api/basic_json/operator=/
+    basic_json& operator=(basic_json other) noexcept (
+        std::is_nothrow_move_constructible<value_t>::value&&
+        std::is_nothrow_move_assignable<value_t>::value&&
+        std::is_nothrow_move_constructible<json_value>::value&&
+        std::is_nothrow_move_assignable<json_value>::value&&
+        std::is_nothrow_move_assignable<json_base_class_t>::value
+    )
+    {
+        // check that passed value is valid
+        other.assert_invariant();
+
+        using std::swap;
+        swap(m_data.m_type, other.m_data.m_type);
+        swap(m_data.m_value, other.m_data.m_value);
+        json_base_class_t::operator=(std::move(other));
+
+        set_parents();
+        assert_invariant();
+        return *this;
+    }
+
+    /// @brief destructor
+    /// @sa https://json.nlohmann.me/api/basic_json/~basic_json/
+    ~basic_json() noexcept
+    {
+        assert_invariant(false);
+    }
+
+    /// @}
+
+  public:
+    ///////////////////////
+    // object inspection //
+    ///////////////////////
+
+    /// @name object inspection
+    /// Functions to inspect the type of a JSON value.
+    /// @{
+
+    /// @brief serialization
+    /// @sa https://json.nlohmann.me/api/basic_json/dump/
+    string_t dump(const int indent = -1,
+                  const char indent_char = ' ',
+                  const bool ensure_ascii = false,
+                  const error_handler_t error_handler = error_handler_t::strict) const
+    {
+        string_t result;
+        serializer s(detail::output_adapter<char, string_t>(result), indent_char, error_handler);
+
+        if (indent >= 0)
+        {
+            s.dump(*this, true, ensure_ascii, static_cast<unsigned int>(indent));
+        }
+        else
+        {
+            s.dump(*this, false, ensure_ascii, 0);
+        }
+
+        return result;
+    }
+
+    /// @brief return the type of the JSON value (explicit)
+    /// @sa https://json.nlohmann.me/api/basic_json/type/
+    constexpr value_t type() const noexcept
+    {
+        return m_data.m_type;
+    }
+
+    /// @brief return whether type is primitive
+    /// @sa https://json.nlohmann.me/api/basic_json/is_primitive/
+    constexpr bool is_primitive() const noexcept
+    {
+        return is_null() || is_string() || is_boolean() || is_number() || is_binary();
+    }
+
+    /// @brief return whether type is structured
+    /// @sa https://json.nlohmann.me/api/basic_json/is_structured/
+    constexpr bool is_structured() const noexcept
+    {
+        return is_array() || is_object();
+    }
+
+    /// @brief return whether value is null
+    /// @sa https://json.nlohmann.me/api/basic_json/is_null/
+    constexpr bool is_null() const noexcept
+    {
+        return m_data.m_type == value_t::null;
+    }
+
+    /// @brief return whether value is a boolean
+    /// @sa https://json.nlohmann.me/api/basic_json/is_boolean/
+    constexpr bool is_boolean() const noexcept
+    {
+        return m_data.m_type == value_t::boolean;
+    }
+
+    /// @brief return whether value is a number
+    /// @sa https://json.nlohmann.me/api/basic_json/is_number/
+    constexpr bool is_number() const noexcept
+    {
+        return is_number_integer() || is_number_float();
+    }
+
+    /// @brief return whether value is an integer number
+    /// @sa https://json.nlohmann.me/api/basic_json/is_number_integer/
+    constexpr bool is_number_integer() const noexcept
+    {
+        return m_data.m_type == value_t::number_integer || m_data.m_type == value_t::number_unsigned;
+    }
+
+    /// @brief return whether value is an unsigned integer number
+    /// @sa https://json.nlohmann.me/api/basic_json/is_number_unsigned/
+    constexpr bool is_number_unsigned() const noexcept
+    {
+        return m_data.m_type == value_t::number_unsigned;
+    }
+
+    /// @brief return whether value is a floating-point number
+    /// @sa https://json.nlohmann.me/api/basic_json/is_number_float/
+    constexpr bool is_number_float() const noexcept
+    {
+        return m_data.m_type == value_t::number_float;
+    }
+
+    /// @brief return whether value is an object
+    /// @sa https://json.nlohmann.me/api/basic_json/is_object/
+    constexpr bool is_object() const noexcept
+    {
+        return m_data.m_type == value_t::object;
+    }
+
+    /// @brief return whether value is an array
+    /// @sa https://json.nlohmann.me/api/basic_json/is_array/
+    constexpr bool is_array() const noexcept
+    {
+        return m_data.m_type == value_t::array;
+    }
+
+    /// @brief return whether value is a string
+    /// @sa https://json.nlohmann.me/api/basic_json/is_string/
+    constexpr bool is_string() const noexcept
+    {
+        return m_data.m_type == value_t::string;
+    }
+
+    /// @brief return whether value is a binary array
+    /// @sa https://json.nlohmann.me/api/basic_json/is_binary/
+    constexpr bool is_binary() const noexcept
+    {
+        return m_data.m_type == value_t::binary;
+    }
+
+    /// @brief return whether value is discarded
+    /// @sa https://json.nlohmann.me/api/basic_json/is_discarded/
+    constexpr bool is_discarded() const noexcept
+    {
+        return m_data.m_type == value_t::discarded;
+    }
+
+    /// @brief return the type of the JSON value (implicit)
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_value_t/
+    constexpr operator value_t() const noexcept
+    {
+        return m_data.m_type;
+    }
+
+    /// @}
+
+  private:
+    //////////////////
+    // value access //
+    //////////////////
+
+    /// get a boolean (explicit)
+    boolean_t get_impl(boolean_t* /*unused*/) const
+    {
+        if (JSON_HEDLEY_LIKELY(is_boolean()))
+        {
+            return m_data.m_value.boolean;
+        }
+
+        JSON_THROW(type_error::create(302, detail::concat("type must be boolean, but is ", type_name()), this));
+    }
+
+    /// get a pointer to the value (object)
+    object_t* get_impl_ptr(object_t* /*unused*/) noexcept
+    {
+        return is_object() ? m_data.m_value.object : nullptr;
+    }
+
+    /// get a pointer to the value (object)
+    constexpr const object_t* get_impl_ptr(const object_t* /*unused*/) const noexcept
+    {
+        return is_object() ? m_data.m_value.object : nullptr;
+    }
+
+    /// get a pointer to the value (array)
+    array_t* get_impl_ptr(array_t* /*unused*/) noexcept
+    {
+        return is_array() ? m_data.m_value.array : nullptr;
+    }
+
+    /// get a pointer to the value (array)
+    constexpr const array_t* get_impl_ptr(const array_t* /*unused*/) const noexcept
+    {
+        return is_array() ? m_data.m_value.array : nullptr;
+    }
+
+    /// get a pointer to the value (string)
+    string_t* get_impl_ptr(string_t* /*unused*/) noexcept
+    {
+        return is_string() ? m_data.m_value.string : nullptr;
+    }
+
+    /// get a pointer to the value (string)
+    constexpr const string_t* get_impl_ptr(const string_t* /*unused*/) const noexcept
+    {
+        return is_string() ? m_data.m_value.string : nullptr;
+    }
+
+    /// get a pointer to the value (boolean)
+    boolean_t* get_impl_ptr(boolean_t* /*unused*/) noexcept
+    {
+        return is_boolean() ? &m_data.m_value.boolean : nullptr;
+    }
+
+    /// get a pointer to the value (boolean)
+    constexpr const boolean_t* get_impl_ptr(const boolean_t* /*unused*/) const noexcept
+    {
+        return is_boolean() ? &m_data.m_value.boolean : nullptr;
+    }
+
+    /// get a pointer to the value (integer number)
+    number_integer_t* get_impl_ptr(number_integer_t* /*unused*/) noexcept
+    {
+        return is_number_integer() ? &m_data.m_value.number_integer : nullptr;
+    }
+
+    /// get a pointer to the value (integer number)
+    constexpr const number_integer_t* get_impl_ptr(const number_integer_t* /*unused*/) const noexcept
+    {
+        return is_number_integer() ? &m_data.m_value.number_integer : nullptr;
+    }
+
+    /// get a pointer to the value (unsigned number)
+    number_unsigned_t* get_impl_ptr(number_unsigned_t* /*unused*/) noexcept
+    {
+        return is_number_unsigned() ? &m_data.m_value.number_unsigned : nullptr;
+    }
+
+    /// get a pointer to the value (unsigned number)
+    constexpr const number_unsigned_t* get_impl_ptr(const number_unsigned_t* /*unused*/) const noexcept
+    {
+        return is_number_unsigned() ? &m_data.m_value.number_unsigned : nullptr;
+    }
+
+    /// get a pointer to the value (floating-point number)
+    number_float_t* get_impl_ptr(number_float_t* /*unused*/) noexcept
+    {
+        return is_number_float() ? &m_data.m_value.number_float : nullptr;
+    }
+
+    /// get a pointer to the value (floating-point number)
+    constexpr const number_float_t* get_impl_ptr(const number_float_t* /*unused*/) const noexcept
+    {
+        return is_number_float() ? &m_data.m_value.number_float : nullptr;
+    }
+
+    /// get a pointer to the value (binary)
+    binary_t* get_impl_ptr(binary_t* /*unused*/) noexcept
+    {
+        return is_binary() ? m_data.m_value.binary : nullptr;
+    }
+
+    /// get a pointer to the value (binary)
+    constexpr const binary_t* get_impl_ptr(const binary_t* /*unused*/) const noexcept
+    {
+        return is_binary() ? m_data.m_value.binary : nullptr;
+    }
+
+    /*!
+    @brief helper function to implement get_ref()
+
+    This function helps to implement get_ref() without code duplication for
+    const and non-const overloads
+
+    @tparam ThisType will be deduced as `basic_json` or `const basic_json`
+
+    @throw type_error.303 if ReferenceType does not match underlying value
+    type of the current JSON
+    */
+    template<typename ReferenceType, typename ThisType>
+    static ReferenceType get_ref_impl(ThisType& obj)
+    {
+        // delegate the call to get_ptr<>()
+        auto* ptr = obj.template get_ptr<typename std::add_pointer<ReferenceType>::type>();
+
+        if (JSON_HEDLEY_LIKELY(ptr != nullptr))
+        {
+            return *ptr;
+        }
+
+        JSON_THROW(type_error::create(303, detail::concat("incompatible ReferenceType for get_ref, actual type is ", obj.type_name()), &obj));
+    }
+
+  public:
+    /// @name value access
+    /// Direct access to the stored value of a JSON value.
+    /// @{
+
+    /// @brief get a pointer value (implicit)
+    /// @sa https://json.nlohmann.me/api/basic_json/get_ptr/
+    template<typename PointerType, typename std::enable_if<
+                 std::is_pointer<PointerType>::value, int>::type = 0>
+    auto get_ptr() noexcept -> decltype(std::declval<basic_json_t&>().get_impl_ptr(std::declval<PointerType>()))
+    {
+        // delegate the call to get_impl_ptr<>()
+        return get_impl_ptr(static_cast<PointerType>(nullptr));
+    }
+
+    /// @brief get a pointer value (implicit)
+    /// @sa https://json.nlohmann.me/api/basic_json/get_ptr/
+    template < typename PointerType, typename std::enable_if <
+                   std::is_pointer<PointerType>::value&&
+                   std::is_const<typename std::remove_pointer<PointerType>::type>::value, int >::type = 0 >
+    constexpr auto get_ptr() const noexcept -> decltype(std::declval<const basic_json_t&>().get_impl_ptr(std::declval<PointerType>()))
+    {
+        // delegate the call to get_impl_ptr<>() const
+        return get_impl_ptr(static_cast<PointerType>(nullptr));
+    }
+
+  private:
+    /*!
+    @brief get a value (explicit)
+
+    Explicit type conversion between the JSON value and a compatible value
+    which is [CopyConstructible](https://en.cppreference.com/w/cpp/named_req/CopyConstructible)
+    and [DefaultConstructible](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible).
+    The value is converted by calling the @ref json_serializer<ValueType>
+    `from_json()` method.
+
+    The function is equivalent to executing
+    @code {.cpp}
+    ValueType ret;
+    JSONSerializer<ValueType>::from_json(*this, ret);
+    return ret;
+    @endcode
+
+    This overloads is chosen if:
+    - @a ValueType is not @ref basic_json,
+    - @ref json_serializer<ValueType> has a `from_json()` method of the form
+      `void from_json(const basic_json&, ValueType&)`, and
+    - @ref json_serializer<ValueType> does not have a `from_json()` method of
+      the form `ValueType from_json(const basic_json&)`
+
+    @tparam ValueType the returned value type
+
+    @return copy of the JSON value, converted to @a ValueType
+
+    @throw what @ref json_serializer<ValueType> `from_json()` method throws
+
+    @liveexample{The example below shows several conversions from JSON values
+    to other types. There a few things to note: (1) Floating-point numbers can
+    be converted to integers\, (2) A JSON array can be converted to a standard
+    `std::vector<short>`\, (3) A JSON object can be converted to C++
+    associative containers such as `std::unordered_map<std::string\,
+    json>`.,get__ValueType_const}
+
+    @since version 2.1.0
+    */
+    template < typename ValueType,
+               detail::enable_if_t <
+                   detail::is_default_constructible<ValueType>::value&&
+                   detail::has_from_json<basic_json_t, ValueType>::value,
+                   int > = 0 >
+    ValueType get_impl(detail::priority_tag<0> /*unused*/) const noexcept(noexcept(
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), std::declval<ValueType&>())))
+    {
+        auto ret = ValueType();
+        JSONSerializer<ValueType>::from_json(*this, ret);
+        return ret;
+    }
+
+    /*!
+    @brief get a value (explicit); special case
+
+    Explicit type conversion between the JSON value and a compatible value
+    which is **not** [CopyConstructible](https://en.cppreference.com/w/cpp/named_req/CopyConstructible)
+    and **not** [DefaultConstructible](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible).
+    The value is converted by calling the @ref json_serializer<ValueType>
+    `from_json()` method.
+
+    The function is equivalent to executing
+    @code {.cpp}
+    return JSONSerializer<ValueType>::from_json(*this);
+    @endcode
+
+    This overloads is chosen if:
+    - @a ValueType is not @ref basic_json and
+    - @ref json_serializer<ValueType> has a `from_json()` method of the form
+      `ValueType from_json(const basic_json&)`
+
+    @note If @ref json_serializer<ValueType> has both overloads of
+    `from_json()`, this one is chosen.
+
+    @tparam ValueType the returned value type
+
+    @return copy of the JSON value, converted to @a ValueType
+
+    @throw what @ref json_serializer<ValueType> `from_json()` method throws
+
+    @since version 2.1.0
+    */
+    template < typename ValueType,
+               detail::enable_if_t <
+                   detail::has_non_default_from_json<basic_json_t, ValueType>::value,
+                   int > = 0 >
+    ValueType get_impl(detail::priority_tag<1> /*unused*/) const noexcept(noexcept(
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>())))
+    {
+        return JSONSerializer<ValueType>::from_json(*this);
+    }
+
+    /*!
+    @brief get special-case overload
+
+    This overloads converts the current @ref basic_json in a different
+    @ref basic_json type
+
+    @tparam BasicJsonType == @ref basic_json
+
+    @return a copy of *this, converted into @a BasicJsonType
+
+    @complexity Depending on the implementation of the called `from_json()`
+                method.
+
+    @since version 3.2.0
+    */
+    template < typename BasicJsonType,
+               detail::enable_if_t <
+                   detail::is_basic_json<BasicJsonType>::value,
+                   int > = 0 >
+    BasicJsonType get_impl(detail::priority_tag<2> /*unused*/) const
+    {
+        return *this;
+    }
+
+    /*!
+    @brief get special-case overload
+
+    This overloads avoids a lot of template boilerplate, it can be seen as the
+    identity method
+
+    @tparam BasicJsonType == @ref basic_json
+
+    @return a copy of *this
+
+    @complexity Constant.
+
+    @since version 2.1.0
+    */
+    template<typename BasicJsonType,
+             detail::enable_if_t<
+                 std::is_same<BasicJsonType, basic_json_t>::value,
+                 int> = 0>
+    basic_json get_impl(detail::priority_tag<3> /*unused*/) const
+    {
+        return *this;
+    }
+
+    /*!
+    @brief get a pointer value (explicit)
+    @copydoc get()
+    */
+    template<typename PointerType,
+             detail::enable_if_t<
+                 std::is_pointer<PointerType>::value,
+                 int> = 0>
+    constexpr auto get_impl(detail::priority_tag<4> /*unused*/) const noexcept
+    -> decltype(std::declval<const basic_json_t&>().template get_ptr<PointerType>())
+    {
+        // delegate the call to get_ptr
+        return get_ptr<PointerType>();
+    }
+
+  public:
+    /*!
+    @brief get a (pointer) value (explicit)
+
+    Performs explicit type conversion between the JSON value and a compatible value if required.
+
+    - If the requested type is a pointer to the internally stored JSON value that pointer is returned.
+    No copies are made.
+
+    - If the requested type is the current @ref basic_json, or a different @ref basic_json convertible
+    from the current @ref basic_json.
+
+    - Otherwise the value is converted by calling the @ref json_serializer<ValueType> `from_json()`
+    method.
+
+    @tparam ValueTypeCV the provided value type
+    @tparam ValueType the returned value type
+
+    @return copy of the JSON value, converted to @tparam ValueType if necessary
+
+    @throw what @ref json_serializer<ValueType> `from_json()` method throws if conversion is required
+
+    @since version 2.1.0
+    */
+    template < typename ValueTypeCV, typename ValueType = detail::uncvref_t<ValueTypeCV>>
+#if defined(JSON_HAS_CPP_14)
+    constexpr
+#endif
+    auto get() const noexcept(
+    noexcept(std::declval<const basic_json_t&>().template get_impl<ValueType>(detail::priority_tag<4> {})))
+    -> decltype(std::declval<const basic_json_t&>().template get_impl<ValueType>(detail::priority_tag<4> {}))
+    {
+        // we cannot static_assert on ValueTypeCV being non-const, because
+        // there is support for get<const basic_json_t>(), which is why we
+        // still need the uncvref
+        static_assert(!std::is_reference<ValueTypeCV>::value,
+                      "get() cannot be used with reference types, you might want to use get_ref()");
+        return get_impl<ValueType>(detail::priority_tag<4> {});
+    }
+
+    /*!
+    @brief get a pointer value (explicit)
+
+    Explicit pointer access to the internally stored JSON value. No copies are
+    made.
+
+    @warning The pointer becomes invalid if the underlying JSON object
+    changes.
+
+    @tparam PointerType pointer type; must be a pointer to @ref array_t, @ref
+    object_t, @ref string_t, @ref boolean_t, @ref number_integer_t,
+    @ref number_unsigned_t, or @ref number_float_t.
+
+    @return pointer to the internally stored JSON value if the requested
+    pointer type @a PointerType fits to the JSON value; `nullptr` otherwise
+
+    @complexity Constant.
+
+    @liveexample{The example below shows how pointers to internal values of a
+    JSON value can be requested. Note that no type conversions are made and a
+    `nullptr` is returned if the value and the requested pointer type does not
+    match.,get__PointerType}
+
+    @sa see @ref get_ptr() for explicit pointer-member access
+
+    @since version 1.0.0
+    */
+    template<typename PointerType, typename std::enable_if<
+                 std::is_pointer<PointerType>::value, int>::type = 0>
+    auto get() noexcept -> decltype(std::declval<basic_json_t&>().template get_ptr<PointerType>())
+    {
+        // delegate the call to get_ptr
+        return get_ptr<PointerType>();
+    }
+
+    /// @brief get a value (explicit)
+    /// @sa https://json.nlohmann.me/api/basic_json/get_to/
+    template < typename ValueType,
+               detail::enable_if_t <
+                   !detail::is_basic_json<ValueType>::value&&
+                   detail::has_from_json<basic_json_t, ValueType>::value,
+                   int > = 0 >
+    ValueType & get_to(ValueType& v) const noexcept(noexcept(
+                JSONSerializer<ValueType>::from_json(std::declval<const basic_json_t&>(), v)))
+    {
+        JSONSerializer<ValueType>::from_json(*this, v);
+        return v;
+    }
+
+    // specialization to allow calling get_to with a basic_json value
+    // see https://github.com/nlohmann/json/issues/2175
+    template<typename ValueType,
+             detail::enable_if_t <
+                 detail::is_basic_json<ValueType>::value,
+                 int> = 0>
+    ValueType & get_to(ValueType& v) const
+    {
+        v = *this;
+        return v;
+    }
+
+    template <
+        typename T, std::size_t N,
+        typename Array = T (&)[N], // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+        detail::enable_if_t <
+            detail::has_from_json<basic_json_t, Array>::value, int > = 0 >
+    Array get_to(T (&v)[N]) const // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+    noexcept(noexcept(JSONSerializer<Array>::from_json(
+                          std::declval<const basic_json_t&>(), v)))
+    {
+        JSONSerializer<Array>::from_json(*this, v);
+        return v;
+    }
+
+    /// @brief get a reference value (implicit)
+    /// @sa https://json.nlohmann.me/api/basic_json/get_ref/
+    template<typename ReferenceType, typename std::enable_if<
+                 std::is_reference<ReferenceType>::value, int>::type = 0>
+    ReferenceType get_ref()
+    {
+        // delegate call to get_ref_impl
+        return get_ref_impl<ReferenceType>(*this);
+    }
+
+    /// @brief get a reference value (implicit)
+    /// @sa https://json.nlohmann.me/api/basic_json/get_ref/
+    template < typename ReferenceType, typename std::enable_if <
+                   std::is_reference<ReferenceType>::value&&
+                   std::is_const<typename std::remove_reference<ReferenceType>::type>::value, int >::type = 0 >
+    ReferenceType get_ref() const
+    {
+        // delegate call to get_ref_impl
+        return get_ref_impl<ReferenceType>(*this);
+    }
+
+    /*!
+    @brief get a value (implicit)
+
+    Implicit type conversion between the JSON value and a compatible value.
+    The call is realized by calling @ref get() const.
+
+    @tparam ValueType non-pointer type compatible to the JSON value, for
+    instance `int` for JSON integer numbers, `bool` for JSON booleans, or
+    `std::vector` types for JSON arrays. The character type of @ref string_t
+    as well as an initializer list of this type is excluded to avoid
+    ambiguities as these types implicitly convert to `std::string`.
+
+    @return copy of the JSON value, converted to type @a ValueType
+
+    @throw type_error.302 in case passed type @a ValueType is incompatible
+    to the JSON value type (e.g., the JSON value is of type boolean, but a
+    string is requested); see example below
+
+    @complexity Linear in the size of the JSON value.
+
+    @liveexample{The example below shows several conversions from JSON values
+    to other types. There a few things to note: (1) Floating-point numbers can
+    be converted to integers\, (2) A JSON array can be converted to a standard
+    `std::vector<short>`\, (3) A JSON object can be converted to C++
+    associative containers such as `std::unordered_map<std::string\,
+    json>`.,operator__ValueType}
+
+    @since version 1.0.0
+    */
+    template < typename ValueType, typename std::enable_if <
+                   detail::conjunction <
+                       detail::negation<std::is_pointer<ValueType>>,
+                       detail::negation<std::is_same<ValueType, std::nullptr_t>>,
+                       detail::negation<std::is_same<ValueType, detail::json_ref<basic_json>>>,
+                                        detail::negation<std::is_same<ValueType, typename string_t::value_type>>,
+                                        detail::negation<detail::is_basic_json<ValueType>>,
+                                        detail::negation<std::is_same<ValueType, std::initializer_list<typename string_t::value_type>>>,
+#if defined(JSON_HAS_CPP_17) && (defined(__GNUC__) || (defined(_MSC_VER) && _MSC_VER >= 1910 && _MSC_VER <= 1914))
+                                                detail::negation<std::is_same<ValueType, std::string_view>>,
+#endif
+#if defined(JSON_HAS_CPP_17) && JSON_HAS_STATIC_RTTI
+                                                detail::negation<std::is_same<ValueType, std::any>>,
+#endif
+                                                detail::is_detected_lazy<detail::get_template_function, const basic_json_t&, ValueType>
+                                                >::value, int >::type = 0 >
+                                        JSON_EXPLICIT operator ValueType() const
+    {
+        // delegate the call to get<>() const
+        return get<ValueType>();
+    }
+
+    /// @brief get a binary value
+    /// @sa https://json.nlohmann.me/api/basic_json/get_binary/
+    binary_t& get_binary()
+    {
+        if (!is_binary())
+        {
+            JSON_THROW(type_error::create(302, detail::concat("type must be binary, but is ", type_name()), this));
+        }
+
+        return *get_ptr<binary_t*>();
+    }
+
+    /// @brief get a binary value
+    /// @sa https://json.nlohmann.me/api/basic_json/get_binary/
+    const binary_t& get_binary() const
+    {
+        if (!is_binary())
+        {
+            JSON_THROW(type_error::create(302, detail::concat("type must be binary, but is ", type_name()), this));
+        }
+
+        return *get_ptr<const binary_t*>();
+    }
+
+    /// @}
+
+    ////////////////////
+    // element access //
+    ////////////////////
+
+    /// @name element access
+    /// Access to the JSON value.
+    /// @{
+
+    /// @brief access specified array element with bounds checking
+    /// @sa https://json.nlohmann.me/api/basic_json/at/
+    reference at(size_type idx)
+    {
+        // at only works for arrays
+        if (JSON_HEDLEY_LIKELY(is_array()))
+        {
+            JSON_TRY
+            {
+                return set_parent(m_data.m_value.array->at(idx));
+            }
+            JSON_CATCH (std::out_of_range&)
+            {
+                // create better exception explanation
+                JSON_THROW(out_of_range::create(401, detail::concat("array index ", std::to_string(idx), " is out of range"), this));
+            }
+        }
+        else
+        {
+            JSON_THROW(type_error::create(304, detail::concat("cannot use at() with ", type_name()), this));
+        }
+    }
+
+    /// @brief access specified array element with bounds checking
+    /// @sa https://json.nlohmann.me/api/basic_json/at/
+    const_reference at(size_type idx) const
+    {
+        // at only works for arrays
+        if (JSON_HEDLEY_LIKELY(is_array()))
+        {
+            JSON_TRY
+            {
+                return m_data.m_value.array->at(idx);
+            }
+            JSON_CATCH (std::out_of_range&)
+            {
+                // create better exception explanation
+                JSON_THROW(out_of_range::create(401, detail::concat("array index ", std::to_string(idx), " is out of range"), this));
+            }
+        }
+        else
+        {
+            JSON_THROW(type_error::create(304, detail::concat("cannot use at() with ", type_name()), this));
+        }
+    }
+
+    /// @brief access specified object element with bounds checking
+    /// @sa https://json.nlohmann.me/api/basic_json/at/
+    reference at(const typename object_t::key_type& key)
+    {
+        // at only works for objects
+        if (JSON_HEDLEY_UNLIKELY(!is_object()))
+        {
+            JSON_THROW(type_error::create(304, detail::concat("cannot use at() with ", type_name()), this));
+        }
+
+        auto it = m_data.m_value.object->find(key);
+        if (it == m_data.m_value.object->end())
+        {
+            JSON_THROW(out_of_range::create(403, detail::concat("key '", key, "' not found"), this));
+        }
+        return set_parent(it->second);
+    }
+
+    /// @brief access specified object element with bounds checking
+    /// @sa https://json.nlohmann.me/api/basic_json/at/
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
+    reference at(KeyType && key)
+    {
+        // at only works for objects
+        if (JSON_HEDLEY_UNLIKELY(!is_object()))
+        {
+            JSON_THROW(type_error::create(304, detail::concat("cannot use at() with ", type_name()), this));
+        }
+
+        auto it = m_data.m_value.object->find(std::forward<KeyType>(key));
+        if (it == m_data.m_value.object->end())
+        {
+            JSON_THROW(out_of_range::create(403, detail::concat("key '", string_t(std::forward<KeyType>(key)), "' not found"), this));
+        }
+        return set_parent(it->second);
+    }
+
+    /// @brief access specified object element with bounds checking
+    /// @sa https://json.nlohmann.me/api/basic_json/at/
+    const_reference at(const typename object_t::key_type& key) const
+    {
+        // at only works for objects
+        if (JSON_HEDLEY_UNLIKELY(!is_object()))
+        {
+            JSON_THROW(type_error::create(304, detail::concat("cannot use at() with ", type_name()), this));
+        }
+
+        auto it = m_data.m_value.object->find(key);
+        if (it == m_data.m_value.object->end())
+        {
+            JSON_THROW(out_of_range::create(403, detail::concat("key '", key, "' not found"), this));
+        }
+        return it->second;
+    }
+
+    /// @brief access specified object element with bounds checking
+    /// @sa https://json.nlohmann.me/api/basic_json/at/
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
+    const_reference at(KeyType && key) const
+    {
+        // at only works for objects
+        if (JSON_HEDLEY_UNLIKELY(!is_object()))
+        {
+            JSON_THROW(type_error::create(304, detail::concat("cannot use at() with ", type_name()), this));
+        }
+
+        auto it = m_data.m_value.object->find(std::forward<KeyType>(key));
+        if (it == m_data.m_value.object->end())
+        {
+            JSON_THROW(out_of_range::create(403, detail::concat("key '", string_t(std::forward<KeyType>(key)), "' not found"), this));
+        }
+        return it->second;
+    }
+
+    /// @brief access specified array element
+    /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
+    reference operator[](size_type idx)
+    {
+        // implicitly convert null value to an empty array
+        if (is_null())
+        {
+            m_data.m_type = value_t::array;
+            m_data.m_value.array = create<array_t>();
+            assert_invariant();
+        }
+
+        // operator[] only works for arrays
+        if (JSON_HEDLEY_LIKELY(is_array()))
+        {
+            // fill up array with null values if given idx is outside range
+            if (idx >= m_data.m_value.array->size())
+            {
+#if JSON_DIAGNOSTICS
+                // remember array size & capacity before resizing
+                const auto old_size = m_data.m_value.array->size();
+                const auto old_capacity = m_data.m_value.array->capacity();
+#endif
+                m_data.m_value.array->resize(idx + 1);
+
+#if JSON_DIAGNOSTICS
+                if (JSON_HEDLEY_UNLIKELY(m_data.m_value.array->capacity() != old_capacity))
+                {
+                    // capacity has changed: update all parents
+                    set_parents();
+                }
+                else
+                {
+                    // set parent for values added above
+                    set_parents(begin() + static_cast<typename iterator::difference_type>(old_size), static_cast<typename iterator::difference_type>(idx + 1 - old_size));
+                }
+#endif
+                assert_invariant();
+            }
+
+            return m_data.m_value.array->operator[](idx);
+        }
+
+        JSON_THROW(type_error::create(305, detail::concat("cannot use operator[] with a numeric argument with ", type_name()), this));
+    }
+
+    /// @brief access specified array element
+    /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
+    const_reference operator[](size_type idx) const
+    {
+        // const operator[] only works for arrays
+        if (JSON_HEDLEY_LIKELY(is_array()))
+        {
+            return m_data.m_value.array->operator[](idx);
+        }
+
+        JSON_THROW(type_error::create(305, detail::concat("cannot use operator[] with a numeric argument with ", type_name()), this));
+    }
+
+    /// @brief access specified object element
+    /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
+    reference operator[](typename object_t::key_type key)
+    {
+        // implicitly convert null value to an empty object
+        if (is_null())
+        {
+            m_data.m_type = value_t::object;
+            m_data.m_value.object = create<object_t>();
+            assert_invariant();
+        }
+
+        // operator[] only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            auto result = m_data.m_value.object->emplace(std::move(key), nullptr);
+            return set_parent(result.first->second);
+        }
+
+        JSON_THROW(type_error::create(305, detail::concat("cannot use operator[] with a string argument with ", type_name()), this));
+    }
+
+    /// @brief access specified object element
+    /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
+    const_reference operator[](const typename object_t::key_type& key) const
+    {
+        // const operator[] only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            auto it = m_data.m_value.object->find(key);
+            JSON_ASSERT(it != m_data.m_value.object->end());
+            return it->second;
+        }
+
+        JSON_THROW(type_error::create(305, detail::concat("cannot use operator[] with a string argument with ", type_name()), this));
+    }
+
+    // these two functions resolve a (const) char * ambiguity affecting Clang and MSVC
+    // (they seemingly cannot be constrained to resolve the ambiguity)
+    template<typename T>
+    reference operator[](T* key)
+    {
+        return operator[](typename object_t::key_type(key));
+    }
+
+    template<typename T>
+    const_reference operator[](T* key) const
+    {
+        return operator[](typename object_t::key_type(key));
+    }
+
+    /// @brief access specified object element
+    /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int > = 0 >
+    reference operator[](KeyType && key)
+    {
+        // implicitly convert null value to an empty object
+        if (is_null())
+        {
+            m_data.m_type = value_t::object;
+            m_data.m_value.object = create<object_t>();
+            assert_invariant();
+        }
+
+        // operator[] only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            auto result = m_data.m_value.object->emplace(std::forward<KeyType>(key), nullptr);
+            return set_parent(result.first->second);
+        }
+
+        JSON_THROW(type_error::create(305, detail::concat("cannot use operator[] with a string argument with ", type_name()), this));
+    }
+
+    /// @brief access specified object element
+    /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int > = 0 >
+    const_reference operator[](KeyType && key) const
+    {
+        // const operator[] only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            auto it = m_data.m_value.object->find(std::forward<KeyType>(key));
+            JSON_ASSERT(it != m_data.m_value.object->end());
+            return it->second;
+        }
+
+        JSON_THROW(type_error::create(305, detail::concat("cannot use operator[] with a string argument with ", type_name()), this));
+    }
+
+  private:
+    template<typename KeyType>
+    using is_comparable_with_object_key = detail::is_comparable <
+        object_comparator_t, const typename object_t::key_type&, KeyType >;
+
+    template<typename ValueType>
+    using value_return_type = std::conditional <
+        detail::is_c_string_uncvref<ValueType>::value,
+        string_t, typename std::decay<ValueType>::type >;
+
+  public:
+    /// @brief access specified object element with default value
+    /// @sa https://json.nlohmann.me/api/basic_json/value/
+    template < class ValueType, detail::enable_if_t <
+                   !detail::is_transparent<object_comparator_t>::value
+                   && detail::is_getable<basic_json_t, ValueType>::value
+                   && !std::is_same<value_t, detail::uncvref_t<ValueType>>::value, int > = 0 >
+    ValueType value(const typename object_t::key_type& key, const ValueType& default_value) const
+    {
+        // value only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            // if key is found, return value and given default value otherwise
+            const auto it = find(key);
+            if (it != end())
+            {
+                return it->template get<ValueType>();
+            }
+
+            return default_value;
+        }
+
+        JSON_THROW(type_error::create(306, detail::concat("cannot use value() with ", type_name()), this));
+    }
+
+    /// @brief access specified object element with default value
+    /// @sa https://json.nlohmann.me/api/basic_json/value/
+    template < class ValueType, class ReturnType = typename value_return_type<ValueType>::type,
+               detail::enable_if_t <
+                   !detail::is_transparent<object_comparator_t>::value
+                   && detail::is_getable<basic_json_t, ReturnType>::value
+                   && !std::is_same<value_t, detail::uncvref_t<ValueType>>::value, int > = 0 >
+    ReturnType value(const typename object_t::key_type& key, ValueType && default_value) const
+    {
+        // value only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            // if key is found, return value and given default value otherwise
+            const auto it = find(key);
+            if (it != end())
+            {
+                return it->template get<ReturnType>();
+            }
+
+            return std::forward<ValueType>(default_value);
+        }
+
+        JSON_THROW(type_error::create(306, detail::concat("cannot use value() with ", type_name()), this));
+    }
+
+    /// @brief access specified object element with default value
+    /// @sa https://json.nlohmann.me/api/basic_json/value/
+    template < class ValueType, class KeyType, detail::enable_if_t <
+                   detail::is_transparent<object_comparator_t>::value
+                   && !detail::is_json_pointer<KeyType>::value
+                   && is_comparable_with_object_key<KeyType>::value
+                   && detail::is_getable<basic_json_t, ValueType>::value
+                   && !std::is_same<value_t, detail::uncvref_t<ValueType>>::value, int > = 0 >
+    ValueType value(KeyType && key, const ValueType& default_value) const
+    {
+        // value only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            // if key is found, return value and given default value otherwise
+            const auto it = find(std::forward<KeyType>(key));
+            if (it != end())
+            {
+                return it->template get<ValueType>();
+            }
+
+            return default_value;
+        }
+
+        JSON_THROW(type_error::create(306, detail::concat("cannot use value() with ", type_name()), this));
+    }
+
+    /// @brief access specified object element via JSON Pointer with default value
+    /// @sa https://json.nlohmann.me/api/basic_json/value/
+    template < class ValueType, class KeyType, class ReturnType = typename value_return_type<ValueType>::type,
+               detail::enable_if_t <
+                   detail::is_transparent<object_comparator_t>::value
+                   && !detail::is_json_pointer<KeyType>::value
+                   && is_comparable_with_object_key<KeyType>::value
+                   && detail::is_getable<basic_json_t, ReturnType>::value
+                   && !std::is_same<value_t, detail::uncvref_t<ValueType>>::value, int > = 0 >
+    ReturnType value(KeyType && key, ValueType && default_value) const
+    {
+        // value only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            // if key is found, return value and given default value otherwise
+            const auto it = find(std::forward<KeyType>(key));
+            if (it != end())
+            {
+                return it->template get<ReturnType>();
+            }
+
+            return std::forward<ValueType>(default_value);
+        }
+
+        JSON_THROW(type_error::create(306, detail::concat("cannot use value() with ", type_name()), this));
+    }
+
+    /// @brief access specified object element via JSON Pointer with default value
+    /// @sa https://json.nlohmann.me/api/basic_json/value/
+    template < class ValueType, detail::enable_if_t <
+                   detail::is_getable<basic_json_t, ValueType>::value
+                   && !std::is_same<value_t, detail::uncvref_t<ValueType>>::value, int > = 0 >
+    ValueType value(const json_pointer& ptr, const ValueType& default_value) const
+    {
+        // value only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            // if pointer resolves a value, return it or use default value
+            JSON_TRY
+            {
+                return ptr.get_checked(this).template get<ValueType>();
+            }
+            JSON_INTERNAL_CATCH (out_of_range&)
+            {
+                return default_value;
+            }
+        }
+
+        JSON_THROW(type_error::create(306, detail::concat("cannot use value() with ", type_name()), this));
+    }
+
+    /// @brief access specified object element via JSON Pointer with default value
+    /// @sa https://json.nlohmann.me/api/basic_json/value/
+    template < class ValueType, class ReturnType = typename value_return_type<ValueType>::type,
+               detail::enable_if_t <
+                   detail::is_getable<basic_json_t, ReturnType>::value
+                   && !std::is_same<value_t, detail::uncvref_t<ValueType>>::value, int > = 0 >
+    ReturnType value(const json_pointer& ptr, ValueType && default_value) const
+    {
+        // value only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            // if pointer resolves a value, return it or use default value
+            JSON_TRY
+            {
+                return ptr.get_checked(this).template get<ReturnType>();
+            }
+            JSON_INTERNAL_CATCH (out_of_range&)
+            {
+                return std::forward<ValueType>(default_value);
+            }
+        }
+
+        JSON_THROW(type_error::create(306, detail::concat("cannot use value() with ", type_name()), this));
+    }
+
+    template < class ValueType, class BasicJsonType, detail::enable_if_t <
+                   detail::is_basic_json<BasicJsonType>::value
+                   && detail::is_getable<basic_json_t, ValueType>::value
+                   && !std::is_same<value_t, detail::uncvref_t<ValueType>>::value, int > = 0 >
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.0, basic_json::json_pointer or nlohmann::json_pointer<basic_json::string_t>) // NOLINT(readability/alt_tokens)
+    ValueType value(const ::nlohmann::json_pointer<BasicJsonType>& ptr, const ValueType& default_value) const
+    {
+        return value(ptr.convert(), default_value);
+    }
+
+    template < class ValueType, class BasicJsonType, class ReturnType = typename value_return_type<ValueType>::type,
+               detail::enable_if_t <
+                   detail::is_basic_json<BasicJsonType>::value
+                   && detail::is_getable<basic_json_t, ReturnType>::value
+                   && !std::is_same<value_t, detail::uncvref_t<ValueType>>::value, int > = 0 >
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.0, basic_json::json_pointer or nlohmann::json_pointer<basic_json::string_t>) // NOLINT(readability/alt_tokens)
+    ReturnType value(const ::nlohmann::json_pointer<BasicJsonType>& ptr, ValueType && default_value) const
+    {
+        return value(ptr.convert(), std::forward<ValueType>(default_value));
+    }
+
+    /// @brief access the first element
+    /// @sa https://json.nlohmann.me/api/basic_json/front/
+    reference front()
+    {
+        return *begin();
+    }
+
+    /// @brief access the first element
+    /// @sa https://json.nlohmann.me/api/basic_json/front/
+    const_reference front() const
+    {
+        return *cbegin();
+    }
+
+    /// @brief access the last element
+    /// @sa https://json.nlohmann.me/api/basic_json/back/
+    reference back()
+    {
+        auto tmp = end();
+        --tmp;
+        return *tmp;
+    }
+
+    /// @brief access the last element
+    /// @sa https://json.nlohmann.me/api/basic_json/back/
+    const_reference back() const
+    {
+        auto tmp = cend();
+        --tmp;
+        return *tmp;
+    }
+
+    /// @brief remove element given an iterator
+    /// @sa https://json.nlohmann.me/api/basic_json/erase/
+    template < class IteratorType, detail::enable_if_t <
+                   std::is_same<IteratorType, typename basic_json_t::iterator>::value ||
+                   std::is_same<IteratorType, typename basic_json_t::const_iterator>::value, int > = 0 >
+    IteratorType erase(IteratorType pos)
+    {
+        // make sure iterator fits the current value
+        if (JSON_HEDLEY_UNLIKELY(this != pos.m_object))
+        {
+            JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value", this));
+        }
+
+        IteratorType result = end();
+
+        switch (m_data.m_type)
+        {
+            case value_t::boolean:
+            case value_t::number_float:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::string:
+            case value_t::binary:
+            {
+                if (JSON_HEDLEY_UNLIKELY(!pos.m_it.primitive_iterator.is_begin()))
+                {
+                    JSON_THROW(invalid_iterator::create(205, "iterator out of range", this));
+                }
+
+                if (is_string())
+                {
+                    AllocatorType<string_t> alloc;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_data.m_value.string);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_data.m_value.string, 1);
+                    m_data.m_value.string = nullptr;
+                }
+                else if (is_binary())
+                {
+                    AllocatorType<binary_t> alloc;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_data.m_value.binary);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_data.m_value.binary, 1);
+                    m_data.m_value.binary = nullptr;
+                }
+
+                m_data.m_type = value_t::null;
+                assert_invariant();
+                break;
+            }
+
+            case value_t::object:
+            {
+                result.m_it.object_iterator = m_data.m_value.object->erase(pos.m_it.object_iterator);
+                break;
+            }
+
+            case value_t::array:
+            {
+                result.m_it.array_iterator = m_data.m_value.array->erase(pos.m_it.array_iterator);
+                break;
+            }
+
+            case value_t::null:
+            case value_t::discarded:
+            default:
+                JSON_THROW(type_error::create(307, detail::concat("cannot use erase() with ", type_name()), this));
+        }
+
+        return result;
+    }
+
+    /// @brief remove elements given an iterator range
+    /// @sa https://json.nlohmann.me/api/basic_json/erase/
+    template < class IteratorType, detail::enable_if_t <
+                   std::is_same<IteratorType, typename basic_json_t::iterator>::value ||
+                   std::is_same<IteratorType, typename basic_json_t::const_iterator>::value, int > = 0 >
+    IteratorType erase(IteratorType first, IteratorType last)
+    {
+        // make sure iterator fits the current value
+        if (JSON_HEDLEY_UNLIKELY(this != first.m_object || this != last.m_object))
+        {
+            JSON_THROW(invalid_iterator::create(203, "iterators do not fit current value", this));
+        }
+
+        IteratorType result = end();
+
+        switch (m_data.m_type)
+        {
+            case value_t::boolean:
+            case value_t::number_float:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::string:
+            case value_t::binary:
+            {
+                if (JSON_HEDLEY_LIKELY(!first.m_it.primitive_iterator.is_begin()
+                                       || !last.m_it.primitive_iterator.is_end()))
+                {
+                    JSON_THROW(invalid_iterator::create(204, "iterators out of range", this));
+                }
+
+                if (is_string())
+                {
+                    AllocatorType<string_t> alloc;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_data.m_value.string);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_data.m_value.string, 1);
+                    m_data.m_value.string = nullptr;
+                }
+                else if (is_binary())
+                {
+                    AllocatorType<binary_t> alloc;
+                    std::allocator_traits<decltype(alloc)>::destroy(alloc, m_data.m_value.binary);
+                    std::allocator_traits<decltype(alloc)>::deallocate(alloc, m_data.m_value.binary, 1);
+                    m_data.m_value.binary = nullptr;
+                }
+
+                m_data.m_type = value_t::null;
+                assert_invariant();
+                break;
+            }
+
+            case value_t::object:
+            {
+                result.m_it.object_iterator = m_data.m_value.object->erase(first.m_it.object_iterator,
+                                              last.m_it.object_iterator);
+                break;
+            }
+
+            case value_t::array:
+            {
+                result.m_it.array_iterator = m_data.m_value.array->erase(first.m_it.array_iterator,
+                                             last.m_it.array_iterator);
+                break;
+            }
+
+            case value_t::null:
+            case value_t::discarded:
+            default:
+                JSON_THROW(type_error::create(307, detail::concat("cannot use erase() with ", type_name()), this));
+        }
+
+        return result;
+    }
+
+  private:
+    template < typename KeyType, detail::enable_if_t <
+                   detail::has_erase_with_key_type<basic_json_t, KeyType>::value, int > = 0 >
+    size_type erase_internal(KeyType && key)
+    {
+        // this erase only works for objects
+        if (JSON_HEDLEY_UNLIKELY(!is_object()))
+        {
+            JSON_THROW(type_error::create(307, detail::concat("cannot use erase() with ", type_name()), this));
+        }
+
+        return m_data.m_value.object->erase(std::forward<KeyType>(key));
+    }
+
+    template < typename KeyType, detail::enable_if_t <
+                   !detail::has_erase_with_key_type<basic_json_t, KeyType>::value, int > = 0 >
+    size_type erase_internal(KeyType && key)
+    {
+        // this erase only works for objects
+        if (JSON_HEDLEY_UNLIKELY(!is_object()))
+        {
+            JSON_THROW(type_error::create(307, detail::concat("cannot use erase() with ", type_name()), this));
+        }
+
+        const auto it = m_data.m_value.object->find(std::forward<KeyType>(key));
+        if (it != m_data.m_value.object->end())
+        {
+            m_data.m_value.object->erase(it);
+            return 1;
+        }
+        return 0;
+    }
+
+  public:
+
+    /// @brief remove element from a JSON object given a key
+    /// @sa https://json.nlohmann.me/api/basic_json/erase/
+    size_type erase(const typename object_t::key_type& key)
+    {
+        // the indirection via erase_internal() is added to avoid making this
+        // function a template and thus de-rank it during overload resolution
+        return erase_internal(key);
+    }
+
+    /// @brief remove element from a JSON object given a key
+    /// @sa https://json.nlohmann.me/api/basic_json/erase/
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
+    size_type erase(KeyType && key)
+    {
+        return erase_internal(std::forward<KeyType>(key));
+    }
+
+    /// @brief remove element from a JSON array given an index
+    /// @sa https://json.nlohmann.me/api/basic_json/erase/
+    void erase(const size_type idx)
+    {
+        // this erase only works for arrays
+        if (JSON_HEDLEY_LIKELY(is_array()))
+        {
+            if (JSON_HEDLEY_UNLIKELY(idx >= size()))
+            {
+                JSON_THROW(out_of_range::create(401, detail::concat("array index ", std::to_string(idx), " is out of range"), this));
+            }
+
+            m_data.m_value.array->erase(m_data.m_value.array->begin() + static_cast<difference_type>(idx));
+        }
+        else
+        {
+            JSON_THROW(type_error::create(307, detail::concat("cannot use erase() with ", type_name()), this));
+        }
+    }
+
+    /// @}
+
+    ////////////
+    // lookup //
+    ////////////
+
+    /// @name lookup
+    /// @{
+
+    /// @brief find an element in a JSON object
+    /// @sa https://json.nlohmann.me/api/basic_json/find/
+    iterator find(const typename object_t::key_type& key)
+    {
+        auto result = end();
+
+        if (is_object())
+        {
+            result.m_it.object_iterator = m_data.m_value.object->find(key);
+        }
+
+        return result;
+    }
+
+    /// @brief find an element in a JSON object
+    /// @sa https://json.nlohmann.me/api/basic_json/find/
+    const_iterator find(const typename object_t::key_type& key) const
+    {
+        auto result = cend();
+
+        if (is_object())
+        {
+            result.m_it.object_iterator = m_data.m_value.object->find(key);
+        }
+
+        return result;
+    }
+
+    /// @brief find an element in a JSON object
+    /// @sa https://json.nlohmann.me/api/basic_json/find/
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
+    iterator find(KeyType && key)
+    {
+        auto result = end();
+
+        if (is_object())
+        {
+            result.m_it.object_iterator = m_data.m_value.object->find(std::forward<KeyType>(key));
+        }
+
+        return result;
+    }
+
+    /// @brief find an element in a JSON object
+    /// @sa https://json.nlohmann.me/api/basic_json/find/
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
+    const_iterator find(KeyType && key) const
+    {
+        auto result = cend();
+
+        if (is_object())
+        {
+            result.m_it.object_iterator = m_data.m_value.object->find(std::forward<KeyType>(key));
+        }
+
+        return result;
+    }
+
+    /// @brief returns the number of occurrences of a key in a JSON object
+    /// @sa https://json.nlohmann.me/api/basic_json/count/
+    size_type count(const typename object_t::key_type& key) const
+    {
+        // return 0 for all nonobject types
+        return is_object() ? m_data.m_value.object->count(key) : 0;
+    }
+
+    /// @brief returns the number of occurrences of a key in a JSON object
+    /// @sa https://json.nlohmann.me/api/basic_json/count/
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
+    size_type count(KeyType && key) const
+    {
+        // return 0 for all nonobject types
+        return is_object() ? m_data.m_value.object->count(std::forward<KeyType>(key)) : 0;
+    }
+
+    /// @brief check the existence of an element in a JSON object
+    /// @sa https://json.nlohmann.me/api/basic_json/contains/
+    bool contains(const typename object_t::key_type& key) const
+    {
+        return is_object() && m_data.m_value.object->find(key) != m_data.m_value.object->end();
+    }
+
+    /// @brief check the existence of an element in a JSON object
+    /// @sa https://json.nlohmann.me/api/basic_json/contains/
+    template<class KeyType, detail::enable_if_t<
+                 detail::is_usable_as_basic_json_key_type<basic_json_t, KeyType>::value, int> = 0>
+    bool contains(KeyType && key) const
+    {
+        return is_object() && m_data.m_value.object->find(std::forward<KeyType>(key)) != m_data.m_value.object->end();
+    }
+
+    /// @brief check the existence of an element in a JSON object given a JSON pointer
+    /// @sa https://json.nlohmann.me/api/basic_json/contains/
+    bool contains(const json_pointer& ptr) const
+    {
+        return ptr.contains(this);
+    }
+
+    template<typename BasicJsonType, detail::enable_if_t<detail::is_basic_json<BasicJsonType>::value, int> = 0>
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.0, basic_json::json_pointer or nlohmann::json_pointer<basic_json::string_t>) // NOLINT(readability/alt_tokens)
+    bool contains(const typename ::nlohmann::json_pointer<BasicJsonType>& ptr) const
+    {
+        return ptr.contains(this);
+    }
+
+    /// @}
+
+    ///////////////
+    // iterators //
+    ///////////////
+
+    /// @name iterators
+    /// @{
+
+    /// @brief returns an iterator to the first element
+    /// @sa https://json.nlohmann.me/api/basic_json/begin/
+    iterator begin() noexcept
+    {
+        iterator result(this);
+        result.set_begin();
+        return result;
+    }
+
+    /// @brief returns an iterator to the first element
+    /// @sa https://json.nlohmann.me/api/basic_json/begin/
+    const_iterator begin() const noexcept
+    {
+        return cbegin();
+    }
+
+    /// @brief returns a const iterator to the first element
+    /// @sa https://json.nlohmann.me/api/basic_json/cbegin/
+    const_iterator cbegin() const noexcept
+    {
+        const_iterator result(this);
+        result.set_begin();
+        return result;
+    }
+
+    /// @brief returns an iterator to one past the last element
+    /// @sa https://json.nlohmann.me/api/basic_json/end/
+    iterator end() noexcept
+    {
+        iterator result(this);
+        result.set_end();
+        return result;
+    }
+
+    /// @brief returns an iterator to one past the last element
+    /// @sa https://json.nlohmann.me/api/basic_json/end/
+    const_iterator end() const noexcept
+    {
+        return cend();
+    }
+
+    /// @brief returns an iterator to one past the last element
+    /// @sa https://json.nlohmann.me/api/basic_json/cend/
+    const_iterator cend() const noexcept
+    {
+        const_iterator result(this);
+        result.set_end();
+        return result;
+    }
+
+    /// @brief returns an iterator to the reverse-beginning
+    /// @sa https://json.nlohmann.me/api/basic_json/rbegin/
+    reverse_iterator rbegin() noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    /// @brief returns an iterator to the reverse-beginning
+    /// @sa https://json.nlohmann.me/api/basic_json/rbegin/
+    const_reverse_iterator rbegin() const noexcept
+    {
+        return crbegin();
+    }
+
+    /// @brief returns an iterator to the reverse-end
+    /// @sa https://json.nlohmann.me/api/basic_json/rend/
+    reverse_iterator rend() noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    /// @brief returns an iterator to the reverse-end
+    /// @sa https://json.nlohmann.me/api/basic_json/rend/
+    const_reverse_iterator rend() const noexcept
+    {
+        return crend();
+    }
+
+    /// @brief returns a const reverse iterator to the last element
+    /// @sa https://json.nlohmann.me/api/basic_json/crbegin/
+    const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(cend());
+    }
+
+    /// @brief returns a const reverse iterator to one before the first
+    /// @sa https://json.nlohmann.me/api/basic_json/crend/
+    const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(cbegin());
+    }
+
+  public:
+    /// @brief wrapper to access iterator member functions in range-based for
+    /// @sa https://json.nlohmann.me/api/basic_json/items/
+    /// @deprecated This function is deprecated since 3.1.0 and will be removed in
+    ///             version 4.0.0 of the library. Please use @ref items() instead;
+    ///             that is, replace `json::iterator_wrapper(j)` with `j.items()`.
+    JSON_HEDLEY_DEPRECATED_FOR(3.1.0, items())
+    static iteration_proxy<iterator> iterator_wrapper(reference ref) noexcept
+    {
+        return ref.items();
+    }
+
+    /// @brief wrapper to access iterator member functions in range-based for
+    /// @sa https://json.nlohmann.me/api/basic_json/items/
+    /// @deprecated This function is deprecated since 3.1.0 and will be removed in
+    ///         version 4.0.0 of the library. Please use @ref items() instead;
+    ///         that is, replace `json::iterator_wrapper(j)` with `j.items()`.
+    JSON_HEDLEY_DEPRECATED_FOR(3.1.0, items())
+    static iteration_proxy<const_iterator> iterator_wrapper(const_reference ref) noexcept
+    {
+        return ref.items();
+    }
+
+    /// @brief helper to access iterator member functions in range-based for
+    /// @sa https://json.nlohmann.me/api/basic_json/items/
+    iteration_proxy<iterator> items() noexcept
+    {
+        return iteration_proxy<iterator>(*this);
+    }
+
+    /// @brief helper to access iterator member functions in range-based for
+    /// @sa https://json.nlohmann.me/api/basic_json/items/
+    iteration_proxy<const_iterator> items() const noexcept
+    {
+        return iteration_proxy<const_iterator>(*this);
+    }
+
+    /// @}
+
+    //////////////
+    // capacity //
+    //////////////
+
+    /// @name capacity
+    /// @{
+
+    /// @brief checks whether the container is empty.
+    /// @sa https://json.nlohmann.me/api/basic_json/empty/
+    bool empty() const noexcept
+    {
+        switch (m_data.m_type)
+        {
+            case value_t::null:
+            {
+                // null values are empty
+                return true;
+            }
+
+            case value_t::array:
+            {
+                // delegate call to array_t::empty()
+                return m_data.m_value.array->empty();
+            }
+
+            case value_t::object:
+            {
+                // delegate call to object_t::empty()
+                return m_data.m_value.object->empty();
+            }
+
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                // all other types are nonempty
+                return false;
+            }
+        }
+    }
+
+    /// @brief returns the number of elements
+    /// @sa https://json.nlohmann.me/api/basic_json/size/
+    size_type size() const noexcept
+    {
+        switch (m_data.m_type)
+        {
+            case value_t::null:
+            {
+                // null values are empty
+                return 0;
+            }
+
+            case value_t::array:
+            {
+                // delegate call to array_t::size()
+                return m_data.m_value.array->size();
+            }
+
+            case value_t::object:
+            {
+                // delegate call to object_t::size()
+                return m_data.m_value.object->size();
+            }
+
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                // all other types have size 1
+                return 1;
+            }
+        }
+    }
+
+    /// @brief returns the maximum possible number of elements
+    /// @sa https://json.nlohmann.me/api/basic_json/max_size/
+    size_type max_size() const noexcept
+    {
+        switch (m_data.m_type)
+        {
+            case value_t::array:
+            {
+                // delegate call to array_t::max_size()
+                return m_data.m_value.array->max_size();
+            }
+
+            case value_t::object:
+            {
+                // delegate call to object_t::max_size()
+                return m_data.m_value.object->max_size();
+            }
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                // all other types have max_size() == size()
+                return size();
+            }
+        }
+    }
+
+    /// @}
+
+    ///////////////
+    // modifiers //
+    ///////////////
+
+    /// @name modifiers
+    /// @{
+
+    /// @brief clears the contents
+    /// @sa https://json.nlohmann.me/api/basic_json/clear/
+    void clear() noexcept
+    {
+        switch (m_data.m_type)
+        {
+            case value_t::number_integer:
+            {
+                m_data.m_value.number_integer = 0;
+                break;
+            }
+
+            case value_t::number_unsigned:
+            {
+                m_data.m_value.number_unsigned = 0;
+                break;
+            }
+
+            case value_t::number_float:
+            {
+                m_data.m_value.number_float = 0.0;
+                break;
+            }
+
+            case value_t::boolean:
+            {
+                m_data.m_value.boolean = false;
+                break;
+            }
+
+            case value_t::string:
+            {
+                m_data.m_value.string->clear();
+                break;
+            }
+
+            case value_t::binary:
+            {
+                m_data.m_value.binary->clear();
+                break;
+            }
+
+            case value_t::array:
+            {
+                m_data.m_value.array->clear();
+                break;
+            }
+
+            case value_t::object:
+            {
+                m_data.m_value.object->clear();
+                break;
+            }
+
+            case value_t::null:
+            case value_t::discarded:
+            default:
+                break;
+        }
+    }
+
+    /// @brief add an object to an array
+    /// @sa https://json.nlohmann.me/api/basic_json/push_back/
+    void push_back(basic_json&& val)
+    {
+        // push_back only works for null objects or arrays
+        if (JSON_HEDLEY_UNLIKELY(!(is_null() || is_array())))
+        {
+            JSON_THROW(type_error::create(308, detail::concat("cannot use push_back() with ", type_name()), this));
+        }
+
+        // transform null object into an array
+        if (is_null())
+        {
+            m_data.m_type = value_t::array;
+            m_data.m_value = value_t::array;
+            assert_invariant();
+        }
+
+        // add element to array (move semantics)
+        const auto old_capacity = m_data.m_value.array->capacity();
+        m_data.m_value.array->push_back(std::move(val));
+        set_parent(m_data.m_value.array->back(), old_capacity);
+        // if val is moved from, basic_json move constructor marks it null, so we do not call the destructor
+    }
+
+    /// @brief add an object to an array
+    /// @sa https://json.nlohmann.me/api/basic_json/operator+=/
+    reference operator+=(basic_json&& val)
+    {
+        push_back(std::move(val));
+        return *this;
+    }
+
+    /// @brief add an object to an array
+    /// @sa https://json.nlohmann.me/api/basic_json/push_back/
+    void push_back(const basic_json& val)
+    {
+        // push_back only works for null objects or arrays
+        if (JSON_HEDLEY_UNLIKELY(!(is_null() || is_array())))
+        {
+            JSON_THROW(type_error::create(308, detail::concat("cannot use push_back() with ", type_name()), this));
+        }
+
+        // transform null object into an array
+        if (is_null())
+        {
+            m_data.m_type = value_t::array;
+            m_data.m_value = value_t::array;
+            assert_invariant();
+        }
+
+        // add element to array
+        const auto old_capacity = m_data.m_value.array->capacity();
+        m_data.m_value.array->push_back(val);
+        set_parent(m_data.m_value.array->back(), old_capacity);
+    }
+
+    /// @brief add an object to an array
+    /// @sa https://json.nlohmann.me/api/basic_json/operator+=/
+    reference operator+=(const basic_json& val)
+    {
+        push_back(val);
+        return *this;
+    }
+
+    /// @brief add an object to an object
+    /// @sa https://json.nlohmann.me/api/basic_json/push_back/
+    void push_back(const typename object_t::value_type& val)
+    {
+        // push_back only works for null objects or objects
+        if (JSON_HEDLEY_UNLIKELY(!(is_null() || is_object())))
+        {
+            JSON_THROW(type_error::create(308, detail::concat("cannot use push_back() with ", type_name()), this));
+        }
+
+        // transform null object into an object
+        if (is_null())
+        {
+            m_data.m_type = value_t::object;
+            m_data.m_value = value_t::object;
+            assert_invariant();
+        }
+
+        // add element to object
+        auto res = m_data.m_value.object->insert(val);
+        set_parent(res.first->second);
+    }
+
+    /// @brief add an object to an object
+    /// @sa https://json.nlohmann.me/api/basic_json/operator+=/
+    reference operator+=(const typename object_t::value_type& val)
+    {
+        push_back(val);
+        return *this;
+    }
+
+    /// @brief add an object to an object
+    /// @sa https://json.nlohmann.me/api/basic_json/push_back/
+    void push_back(initializer_list_t init)
+    {
+        if (is_object() && init.size() == 2 && (*init.begin())->is_string())
+        {
+            basic_json&& key = init.begin()->moved_or_copied();
+            push_back(typename object_t::value_type(
+                          std::move(key.get_ref<string_t&>()), (init.begin() + 1)->moved_or_copied()));
+        }
+        else
+        {
+            push_back(basic_json(init));
+        }
+    }
+
+    /// @brief add an object to an object
+    /// @sa https://json.nlohmann.me/api/basic_json/operator+=/
+    reference operator+=(initializer_list_t init)
+    {
+        push_back(init);
+        return *this;
+    }
+
+    /// @brief add an object to an array
+    /// @sa https://json.nlohmann.me/api/basic_json/emplace_back/
+    template<class... Args>
+    reference emplace_back(Args&& ... args)
+    {
+        // emplace_back only works for null objects or arrays
+        if (JSON_HEDLEY_UNLIKELY(!(is_null() || is_array())))
+        {
+            JSON_THROW(type_error::create(311, detail::concat("cannot use emplace_back() with ", type_name()), this));
+        }
+
+        // transform null object into an array
+        if (is_null())
+        {
+            m_data.m_type = value_t::array;
+            m_data.m_value = value_t::array;
+            assert_invariant();
+        }
+
+        // add element to array (perfect forwarding)
+        const auto old_capacity = m_data.m_value.array->capacity();
+        m_data.m_value.array->emplace_back(std::forward<Args>(args)...);
+        return set_parent(m_data.m_value.array->back(), old_capacity);
+    }
+
+    /// @brief add an object to an object if key does not exist
+    /// @sa https://json.nlohmann.me/api/basic_json/emplace/
+    template<class... Args>
+    std::pair<iterator, bool> emplace(Args&& ... args)
+    {
+        // emplace only works for null objects or arrays
+        if (JSON_HEDLEY_UNLIKELY(!(is_null() || is_object())))
+        {
+            JSON_THROW(type_error::create(311, detail::concat("cannot use emplace() with ", type_name()), this));
+        }
+
+        // transform null object into an object
+        if (is_null())
+        {
+            m_data.m_type = value_t::object;
+            m_data.m_value = value_t::object;
+            assert_invariant();
+        }
+
+        // add element to array (perfect forwarding)
+        auto res = m_data.m_value.object->emplace(std::forward<Args>(args)...);
+        set_parent(res.first->second);
+
+        // create result iterator and set iterator to the result of emplace
+        auto it = begin();
+        it.m_it.object_iterator = res.first;
+
+        // return pair of iterator and boolean
+        return {it, res.second};
+    }
+
+    /// Helper for insertion of an iterator
+    /// @note: This uses std::distance to support GCC 4.8,
+    ///        see https://github.com/nlohmann/json/pull/1257
+    template<typename... Args>
+    iterator insert_iterator(const_iterator pos, Args&& ... args)
+    {
+        iterator result(this);
+        JSON_ASSERT(m_data.m_value.array != nullptr);
+
+        auto insert_pos = std::distance(m_data.m_value.array->begin(), pos.m_it.array_iterator);
+        m_data.m_value.array->insert(pos.m_it.array_iterator, std::forward<Args>(args)...);
+        result.m_it.array_iterator = m_data.m_value.array->begin() + insert_pos;
+
+        // This could have been written as:
+        // result.m_it.array_iterator = m_data.m_value.array->insert(pos.m_it.array_iterator, cnt, val);
+        // but the return value of insert is missing in GCC 4.8, so it is written this way instead.
+
+        set_parents();
+        return result;
+    }
+
+    /// @brief inserts element into array
+    /// @sa https://json.nlohmann.me/api/basic_json/insert/
+    iterator insert(const_iterator pos, const basic_json& val)
+    {
+        // insert only works for arrays
+        if (JSON_HEDLEY_LIKELY(is_array()))
+        {
+            // check if iterator pos fits to this JSON value
+            if (JSON_HEDLEY_UNLIKELY(pos.m_object != this))
+            {
+                JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value", this));
+            }
+
+            // insert to array and return iterator
+            return insert_iterator(pos, val);
+        }
+
+        JSON_THROW(type_error::create(309, detail::concat("cannot use insert() with ", type_name()), this));
+    }
+
+    /// @brief inserts element into array
+    /// @sa https://json.nlohmann.me/api/basic_json/insert/
+    iterator insert(const_iterator pos, basic_json&& val)
+    {
+        return insert(pos, val);
+    }
+
+    /// @brief inserts copies of element into array
+    /// @sa https://json.nlohmann.me/api/basic_json/insert/
+    iterator insert(const_iterator pos, size_type cnt, const basic_json& val)
+    {
+        // insert only works for arrays
+        if (JSON_HEDLEY_LIKELY(is_array()))
+        {
+            // check if iterator pos fits to this JSON value
+            if (JSON_HEDLEY_UNLIKELY(pos.m_object != this))
+            {
+                JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value", this));
+            }
+
+            // insert to array and return iterator
+            return insert_iterator(pos, cnt, val);
+        }
+
+        JSON_THROW(type_error::create(309, detail::concat("cannot use insert() with ", type_name()), this));
+    }
+
+    /// @brief inserts range of elements into array
+    /// @sa https://json.nlohmann.me/api/basic_json/insert/
+    iterator insert(const_iterator pos, const_iterator first, const_iterator last)
+    {
+        // insert only works for arrays
+        if (JSON_HEDLEY_UNLIKELY(!is_array()))
+        {
+            JSON_THROW(type_error::create(309, detail::concat("cannot use insert() with ", type_name()), this));
+        }
+
+        // check if iterator pos fits to this JSON value
+        if (JSON_HEDLEY_UNLIKELY(pos.m_object != this))
+        {
+            JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value", this));
+        }
+
+        // check if range iterators belong to the same JSON object
+        if (JSON_HEDLEY_UNLIKELY(first.m_object != last.m_object))
+        {
+            JSON_THROW(invalid_iterator::create(210, "iterators do not fit", this));
+        }
+
+        if (JSON_HEDLEY_UNLIKELY(first.m_object == this))
+        {
+            JSON_THROW(invalid_iterator::create(211, "passed iterators may not belong to container", this));
+        }
+
+        // insert to array and return iterator
+        return insert_iterator(pos, first.m_it.array_iterator, last.m_it.array_iterator);
+    }
+
+    /// @brief inserts elements from initializer list into array
+    /// @sa https://json.nlohmann.me/api/basic_json/insert/
+    iterator insert(const_iterator pos, initializer_list_t ilist)
+    {
+        // insert only works for arrays
+        if (JSON_HEDLEY_UNLIKELY(!is_array()))
+        {
+            JSON_THROW(type_error::create(309, detail::concat("cannot use insert() with ", type_name()), this));
+        }
+
+        // check if iterator pos fits to this JSON value
+        if (JSON_HEDLEY_UNLIKELY(pos.m_object != this))
+        {
+            JSON_THROW(invalid_iterator::create(202, "iterator does not fit current value", this));
+        }
+
+        // insert to array and return iterator
+        return insert_iterator(pos, ilist.begin(), ilist.end());
+    }
+
+    /// @brief inserts range of elements into object
+    /// @sa https://json.nlohmann.me/api/basic_json/insert/
+    void insert(const_iterator first, const_iterator last)
+    {
+        // insert only works for objects
+        if (JSON_HEDLEY_UNLIKELY(!is_object()))
+        {
+            JSON_THROW(type_error::create(309, detail::concat("cannot use insert() with ", type_name()), this));
+        }
+
+        // check if range iterators belong to the same JSON object
+        if (JSON_HEDLEY_UNLIKELY(first.m_object != last.m_object))
+        {
+            JSON_THROW(invalid_iterator::create(210, "iterators do not fit", this));
+        }
+
+        // passed iterators must belong to objects
+        if (JSON_HEDLEY_UNLIKELY(!first.m_object->is_object()))
+        {
+            JSON_THROW(invalid_iterator::create(202, "iterators first and last must point to objects", this));
+        }
+
+        m_data.m_value.object->insert(first.m_it.object_iterator, last.m_it.object_iterator);
+    }
+
+    /// @brief updates a JSON object from another object, overwriting existing keys
+    /// @sa https://json.nlohmann.me/api/basic_json/update/
+    void update(const_reference j, bool merge_objects = false)
+    {
+        update(j.begin(), j.end(), merge_objects);
+    }
+
+    /// @brief updates a JSON object from another object, overwriting existing keys
+    /// @sa https://json.nlohmann.me/api/basic_json/update/
+    void update(const_iterator first, const_iterator last, bool merge_objects = false)
+    {
+        // implicitly convert null value to an empty object
+        if (is_null())
+        {
+            m_data.m_type = value_t::object;
+            m_data.m_value.object = create<object_t>();
+            assert_invariant();
+        }
+
+        if (JSON_HEDLEY_UNLIKELY(!is_object()))
+        {
+            JSON_THROW(type_error::create(312, detail::concat("cannot use update() with ", type_name()), this));
+        }
+
+        // check if range iterators belong to the same JSON object
+        if (JSON_HEDLEY_UNLIKELY(first.m_object != last.m_object))
+        {
+            JSON_THROW(invalid_iterator::create(210, "iterators do not fit", this));
+        }
+
+        // passed iterators must belong to objects
+        if (JSON_HEDLEY_UNLIKELY(!first.m_object->is_object()))
+        {
+            JSON_THROW(type_error::create(312, detail::concat("cannot use update() with ", first.m_object->type_name()), first.m_object));
+        }
+
+        for (auto it = first; it != last; ++it)
+        {
+            if (merge_objects && it.value().is_object())
+            {
+                auto it2 = m_data.m_value.object->find(it.key());
+                if (it2 != m_data.m_value.object->end())
+                {
+                    it2->second.update(it.value(), true);
+                    continue;
+                }
+            }
+            m_data.m_value.object->operator[](it.key()) = it.value();
+#if JSON_DIAGNOSTICS
+            m_data.m_value.object->operator[](it.key()).m_parent = this;
+#endif
+        }
+    }
+
+    /// @brief exchanges the values
+    /// @sa https://json.nlohmann.me/api/basic_json/swap/
+    void swap(reference other) noexcept (
+        std::is_nothrow_move_constructible<value_t>::value&&
+        std::is_nothrow_move_assignable<value_t>::value&&
+        std::is_nothrow_move_constructible<json_value>::value&& // NOLINT(cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
+        std::is_nothrow_move_assignable<json_value>::value
+    )
+    {
+        std::swap(m_data.m_type, other.m_data.m_type);
+        std::swap(m_data.m_value, other.m_data.m_value);
+
+        set_parents();
+        other.set_parents();
+        assert_invariant();
+    }
+
+    /// @brief exchanges the values
+    /// @sa https://json.nlohmann.me/api/basic_json/swap/
+    friend void swap(reference left, reference right) noexcept (
+        std::is_nothrow_move_constructible<value_t>::value&&
+        std::is_nothrow_move_assignable<value_t>::value&&
+        std::is_nothrow_move_constructible<json_value>::value&& // NOLINT(cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
+        std::is_nothrow_move_assignable<json_value>::value
+    )
+    {
+        left.swap(right);
+    }
+
+    /// @brief exchanges the values
+    /// @sa https://json.nlohmann.me/api/basic_json/swap/
+    void swap(array_t& other) // NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
+    {
+        // swap only works for arrays
+        if (JSON_HEDLEY_LIKELY(is_array()))
+        {
+            using std::swap;
+            swap(*(m_data.m_value.array), other);
+        }
+        else
+        {
+            JSON_THROW(type_error::create(310, detail::concat("cannot use swap(array_t&) with ", type_name()), this));
+        }
+    }
+
+    /// @brief exchanges the values
+    /// @sa https://json.nlohmann.me/api/basic_json/swap/
+    void swap(object_t& other) // NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
+    {
+        // swap only works for objects
+        if (JSON_HEDLEY_LIKELY(is_object()))
+        {
+            using std::swap;
+            swap(*(m_data.m_value.object), other);
+        }
+        else
+        {
+            JSON_THROW(type_error::create(310, detail::concat("cannot use swap(object_t&) with ", type_name()), this));
+        }
+    }
+
+    /// @brief exchanges the values
+    /// @sa https://json.nlohmann.me/api/basic_json/swap/
+    void swap(string_t& other) // NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
+    {
+        // swap only works for strings
+        if (JSON_HEDLEY_LIKELY(is_string()))
+        {
+            using std::swap;
+            swap(*(m_data.m_value.string), other);
+        }
+        else
+        {
+            JSON_THROW(type_error::create(310, detail::concat("cannot use swap(string_t&) with ", type_name()), this));
+        }
+    }
+
+    /// @brief exchanges the values
+    /// @sa https://json.nlohmann.me/api/basic_json/swap/
+    void swap(binary_t& other) // NOLINT(bugprone-exception-escape,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
+    {
+        // swap only works for strings
+        if (JSON_HEDLEY_LIKELY(is_binary()))
+        {
+            using std::swap;
+            swap(*(m_data.m_value.binary), other);
+        }
+        else
+        {
+            JSON_THROW(type_error::create(310, detail::concat("cannot use swap(binary_t&) with ", type_name()), this));
+        }
+    }
+
+    /// @brief exchanges the values
+    /// @sa https://json.nlohmann.me/api/basic_json/swap/
+    void swap(typename binary_t::container_type& other) // NOLINT(bugprone-exception-escape)
+    {
+        // swap only works for strings
+        if (JSON_HEDLEY_LIKELY(is_binary()))
+        {
+            using std::swap;
+            swap(*(m_data.m_value.binary), other);
+        }
+        else
+        {
+            JSON_THROW(type_error::create(310, detail::concat("cannot use swap(binary_t::container_type&) with ", type_name()), this));
+        }
+    }
+
+    /// @}
+
+    //////////////////////////////////////////
+    // lexicographical comparison operators //
+    //////////////////////////////////////////
+
+    /// @name lexicographical comparison operators
+    /// @{
+
+    // note parentheses around operands are necessary; see
+    // https://github.com/nlohmann/json/issues/1530
+#define JSON_IMPLEMENT_OPERATOR(op, null_result, unordered_result, default_result)                       \
+    const auto lhs_type = lhs.type();                                                                    \
+    const auto rhs_type = rhs.type();                                                                    \
+    \
+    if (lhs_type == rhs_type) /* NOLINT(readability/braces) */                                           \
+    {                                                                                                    \
+        switch (lhs_type)                                                                                \
+        {                                                                                                \
+            case value_t::array:                                                                         \
+                return (*lhs.m_data.m_value.array) op (*rhs.m_data.m_value.array);                                     \
+                \
+            case value_t::object:                                                                        \
+                return (*lhs.m_data.m_value.object) op (*rhs.m_data.m_value.object);                                   \
+                \
+            case value_t::null:                                                                          \
+                return (null_result);                                                                    \
+                \
+            case value_t::string:                                                                        \
+                return (*lhs.m_data.m_value.string) op (*rhs.m_data.m_value.string);                                   \
+                \
+            case value_t::boolean:                                                                       \
+                return (lhs.m_data.m_value.boolean) op (rhs.m_data.m_value.boolean);                                   \
+                \
+            case value_t::number_integer:                                                                \
+                return (lhs.m_data.m_value.number_integer) op (rhs.m_data.m_value.number_integer);                     \
+                \
+            case value_t::number_unsigned:                                                               \
+                return (lhs.m_data.m_value.number_unsigned) op (rhs.m_data.m_value.number_unsigned);                   \
+                \
+            case value_t::number_float:                                                                  \
+                return (lhs.m_data.m_value.number_float) op (rhs.m_data.m_value.number_float);                         \
+                \
+            case value_t::binary:                                                                        \
+                return (*lhs.m_data.m_value.binary) op (*rhs.m_data.m_value.binary);                                   \
+                \
+            case value_t::discarded:                                                                     \
+            default:                                                                                     \
+                return (unordered_result);                                                               \
+        }                                                                                                \
+    }                                                                                                    \
+    else if (lhs_type == value_t::number_integer && rhs_type == value_t::number_float)                   \
+    {                                                                                                    \
+        return static_cast<number_float_t>(lhs.m_data.m_value.number_integer) op rhs.m_data.m_value.number_float;      \
+    }                                                                                                    \
+    else if (lhs_type == value_t::number_float && rhs_type == value_t::number_integer)                   \
+    {                                                                                                    \
+        return lhs.m_data.m_value.number_float op static_cast<number_float_t>(rhs.m_data.m_value.number_integer);      \
+    }                                                                                                    \
+    else if (lhs_type == value_t::number_unsigned && rhs_type == value_t::number_float)                  \
+    {                                                                                                    \
+        return static_cast<number_float_t>(lhs.m_data.m_value.number_unsigned) op rhs.m_data.m_value.number_float;     \
+    }                                                                                                    \
+    else if (lhs_type == value_t::number_float && rhs_type == value_t::number_unsigned)                  \
+    {                                                                                                    \
+        return lhs.m_data.m_value.number_float op static_cast<number_float_t>(rhs.m_data.m_value.number_unsigned);     \
+    }                                                                                                    \
+    else if (lhs_type == value_t::number_unsigned && rhs_type == value_t::number_integer)                \
+    {                                                                                                    \
+        return static_cast<number_integer_t>(lhs.m_data.m_value.number_unsigned) op rhs.m_data.m_value.number_integer; \
+    }                                                                                                    \
+    else if (lhs_type == value_t::number_integer && rhs_type == value_t::number_unsigned)                \
+    {                                                                                                    \
+        return lhs.m_data.m_value.number_integer op static_cast<number_integer_t>(rhs.m_data.m_value.number_unsigned); \
+    }                                                                                                    \
+    else if(compares_unordered(lhs, rhs))\
+    {\
+        return (unordered_result);\
+    }\
+    \
+    return (default_result);
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    // returns true if:
+    // - any operand is NaN and the other operand is of number type
+    // - any operand is discarded
+    // in legacy mode, discarded values are considered ordered if
+    // an operation is computed as an odd number of inverses of others
+    static bool compares_unordered(const_reference lhs, const_reference rhs, bool inverse = false) noexcept
+    {
+        if ((lhs.is_number_float() && std::isnan(lhs.m_data.m_value.number_float) && rhs.is_number())
+                || (rhs.is_number_float() && std::isnan(rhs.m_data.m_value.number_float) && lhs.is_number()))
+        {
+            return true;
+        }
+#if JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON
+        return (lhs.is_discarded() || rhs.is_discarded()) && !inverse;
+#else
+        static_cast<void>(inverse);
+        return lhs.is_discarded() || rhs.is_discarded();
+#endif
+    }
+
+  private:
+    bool compares_unordered(const_reference rhs, bool inverse = false) const noexcept
+    {
+        return compares_unordered(*this, rhs, inverse);
+    }
+
+  public:
+#if JSON_HAS_THREE_WAY_COMPARISON
+    /// @brief comparison: equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_eq/
+    bool operator==(const_reference rhs) const noexcept
+    {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+        const_reference lhs = *this;
+        JSON_IMPLEMENT_OPERATOR( ==, true, false, false)
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+    }
+
+    /// @brief comparison: equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_eq/
+    template<typename ScalarType>
+    requires std::is_scalar_v<ScalarType>
+    bool operator==(ScalarType rhs) const noexcept
+    {
+        return *this == basic_json(rhs);
+    }
+
+    /// @brief comparison: not equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ne/
+    bool operator!=(const_reference rhs) const noexcept
+    {
+        if (compares_unordered(rhs, true))
+        {
+            return false;
+        }
+        return !operator==(rhs);
+    }
+
+    /// @brief comparison: 3-way
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_spaceship/
+    std::partial_ordering operator<=>(const_reference rhs) const noexcept // *NOPAD*
+    {
+        const_reference lhs = *this;
+        // default_result is used if we cannot compare values. In that case,
+        // we compare types.
+        JSON_IMPLEMENT_OPERATOR(<=>, // *NOPAD*
+                                std::partial_ordering::equivalent,
+                                std::partial_ordering::unordered,
+                                lhs_type <=> rhs_type) // *NOPAD*
+    }
+
+    /// @brief comparison: 3-way
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_spaceship/
+    template<typename ScalarType>
+    requires std::is_scalar_v<ScalarType>
+    std::partial_ordering operator<=>(ScalarType rhs) const noexcept // *NOPAD*
+    {
+        return *this <=> basic_json(rhs); // *NOPAD*
+    }
+
+#if JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON
+    // all operators that are computed as an odd number of inverses of others
+    // need to be overloaded to emulate the legacy comparison behavior
+
+    /// @brief comparison: less than or equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_le/
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.0, undef JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON)
+    bool operator<=(const_reference rhs) const noexcept
+    {
+        if (compares_unordered(rhs, true))
+        {
+            return false;
+        }
+        return !(rhs < *this);
+    }
+
+    /// @brief comparison: less than or equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_le/
+    template<typename ScalarType>
+    requires std::is_scalar_v<ScalarType>
+    bool operator<=(ScalarType rhs) const noexcept
+    {
+        return *this <= basic_json(rhs);
+    }
+
+    /// @brief comparison: greater than or equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ge/
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.0, undef JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON)
+    bool operator>=(const_reference rhs) const noexcept
+    {
+        if (compares_unordered(rhs, true))
+        {
+            return false;
+        }
+        return !(*this < rhs);
+    }
+
+    /// @brief comparison: greater than or equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ge/
+    template<typename ScalarType>
+    requires std::is_scalar_v<ScalarType>
+    bool operator>=(ScalarType rhs) const noexcept
+    {
+        return *this >= basic_json(rhs);
+    }
+#endif
+#else
+    /// @brief comparison: equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_eq/
+    friend bool operator==(const_reference lhs, const_reference rhs) noexcept
+    {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+        JSON_IMPLEMENT_OPERATOR( ==, true, false, false)
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+    }
+
+    /// @brief comparison: equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_eq/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator==(const_reference lhs, ScalarType rhs) noexcept
+    {
+        return lhs == basic_json(rhs);
+    }
+
+    /// @brief comparison: equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_eq/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator==(ScalarType lhs, const_reference rhs) noexcept
+    {
+        return basic_json(lhs) == rhs;
+    }
+
+    /// @brief comparison: not equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ne/
+    friend bool operator!=(const_reference lhs, const_reference rhs) noexcept
+    {
+        if (compares_unordered(lhs, rhs, true))
+        {
+            return false;
+        }
+        return !(lhs == rhs);
+    }
+
+    /// @brief comparison: not equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ne/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator!=(const_reference lhs, ScalarType rhs) noexcept
+    {
+        return lhs != basic_json(rhs);
+    }
+
+    /// @brief comparison: not equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ne/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator!=(ScalarType lhs, const_reference rhs) noexcept
+    {
+        return basic_json(lhs) != rhs;
+    }
+
+    /// @brief comparison: less than
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_lt/
+    friend bool operator<(const_reference lhs, const_reference rhs) noexcept
+    {
+        // default_result is used if we cannot compare values. In that case,
+        // we compare types. Note we have to call the operator explicitly,
+        // because MSVC has problems otherwise.
+        JSON_IMPLEMENT_OPERATOR( <, false, false, operator<(lhs_type, rhs_type))
+    }
+
+    /// @brief comparison: less than
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_lt/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator<(const_reference lhs, ScalarType rhs) noexcept
+    {
+        return lhs < basic_json(rhs);
+    }
+
+    /// @brief comparison: less than
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_lt/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator<(ScalarType lhs, const_reference rhs) noexcept
+    {
+        return basic_json(lhs) < rhs;
+    }
+
+    /// @brief comparison: less than or equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_le/
+    friend bool operator<=(const_reference lhs, const_reference rhs) noexcept
+    {
+        if (compares_unordered(lhs, rhs, true))
+        {
+            return false;
+        }
+        return !(rhs < lhs);
+    }
+
+    /// @brief comparison: less than or equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_le/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator<=(const_reference lhs, ScalarType rhs) noexcept
+    {
+        return lhs <= basic_json(rhs);
+    }
+
+    /// @brief comparison: less than or equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_le/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator<=(ScalarType lhs, const_reference rhs) noexcept
+    {
+        return basic_json(lhs) <= rhs;
+    }
+
+    /// @brief comparison: greater than
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_gt/
+    friend bool operator>(const_reference lhs, const_reference rhs) noexcept
+    {
+        // double inverse
+        if (compares_unordered(lhs, rhs))
+        {
+            return false;
+        }
+        return !(lhs <= rhs);
+    }
+
+    /// @brief comparison: greater than
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_gt/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator>(const_reference lhs, ScalarType rhs) noexcept
+    {
+        return lhs > basic_json(rhs);
+    }
+
+    /// @brief comparison: greater than
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_gt/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator>(ScalarType lhs, const_reference rhs) noexcept
+    {
+        return basic_json(lhs) > rhs;
+    }
+
+    /// @brief comparison: greater than or equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ge/
+    friend bool operator>=(const_reference lhs, const_reference rhs) noexcept
+    {
+        if (compares_unordered(lhs, rhs, true))
+        {
+            return false;
+        }
+        return !(lhs < rhs);
+    }
+
+    /// @brief comparison: greater than or equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ge/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator>=(const_reference lhs, ScalarType rhs) noexcept
+    {
+        return lhs >= basic_json(rhs);
+    }
+
+    /// @brief comparison: greater than or equal
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ge/
+    template<typename ScalarType, typename std::enable_if<
+                 std::is_scalar<ScalarType>::value, int>::type = 0>
+    friend bool operator>=(ScalarType lhs, const_reference rhs) noexcept
+    {
+        return basic_json(lhs) >= rhs;
+    }
+#endif
+
+#undef JSON_IMPLEMENT_OPERATOR
+
+    /// @}
+
+    ///////////////////
+    // serialization //
+    ///////////////////
+
+    /// @name serialization
+    /// @{
+#ifndef JSON_NO_IO
+    /// @brief serialize to stream
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ltlt/
+    friend std::ostream& operator<<(std::ostream& o, const basic_json& j)
+    {
+        // read width member and use it as indentation parameter if nonzero
+        const bool pretty_print = o.width() > 0;
+        const auto indentation = pretty_print ? o.width() : 0;
+
+        // reset width to 0 for subsequent calls to this stream
+        o.width(0);
+
+        // do the actual serialization
+        serializer s(detail::output_adapter<char>(o), o.fill());
+        s.dump(j, pretty_print, false, static_cast<unsigned int>(indentation));
+        return o;
+    }
+
+    /// @brief serialize to stream
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_ltlt/
+    /// @deprecated This function is deprecated since 3.0.0 and will be removed in
+    ///             version 4.0.0 of the library. Please use
+    ///             operator<<(std::ostream&, const basic_json&) instead; that is,
+    ///             replace calls like `j >> o;` with `o << j;`.
+    JSON_HEDLEY_DEPRECATED_FOR(3.0.0, operator<<(std::ostream&, const basic_json&))
+    friend std::ostream& operator>>(const basic_json& j, std::ostream& o)
+    {
+        return o << j;
+    }
+#endif  // JSON_NO_IO
+    /// @}
+
+    /////////////////////
+    // deserialization //
+    /////////////////////
+
+    /// @name deserialization
+    /// @{
+
+    /// @brief deserialize from a compatible input
+    /// @sa https://json.nlohmann.me/api/basic_json/parse/
+    template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json parse(InputType&& i,
+                            const parser_callback_t cb = nullptr,
+                            const bool allow_exceptions = true,
+                            const bool ignore_comments = false)
+    {
+        basic_json result;
+        parser(detail::input_adapter(std::forward<InputType>(i)), cb, allow_exceptions, ignore_comments).parse(true, result);
+        return result;
+    }
+
+    /// @brief deserialize from a pair of character iterators
+    /// @sa https://json.nlohmann.me/api/basic_json/parse/
+    template<typename IteratorType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json parse(IteratorType first,
+                            IteratorType last,
+                            const parser_callback_t cb = nullptr,
+                            const bool allow_exceptions = true,
+                            const bool ignore_comments = false)
+    {
+        basic_json result;
+        parser(detail::input_adapter(std::move(first), std::move(last)), cb, allow_exceptions, ignore_comments).parse(true, result);
+        return result;
+    }
+
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, parse(ptr, ptr + len))
+    static basic_json parse(detail::span_input_adapter&& i,
+                            const parser_callback_t cb = nullptr,
+                            const bool allow_exceptions = true,
+                            const bool ignore_comments = false)
+    {
+        basic_json result;
+        parser(i.get(), cb, allow_exceptions, ignore_comments).parse(true, result);
+        return result;
+    }
+
+    /// @brief check if the input is valid JSON
+    /// @sa https://json.nlohmann.me/api/basic_json/accept/
+    template<typename InputType>
+    static bool accept(InputType&& i,
+                       const bool ignore_comments = false)
+    {
+        return parser(detail::input_adapter(std::forward<InputType>(i)), nullptr, false, ignore_comments).accept(true);
+    }
+
+    /// @brief check if the input is valid JSON
+    /// @sa https://json.nlohmann.me/api/basic_json/accept/
+    template<typename IteratorType>
+    static bool accept(IteratorType first, IteratorType last,
+                       const bool ignore_comments = false)
+    {
+        return parser(detail::input_adapter(std::move(first), std::move(last)), nullptr, false, ignore_comments).accept(true);
+    }
+
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, accept(ptr, ptr + len))
+    static bool accept(detail::span_input_adapter&& i,
+                       const bool ignore_comments = false)
+    {
+        return parser(i.get(), nullptr, false, ignore_comments).accept(true);
+    }
+
+    /// @brief generate SAX events
+    /// @sa https://json.nlohmann.me/api/basic_json/sax_parse/
+    template <typename InputType, typename SAX>
+    JSON_HEDLEY_NON_NULL(2)
+    static bool sax_parse(InputType&& i, SAX* sax,
+                          input_format_t format = input_format_t::json,
+                          const bool strict = true,
+                          const bool ignore_comments = false)
+    {
+        auto ia = detail::input_adapter(std::forward<InputType>(i));
+        return format == input_format_t::json
+               ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
+               : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+    }
+
+    /// @brief generate SAX events
+    /// @sa https://json.nlohmann.me/api/basic_json/sax_parse/
+    template<class IteratorType, class SAX>
+    JSON_HEDLEY_NON_NULL(3)
+    static bool sax_parse(IteratorType first, IteratorType last, SAX* sax,
+                          input_format_t format = input_format_t::json,
+                          const bool strict = true,
+                          const bool ignore_comments = false)
+    {
+        auto ia = detail::input_adapter(std::move(first), std::move(last));
+        return format == input_format_t::json
+               ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
+               : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+    }
+
+    /// @brief generate SAX events
+    /// @sa https://json.nlohmann.me/api/basic_json/sax_parse/
+    /// @deprecated This function is deprecated since 3.8.0 and will be removed in
+    ///             version 4.0.0 of the library. Please use
+    ///             sax_parse(ptr, ptr + len) instead.
+    template <typename SAX>
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, sax_parse(ptr, ptr + len, ...))
+    JSON_HEDLEY_NON_NULL(2)
+    static bool sax_parse(detail::span_input_adapter&& i, SAX* sax,
+                          input_format_t format = input_format_t::json,
+                          const bool strict = true,
+                          const bool ignore_comments = false)
+    {
+        auto ia = i.get();
+        return format == input_format_t::json
+               // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
+               ? parser(std::move(ia), nullptr, true, ignore_comments).sax_parse(sax, strict)
+               // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
+               : detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia), format).sax_parse(format, sax, strict);
+    }
+#ifndef JSON_NO_IO
+    /// @brief deserialize from stream
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_gtgt/
+    /// @deprecated This stream operator is deprecated since 3.0.0 and will be removed in
+    ///             version 4.0.0 of the library. Please use
+    ///             operator>>(std::istream&, basic_json&) instead; that is,
+    ///             replace calls like `j << i;` with `i >> j;`.
+    JSON_HEDLEY_DEPRECATED_FOR(3.0.0, operator>>(std::istream&, basic_json&))
+    friend std::istream& operator<<(basic_json& j, std::istream& i)
+    {
+        return operator>>(i, j);
+    }
+
+    /// @brief deserialize from stream
+    /// @sa https://json.nlohmann.me/api/basic_json/operator_gtgt/
+    friend std::istream& operator>>(std::istream& i, basic_json& j)
+    {
+        parser(detail::input_adapter(i)).parse(false, j);
+        return i;
+    }
+#endif  // JSON_NO_IO
+    /// @}
+
+    ///////////////////////////
+    // convenience functions //
+    ///////////////////////////
+
+    /// @brief return the type as string
+    /// @sa https://json.nlohmann.me/api/basic_json/type_name/
+    JSON_HEDLEY_RETURNS_NON_NULL
+    const char* type_name() const noexcept
+    {
+        switch (m_data.m_type)
+        {
+            case value_t::null:
+                return "null";
+            case value_t::object:
+                return "object";
+            case value_t::array:
+                return "array";
+            case value_t::string:
+                return "string";
+            case value_t::boolean:
+                return "boolean";
+            case value_t::binary:
+                return "binary";
+            case value_t::discarded:
+                return "discarded";
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            default:
+                return "number";
+        }
+    }
+
+  JSON_PRIVATE_UNLESS_TESTED:
+    //////////////////////
+    // member variables //
+    //////////////////////
+
+    struct data
+    {
+        /// the type of the current element
+        value_t m_type = value_t::null;
+
+        /// the value of the current element
+        json_value m_value = {};
+
+        data(const value_t v)
+            : m_type(v), m_value(v)
+        {
+        }
+
+        data(size_type cnt, const basic_json& val)
+            : m_type(value_t::array)
+        {
+            m_value.array = create<array_t>(cnt, val);
+        }
+
+        data() noexcept = default;
+        data(data&&) noexcept = default;
+        data(const data&) noexcept = delete;
+        data& operator=(data&&) noexcept = delete;
+        data& operator=(const data&) noexcept = delete;
+
+        ~data() noexcept
+        {
+            m_value.destroy(m_type);
+        }
+    };
+
+    data m_data = {};
+
+#if JSON_DIAGNOSTICS
+    /// a pointer to a parent value (for debugging purposes)
+    basic_json* m_parent = nullptr;
+#endif
+
+    //////////////////////////////////////////
+    // binary serialization/deserialization //
+    //////////////////////////////////////////
+
+    /// @name binary serialization/deserialization support
+    /// @{
+
+  public:
+    /// @brief create a CBOR serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_cbor/
+    static std::vector<std::uint8_t> to_cbor(const basic_json& j)
+    {
+        std::vector<std::uint8_t> result;
+        to_cbor(j, result);
+        return result;
+    }
+
+    /// @brief create a CBOR serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_cbor/
+    static void to_cbor(const basic_json& j, detail::output_adapter<std::uint8_t> o)
+    {
+        binary_writer<std::uint8_t>(o).write_cbor(j);
+    }
+
+    /// @brief create a CBOR serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_cbor/
+    static void to_cbor(const basic_json& j, detail::output_adapter<char> o)
+    {
+        binary_writer<char>(o).write_cbor(j);
+    }
+
+    /// @brief create a MessagePack serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_msgpack/
+    static std::vector<std::uint8_t> to_msgpack(const basic_json& j)
+    {
+        std::vector<std::uint8_t> result;
+        to_msgpack(j, result);
+        return result;
+    }
+
+    /// @brief create a MessagePack serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_msgpack/
+    static void to_msgpack(const basic_json& j, detail::output_adapter<std::uint8_t> o)
+    {
+        binary_writer<std::uint8_t>(o).write_msgpack(j);
+    }
+
+    /// @brief create a MessagePack serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_msgpack/
+    static void to_msgpack(const basic_json& j, detail::output_adapter<char> o)
+    {
+        binary_writer<char>(o).write_msgpack(j);
+    }
+
+    /// @brief create a UBJSON serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_ubjson/
+    static std::vector<std::uint8_t> to_ubjson(const basic_json& j,
+            const bool use_size = false,
+            const bool use_type = false)
+    {
+        std::vector<std::uint8_t> result;
+        to_ubjson(j, result, use_size, use_type);
+        return result;
+    }
+
+    /// @brief create a UBJSON serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_ubjson/
+    static void to_ubjson(const basic_json& j, detail::output_adapter<std::uint8_t> o,
+                          const bool use_size = false, const bool use_type = false)
+    {
+        binary_writer<std::uint8_t>(o).write_ubjson(j, use_size, use_type);
+    }
+
+    /// @brief create a UBJSON serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_ubjson/
+    static void to_ubjson(const basic_json& j, detail::output_adapter<char> o,
+                          const bool use_size = false, const bool use_type = false)
+    {
+        binary_writer<char>(o).write_ubjson(j, use_size, use_type);
+    }
+
+    /// @brief create a BJData serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_bjdata/
+    static std::vector<std::uint8_t> to_bjdata(const basic_json& j,
+            const bool use_size = false,
+            const bool use_type = false)
+    {
+        std::vector<std::uint8_t> result;
+        to_bjdata(j, result, use_size, use_type);
+        return result;
+    }
+
+    /// @brief create a BJData serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_bjdata/
+    static void to_bjdata(const basic_json& j, detail::output_adapter<std::uint8_t> o,
+                          const bool use_size = false, const bool use_type = false)
+    {
+        binary_writer<std::uint8_t>(o).write_ubjson(j, use_size, use_type, true, true);
+    }
+
+    /// @brief create a BJData serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_bjdata/
+    static void to_bjdata(const basic_json& j, detail::output_adapter<char> o,
+                          const bool use_size = false, const bool use_type = false)
+    {
+        binary_writer<char>(o).write_ubjson(j, use_size, use_type, true, true);
+    }
+
+    /// @brief create a BSON serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_bson/
+    static std::vector<std::uint8_t> to_bson(const basic_json& j)
+    {
+        std::vector<std::uint8_t> result;
+        to_bson(j, result);
+        return result;
+    }
+
+    /// @brief create a BSON serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_bson/
+    static void to_bson(const basic_json& j, detail::output_adapter<std::uint8_t> o)
+    {
+        binary_writer<std::uint8_t>(o).write_bson(j);
+    }
+
+    /// @brief create a BSON serialization of a given JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/to_bson/
+    static void to_bson(const basic_json& j, detail::output_adapter<char> o)
+    {
+        binary_writer<char>(o).write_bson(j);
+    }
+
+    /// @brief create a JSON value from an input in CBOR format
+    /// @sa https://json.nlohmann.me/api/basic_json/from_cbor/
+    template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json from_cbor(InputType&& i,
+                                const bool strict = true,
+                                const bool allow_exceptions = true,
+                                const cbor_tag_handler_t tag_handler = cbor_tag_handler_t::error)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = detail::input_adapter(std::forward<InputType>(i));
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::cbor).sax_parse(input_format_t::cbor, &sdp, strict, tag_handler);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    /// @brief create a JSON value from an input in CBOR format
+    /// @sa https://json.nlohmann.me/api/basic_json/from_cbor/
+    template<typename IteratorType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json from_cbor(IteratorType first, IteratorType last,
+                                const bool strict = true,
+                                const bool allow_exceptions = true,
+                                const cbor_tag_handler_t tag_handler = cbor_tag_handler_t::error)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = detail::input_adapter(std::move(first), std::move(last));
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::cbor).sax_parse(input_format_t::cbor, &sdp, strict, tag_handler);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    template<typename T>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, from_cbor(ptr, ptr + len))
+    static basic_json from_cbor(const T* ptr, std::size_t len,
+                                const bool strict = true,
+                                const bool allow_exceptions = true,
+                                const cbor_tag_handler_t tag_handler = cbor_tag_handler_t::error)
+    {
+        return from_cbor(ptr, ptr + len, strict, allow_exceptions, tag_handler);
+    }
+
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, from_cbor(ptr, ptr + len))
+    static basic_json from_cbor(detail::span_input_adapter&& i,
+                                const bool strict = true,
+                                const bool allow_exceptions = true,
+                                const cbor_tag_handler_t tag_handler = cbor_tag_handler_t::error)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = i.get();
+        // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::cbor).sax_parse(input_format_t::cbor, &sdp, strict, tag_handler);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    /// @brief create a JSON value from an input in MessagePack format
+    /// @sa https://json.nlohmann.me/api/basic_json/from_msgpack/
+    template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json from_msgpack(InputType&& i,
+                                   const bool strict = true,
+                                   const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = detail::input_adapter(std::forward<InputType>(i));
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::msgpack).sax_parse(input_format_t::msgpack, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    /// @brief create a JSON value from an input in MessagePack format
+    /// @sa https://json.nlohmann.me/api/basic_json/from_msgpack/
+    template<typename IteratorType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json from_msgpack(IteratorType first, IteratorType last,
+                                   const bool strict = true,
+                                   const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = detail::input_adapter(std::move(first), std::move(last));
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::msgpack).sax_parse(input_format_t::msgpack, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    template<typename T>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, from_msgpack(ptr, ptr + len))
+    static basic_json from_msgpack(const T* ptr, std::size_t len,
+                                   const bool strict = true,
+                                   const bool allow_exceptions = true)
+    {
+        return from_msgpack(ptr, ptr + len, strict, allow_exceptions);
+    }
+
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, from_msgpack(ptr, ptr + len))
+    static basic_json from_msgpack(detail::span_input_adapter&& i,
+                                   const bool strict = true,
+                                   const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = i.get();
+        // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::msgpack).sax_parse(input_format_t::msgpack, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    /// @brief create a JSON value from an input in UBJSON format
+    /// @sa https://json.nlohmann.me/api/basic_json/from_ubjson/
+    template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json from_ubjson(InputType&& i,
+                                  const bool strict = true,
+                                  const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = detail::input_adapter(std::forward<InputType>(i));
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::ubjson).sax_parse(input_format_t::ubjson, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    /// @brief create a JSON value from an input in UBJSON format
+    /// @sa https://json.nlohmann.me/api/basic_json/from_ubjson/
+    template<typename IteratorType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json from_ubjson(IteratorType first, IteratorType last,
+                                  const bool strict = true,
+                                  const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = detail::input_adapter(std::move(first), std::move(last));
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::ubjson).sax_parse(input_format_t::ubjson, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    template<typename T>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, from_ubjson(ptr, ptr + len))
+    static basic_json from_ubjson(const T* ptr, std::size_t len,
+                                  const bool strict = true,
+                                  const bool allow_exceptions = true)
+    {
+        return from_ubjson(ptr, ptr + len, strict, allow_exceptions);
+    }
+
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, from_ubjson(ptr, ptr + len))
+    static basic_json from_ubjson(detail::span_input_adapter&& i,
+                                  const bool strict = true,
+                                  const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = i.get();
+        // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::ubjson).sax_parse(input_format_t::ubjson, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    /// @brief create a JSON value from an input in BJData format
+    /// @sa https://json.nlohmann.me/api/basic_json/from_bjdata/
+    template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json from_bjdata(InputType&& i,
+                                  const bool strict = true,
+                                  const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = detail::input_adapter(std::forward<InputType>(i));
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::bjdata).sax_parse(input_format_t::bjdata, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    /// @brief create a JSON value from an input in BJData format
+    /// @sa https://json.nlohmann.me/api/basic_json/from_bjdata/
+    template<typename IteratorType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json from_bjdata(IteratorType first, IteratorType last,
+                                  const bool strict = true,
+                                  const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = detail::input_adapter(std::move(first), std::move(last));
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::bjdata).sax_parse(input_format_t::bjdata, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    /// @brief create a JSON value from an input in BSON format
+    /// @sa https://json.nlohmann.me/api/basic_json/from_bson/
+    template<typename InputType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json from_bson(InputType&& i,
+                                const bool strict = true,
+                                const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = detail::input_adapter(std::forward<InputType>(i));
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::bson).sax_parse(input_format_t::bson, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    /// @brief create a JSON value from an input in BSON format
+    /// @sa https://json.nlohmann.me/api/basic_json/from_bson/
+    template<typename IteratorType>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json from_bson(IteratorType first, IteratorType last,
+                                const bool strict = true,
+                                const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = detail::input_adapter(std::move(first), std::move(last));
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::bson).sax_parse(input_format_t::bson, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+
+    template<typename T>
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, from_bson(ptr, ptr + len))
+    static basic_json from_bson(const T* ptr, std::size_t len,
+                                const bool strict = true,
+                                const bool allow_exceptions = true)
+    {
+        return from_bson(ptr, ptr + len, strict, allow_exceptions);
+    }
+
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    JSON_HEDLEY_DEPRECATED_FOR(3.8.0, from_bson(ptr, ptr + len))
+    static basic_json from_bson(detail::span_input_adapter&& i,
+                                const bool strict = true,
+                                const bool allow_exceptions = true)
+    {
+        basic_json result;
+        detail::json_sax_dom_parser<basic_json> sdp(result, allow_exceptions);
+        auto ia = i.get();
+        // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg)
+        const bool res = binary_reader<decltype(ia)>(std::move(ia), input_format_t::bson).sax_parse(input_format_t::bson, &sdp, strict);
+        return res ? result : basic_json(value_t::discarded);
+    }
+    /// @}
+
+    //////////////////////////
+    // JSON Pointer support //
+    //////////////////////////
+
+    /// @name JSON Pointer functions
+    /// @{
+
+    /// @brief access specified element via JSON Pointer
+    /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
+    reference operator[](const json_pointer& ptr)
+    {
+        return ptr.get_unchecked(this);
+    }
+
+    template<typename BasicJsonType, detail::enable_if_t<detail::is_basic_json<BasicJsonType>::value, int> = 0>
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.0, basic_json::json_pointer or nlohmann::json_pointer<basic_json::string_t>) // NOLINT(readability/alt_tokens)
+    reference operator[](const ::nlohmann::json_pointer<BasicJsonType>& ptr)
+    {
+        return ptr.get_unchecked(this);
+    }
+
+    /// @brief access specified element via JSON Pointer
+    /// @sa https://json.nlohmann.me/api/basic_json/operator%5B%5D/
+    const_reference operator[](const json_pointer& ptr) const
+    {
+        return ptr.get_unchecked(this);
+    }
+
+    template<typename BasicJsonType, detail::enable_if_t<detail::is_basic_json<BasicJsonType>::value, int> = 0>
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.0, basic_json::json_pointer or nlohmann::json_pointer<basic_json::string_t>) // NOLINT(readability/alt_tokens)
+    const_reference operator[](const ::nlohmann::json_pointer<BasicJsonType>& ptr) const
+    {
+        return ptr.get_unchecked(this);
+    }
+
+    /// @brief access specified element via JSON Pointer
+    /// @sa https://json.nlohmann.me/api/basic_json/at/
+    reference at(const json_pointer& ptr)
+    {
+        return ptr.get_checked(this);
+    }
+
+    template<typename BasicJsonType, detail::enable_if_t<detail::is_basic_json<BasicJsonType>::value, int> = 0>
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.0, basic_json::json_pointer or nlohmann::json_pointer<basic_json::string_t>) // NOLINT(readability/alt_tokens)
+    reference at(const ::nlohmann::json_pointer<BasicJsonType>& ptr)
+    {
+        return ptr.get_checked(this);
+    }
+
+    /// @brief access specified element via JSON Pointer
+    /// @sa https://json.nlohmann.me/api/basic_json/at/
+    const_reference at(const json_pointer& ptr) const
+    {
+        return ptr.get_checked(this);
+    }
+
+    template<typename BasicJsonType, detail::enable_if_t<detail::is_basic_json<BasicJsonType>::value, int> = 0>
+    JSON_HEDLEY_DEPRECATED_FOR(3.11.0, basic_json::json_pointer or nlohmann::json_pointer<basic_json::string_t>) // NOLINT(readability/alt_tokens)
+    const_reference at(const ::nlohmann::json_pointer<BasicJsonType>& ptr) const
+    {
+        return ptr.get_checked(this);
+    }
+
+    /// @brief return flattened JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/flatten/
+    basic_json flatten() const
+    {
+        basic_json result(value_t::object);
+        json_pointer::flatten("", *this, result);
+        return result;
+    }
+
+    /// @brief unflatten a previously flattened JSON value
+    /// @sa https://json.nlohmann.me/api/basic_json/unflatten/
+    basic_json unflatten() const
+    {
+        return json_pointer::unflatten(*this);
+    }
+
+    /// @}
+
+    //////////////////////////
+    // JSON Patch functions //
+    //////////////////////////
+
+    /// @name JSON Patch functions
+    /// @{
+
+    /// @brief applies a JSON patch in-place without copying the object
+    /// @sa https://json.nlohmann.me/api/basic_json/patch/
+    void patch_inplace(const basic_json& json_patch)
+    {
+        basic_json& result = *this;
+        // the valid JSON Patch operations
+        enum class patch_operations {add, remove, replace, move, copy, test, invalid};
+
+        const auto get_op = [](const std::string & op)
+        {
+            if (op == "add")
+            {
+                return patch_operations::add;
+            }
+            if (op == "remove")
+            {
+                return patch_operations::remove;
+            }
+            if (op == "replace")
+            {
+                return patch_operations::replace;
+            }
+            if (op == "move")
+            {
+                return patch_operations::move;
+            }
+            if (op == "copy")
+            {
+                return patch_operations::copy;
+            }
+            if (op == "test")
+            {
+                return patch_operations::test;
+            }
+
+            return patch_operations::invalid;
+        };
+
+        // wrapper for "add" operation; add value at ptr
+        const auto operation_add = [&result](json_pointer & ptr, basic_json val)
+        {
+            // adding to the root of the target document means replacing it
+            if (ptr.empty())
+            {
+                result = val;
+                return;
+            }
+
+            // make sure the top element of the pointer exists
+            json_pointer const top_pointer = ptr.top();
+            if (top_pointer != ptr)
+            {
+                result.at(top_pointer);
+            }
+
+            // get reference to parent of JSON pointer ptr
+            const auto last_path = ptr.back();
+            ptr.pop_back();
+            // parent must exist when performing patch add per RFC6902 specs
+            basic_json& parent = result.at(ptr);
+
+            switch (parent.m_data.m_type)
+            {
+                case value_t::null:
+                case value_t::object:
+                {
+                    // use operator[] to add value
+                    parent[last_path] = val;
+                    break;
+                }
+
+                case value_t::array:
+                {
+                    if (last_path == "-")
+                    {
+                        // special case: append to back
+                        parent.push_back(val);
+                    }
+                    else
+                    {
+                        const auto idx = json_pointer::template array_index<basic_json_t>(last_path);
+                        if (JSON_HEDLEY_UNLIKELY(idx > parent.size()))
+                        {
+                            // avoid undefined behavior
+                            JSON_THROW(out_of_range::create(401, detail::concat("array index ", std::to_string(idx), " is out of range"), &parent));
+                        }
+
+                        // default case: insert add offset
+                        parent.insert(parent.begin() + static_cast<difference_type>(idx), val);
+                    }
+                    break;
+                }
+
+                // if there exists a parent it cannot be primitive
+                case value_t::string: // LCOV_EXCL_LINE
+                case value_t::boolean: // LCOV_EXCL_LINE
+                case value_t::number_integer: // LCOV_EXCL_LINE
+                case value_t::number_unsigned: // LCOV_EXCL_LINE
+                case value_t::number_float: // LCOV_EXCL_LINE
+                case value_t::binary: // LCOV_EXCL_LINE
+                case value_t::discarded: // LCOV_EXCL_LINE
+                default:            // LCOV_EXCL_LINE
+                    JSON_ASSERT(false); // NOLINT(cert-dcl03-c,hicpp-static-assert,misc-static-assert) LCOV_EXCL_LINE
+            }
+        };
+
+        // wrapper for "remove" operation; remove value at ptr
+        const auto operation_remove = [this, & result](json_pointer & ptr)
+        {
+            // get reference to parent of JSON pointer ptr
+            const auto last_path = ptr.back();
+            ptr.pop_back();
+            basic_json& parent = result.at(ptr);
+
+            // remove child
+            if (parent.is_object())
+            {
+                // perform range check
+                auto it = parent.find(last_path);
+                if (JSON_HEDLEY_LIKELY(it != parent.end()))
+                {
+                    parent.erase(it);
+                }
+                else
+                {
+                    JSON_THROW(out_of_range::create(403, detail::concat("key '", last_path, "' not found"), this));
+                }
+            }
+            else if (parent.is_array())
+            {
+                // note erase performs range check
+                parent.erase(json_pointer::template array_index<basic_json_t>(last_path));
+            }
+        };
+
+        // type check: top level value must be an array
+        if (JSON_HEDLEY_UNLIKELY(!json_patch.is_array()))
+        {
+            JSON_THROW(parse_error::create(104, 0, "JSON patch must be an array of objects", &json_patch));
+        }
+
+        // iterate and apply the operations
+        for (const auto& val : json_patch)
+        {
+            // wrapper to get a value for an operation
+            const auto get_value = [&val](const std::string & op,
+                                          const std::string & member,
+                                          bool string_type) -> basic_json &
+            {
+                // find value
+                auto it = val.m_data.m_value.object->find(member);
+
+                // context-sensitive error message
+                const auto error_msg = (op == "op") ? "operation" : detail::concat("operation '", op, '\'');
+
+                // check if desired value is present
+                if (JSON_HEDLEY_UNLIKELY(it == val.m_data.m_value.object->end()))
+                {
+                    // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
+                    JSON_THROW(parse_error::create(105, 0, detail::concat(error_msg, " must have member '", member, "'"), &val));
+                }
+
+                // check if result is of type string
+                if (JSON_HEDLEY_UNLIKELY(string_type && !it->second.is_string()))
+                {
+                    // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
+                    JSON_THROW(parse_error::create(105, 0, detail::concat(error_msg, " must have string member '", member, "'"), &val));
+                }
+
+                // no error: return value
+                return it->second;
+            };
+
+            // type check: every element of the array must be an object
+            if (JSON_HEDLEY_UNLIKELY(!val.is_object()))
+            {
+                JSON_THROW(parse_error::create(104, 0, "JSON patch must be an array of objects", &val));
+            }
+
+            // collect mandatory members
+            const auto op = get_value("op", "op", true).template get<std::string>();
+            const auto path = get_value(op, "path", true).template get<std::string>();
+            json_pointer ptr(path);
+
+            switch (get_op(op))
+            {
+                case patch_operations::add:
+                {
+                    operation_add(ptr, get_value("add", "value", false));
+                    break;
+                }
+
+                case patch_operations::remove:
+                {
+                    operation_remove(ptr);
+                    break;
+                }
+
+                case patch_operations::replace:
+                {
+                    // the "path" location must exist - use at()
+                    result.at(ptr) = get_value("replace", "value", false);
+                    break;
+                }
+
+                case patch_operations::move:
+                {
+                    const auto from_path = get_value("move", "from", true).template get<std::string>();
+                    json_pointer from_ptr(from_path);
+
+                    // the "from" location must exist - use at()
+                    basic_json const v = result.at(from_ptr);
+
+                    // The move operation is functionally identical to a
+                    // "remove" operation on the "from" location, followed
+                    // immediately by an "add" operation at the target
+                    // location with the value that was just removed.
+                    operation_remove(from_ptr);
+                    operation_add(ptr, v);
+                    break;
+                }
+
+                case patch_operations::copy:
+                {
+                    const auto from_path = get_value("copy", "from", true).template get<std::string>();
+                    const json_pointer from_ptr(from_path);
+
+                    // the "from" location must exist - use at()
+                    basic_json const v = result.at(from_ptr);
+
+                    // The copy is functionally identical to an "add"
+                    // operation at the target location using the value
+                    // specified in the "from" member.
+                    operation_add(ptr, v);
+                    break;
+                }
+
+                case patch_operations::test:
+                {
+                    bool success = false;
+                    JSON_TRY
+                    {
+                        // check if "value" matches the one at "path"
+                        // the "path" location must exist - use at()
+                        success = (result.at(ptr) == get_value("test", "value", false));
+                    }
+                    JSON_INTERNAL_CATCH (out_of_range&)
+                    {
+                        // ignore out of range errors: success remains false
+                    }
+
+                    // throw an exception if test fails
+                    if (JSON_HEDLEY_UNLIKELY(!success))
+                    {
+                        JSON_THROW(other_error::create(501, detail::concat("unsuccessful: ", val.dump()), &val));
+                    }
+
+                    break;
+                }
+
+                case patch_operations::invalid:
+                default:
+                {
+                    // op must be "add", "remove", "replace", "move", "copy", or
+                    // "test"
+                    JSON_THROW(parse_error::create(105, 0, detail::concat("operation value '", op, "' is invalid"), &val));
+                }
+            }
+        }
+    }
+
+    /// @brief applies a JSON patch to a copy of the current object
+    /// @sa https://json.nlohmann.me/api/basic_json/patch/
+    basic_json patch(const basic_json& json_patch) const
+    {
+        basic_json result = *this;
+        result.patch_inplace(json_patch);
+        return result;
+    }
+
+    /// @brief creates a diff as a JSON patch
+    /// @sa https://json.nlohmann.me/api/basic_json/diff/
+    JSON_HEDLEY_WARN_UNUSED_RESULT
+    static basic_json diff(const basic_json& source, const basic_json& target,
+                           const std::string& path = "")
+    {
+        // the patch
+        basic_json result(value_t::array);
+
+        // if the values are the same, return empty patch
+        if (source == target)
+        {
+            return result;
+        }
+
+        if (source.type() != target.type())
+        {
+            // different types: replace value
+            result.push_back(
+            {
+                {"op", "replace"}, {"path", path}, {"value", target}
+            });
+            return result;
+        }
+
+        switch (source.type())
+        {
+            case value_t::array:
+            {
+                // first pass: traverse common elements
+                std::size_t i = 0;
+                while (i < source.size() && i < target.size())
+                {
+                    // recursive call to compare array values at index i
+                    auto temp_diff = diff(source[i], target[i], detail::concat(path, '/', std::to_string(i)));
+                    result.insert(result.end(), temp_diff.begin(), temp_diff.end());
+                    ++i;
+                }
+
+                // We now reached the end of at least one array
+                // in a second pass, traverse the remaining elements
+
+                // remove my remaining elements
+                const auto end_index = static_cast<difference_type>(result.size());
+                while (i < source.size())
+                {
+                    // add operations in reverse order to avoid invalid
+                    // indices
+                    result.insert(result.begin() + end_index, object(
+                    {
+                        {"op", "remove"},
+                        {"path", detail::concat(path, '/', std::to_string(i))}
+                    }));
+                    ++i;
+                }
+
+                // add other remaining elements
+                while (i < target.size())
+                {
+                    result.push_back(
+                    {
+                        {"op", "add"},
+                        {"path", detail::concat(path, "/-")},
+                        {"value", target[i]}
+                    });
+                    ++i;
+                }
+
+                break;
+            }
+
+            case value_t::object:
+            {
+                // first pass: traverse this object's elements
+                for (auto it = source.cbegin(); it != source.cend(); ++it)
+                {
+                    // escape the key name to be used in a JSON patch
+                    const auto path_key = detail::concat(path, '/', detail::escape(it.key()));
+
+                    if (target.find(it.key()) != target.end())
+                    {
+                        // recursive call to compare object values at key it
+                        auto temp_diff = diff(it.value(), target[it.key()], path_key);
+                        result.insert(result.end(), temp_diff.begin(), temp_diff.end());
+                    }
+                    else
+                    {
+                        // found a key that is not in o -> remove it
+                        result.push_back(object(
+                        {
+                            {"op", "remove"}, {"path", path_key}
+                        }));
+                    }
+                }
+
+                // second pass: traverse other object's elements
+                for (auto it = target.cbegin(); it != target.cend(); ++it)
+                {
+                    if (source.find(it.key()) == source.end())
+                    {
+                        // found a key that is not in this -> add it
+                        const auto path_key = detail::concat(path, '/', detail::escape(it.key()));
+                        result.push_back(
+                        {
+                            {"op", "add"}, {"path", path_key},
+                            {"value", it.value()}
+                        });
+                    }
+                }
+
+                break;
+            }
+
+            case value_t::null:
+            case value_t::string:
+            case value_t::boolean:
+            case value_t::number_integer:
+            case value_t::number_unsigned:
+            case value_t::number_float:
+            case value_t::binary:
+            case value_t::discarded:
+            default:
+            {
+                // both primitive type: replace value
+                result.push_back(
+                {
+                    {"op", "replace"}, {"path", path}, {"value", target}
+                });
+                break;
+            }
+        }
+
+        return result;
+    }
+    /// @}
+
+    ////////////////////////////////
+    // JSON Merge Patch functions //
+    ////////////////////////////////
+
+    /// @name JSON Merge Patch functions
+    /// @{
+
+    /// @brief applies a JSON Merge Patch
+    /// @sa https://json.nlohmann.me/api/basic_json/merge_patch/
+    void merge_patch(const basic_json& apply_patch)
+    {
+        if (apply_patch.is_object())
+        {
+            if (!is_object())
+            {
+                *this = object();
+            }
+            for (auto it = apply_patch.begin(); it != apply_patch.end(); ++it)
+            {
+                if (it.value().is_null())
+                {
+                    erase(it.key());
+                }
+                else
+                {
+                    operator[](it.key()).merge_patch(it.value());
+                }
+            }
+        }
+        else
+        {
+            *this = apply_patch;
+        }
+    }
+
+    /// @}
+};
+
+/// @brief user-defined to_string function for JSON values
+/// @sa https://json.nlohmann.me/api/basic_json/to_string/
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+std::string to_string(const NLOHMANN_BASIC_JSON_TPL& j)
+{
+    return j.dump();
+}
+
+inline namespace literals
+{
+inline namespace json_literals
+{
+
+/// @brief user-defined string literal for JSON values
+/// @sa https://json.nlohmann.me/api/basic_json/operator_literal_json/
+JSON_HEDLEY_NON_NULL(1)
+#if !defined(JSON_HEDLEY_GCC_VERSION) || JSON_HEDLEY_GCC_VERSION_CHECK(4,9,0)
+    inline nlohmann::json operator ""_json(const char* s, std::size_t n)
+#else
+    inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+#endif
+{
+    return nlohmann::json::parse(s, s + n);
+}
+
+/// @brief user-defined string literal for JSON pointer
+/// @sa https://json.nlohmann.me/api/basic_json/operator_literal_json_pointer/
+JSON_HEDLEY_NON_NULL(1)
+#if !defined(JSON_HEDLEY_GCC_VERSION) || JSON_HEDLEY_GCC_VERSION_CHECK(4,9,0)
+    inline nlohmann::json::json_pointer operator ""_json_pointer(const char* s, std::size_t n)
+#else
+    inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+#endif
+{
+    return nlohmann::json::json_pointer(std::string(s, n));
+}
+
+}  // namespace json_literals
+}  // namespace literals
+NLOHMANN_JSON_NAMESPACE_END
+
+///////////////////////
+// nonmember support //
+///////////////////////
+
+namespace std // NOLINT(cert-dcl58-cpp)
+{
+
+/// @brief hash value for JSON objects
+/// @sa https://json.nlohmann.me/api/basic_json/std_hash/
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+struct hash<nlohmann::NLOHMANN_BASIC_JSON_TPL> // NOLINT(cert-dcl58-cpp)
+{
+    std::size_t operator()(const nlohmann::NLOHMANN_BASIC_JSON_TPL& j) const
+    {
+        return nlohmann::detail::hash(j);
+    }
+};
+
+// specialization for std::less<value_t>
+template<>
+struct less< ::nlohmann::detail::value_t> // do not remove the space after '<', see https://github.com/nlohmann/json/pull/679
+{
+    /*!
+    @brief compare two value_t enum values
+    @since version 3.0.0
+    */
+    bool operator()(::nlohmann::detail::value_t lhs,
+                    ::nlohmann::detail::value_t rhs) const noexcept
+    {
+#if JSON_HAS_THREE_WAY_COMPARISON
+        return std::is_lt(lhs <=> rhs); // *NOPAD*
+#else
+        return ::nlohmann::detail::operator<(lhs, rhs);
+#endif
+    }
+};
+
+// C++20 prohibit function specialization in the std namespace.
+#ifndef JSON_HAS_CPP_20
+
+/// @brief exchanges the values of two JSON objects
+/// @sa https://json.nlohmann.me/api/basic_json/std_swap/
+NLOHMANN_BASIC_JSON_TPL_DECLARATION
+inline void swap(nlohmann::NLOHMANN_BASIC_JSON_TPL& j1, nlohmann::NLOHMANN_BASIC_JSON_TPL& j2) noexcept(  // NOLINT(readability-inconsistent-declaration-parameter-name, cert-dcl58-cpp)
+    is_nothrow_move_constructible<nlohmann::NLOHMANN_BASIC_JSON_TPL>::value&&                          // NOLINT(misc-redundant-expression,cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
+    is_nothrow_move_assignable<nlohmann::NLOHMANN_BASIC_JSON_TPL>::value)
+{
+    j1.swap(j2);
+}
+
+#endif
+
+}  // namespace std
+
+#if JSON_USE_GLOBAL_UDLS
+    #if !defined(JSON_HEDLEY_GCC_VERSION) || JSON_HEDLEY_GCC_VERSION_CHECK(4,9,0)
+        using nlohmann::literals::json_literals::operator ""_json; // NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+        using nlohmann::literals::json_literals::operator ""_json_pointer; //NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+    #else
+        using nlohmann::literals::json_literals::operator "" _json; // NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+        using nlohmann::literals::json_literals::operator "" _json_pointer; //NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+    #endif
+#endif
+
+// #include <nlohmann/detail/macro_unscope.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+// restore clang diagnostic settings
+#if defined(__clang__)
+    #pragma clang diagnostic pop
+#endif
+
+// clean up
+#undef JSON_ASSERT
+#undef JSON_INTERNAL_CATCH
+#undef JSON_THROW
+#undef JSON_PRIVATE_UNLESS_TESTED
+#undef NLOHMANN_BASIC_JSON_TPL_DECLARATION
+#undef NLOHMANN_BASIC_JSON_TPL
+#undef JSON_EXPLICIT
+#undef NLOHMANN_CAN_CALL_STD_FUNC_IMPL
+#undef JSON_INLINE_VARIABLE
+#undef JSON_NO_UNIQUE_ADDRESS
+#undef JSON_DISABLE_ENUM_SERIALIZATION
+#undef JSON_USE_GLOBAL_UDLS
+
+#ifndef JSON_TEST_KEEP_MACROS
+    #undef JSON_CATCH
+    #undef JSON_TRY
+    #undef JSON_HAS_CPP_11
+    #undef JSON_HAS_CPP_14
+    #undef JSON_HAS_CPP_17
+    #undef JSON_HAS_CPP_20
+    #undef JSON_HAS_FILESYSTEM
+    #undef JSON_HAS_EXPERIMENTAL_FILESYSTEM
+    #undef JSON_HAS_THREE_WAY_COMPARISON
+    #undef JSON_HAS_RANGES
+    #undef JSON_HAS_STATIC_RTTI
+    #undef JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON
+#endif
+
+// #include <nlohmann/thirdparty/hedley/hedley_undef.hpp>
+//     __ _____ _____ _____
+//  __|  |   __|     |   | |  JSON for Modern C++
+// |  |  |__   |  |  | | | |  version 3.11.3
+// |_____|_____|_____|_|___|  https://github.com/nlohmann/json
+//
+// SPDX-FileCopyrightText: 2013-2023 Niels Lohmann <https://nlohmann.me>
+// SPDX-License-Identifier: MIT
+
+
+
+#undef JSON_HEDLEY_ALWAYS_INLINE
+#undef JSON_HEDLEY_ARM_VERSION
+#undef JSON_HEDLEY_ARM_VERSION_CHECK
+#undef JSON_HEDLEY_ARRAY_PARAM
+#undef JSON_HEDLEY_ASSUME
+#undef JSON_HEDLEY_BEGIN_C_DECLS
+#undef JSON_HEDLEY_CLANG_HAS_ATTRIBUTE
+#undef JSON_HEDLEY_CLANG_HAS_BUILTIN
+#undef JSON_HEDLEY_CLANG_HAS_CPP_ATTRIBUTE
+#undef JSON_HEDLEY_CLANG_HAS_DECLSPEC_DECLSPEC_ATTRIBUTE
+#undef JSON_HEDLEY_CLANG_HAS_EXTENSION
+#undef JSON_HEDLEY_CLANG_HAS_FEATURE
+#undef JSON_HEDLEY_CLANG_HAS_WARNING
+#undef JSON_HEDLEY_COMPCERT_VERSION
+#undef JSON_HEDLEY_COMPCERT_VERSION_CHECK
+#undef JSON_HEDLEY_CONCAT
+#undef JSON_HEDLEY_CONCAT3
+#undef JSON_HEDLEY_CONCAT3_EX
+#undef JSON_HEDLEY_CONCAT_EX
+#undef JSON_HEDLEY_CONST
+#undef JSON_HEDLEY_CONSTEXPR
+#undef JSON_HEDLEY_CONST_CAST
+#undef JSON_HEDLEY_CPP_CAST
+#undef JSON_HEDLEY_CRAY_VERSION
+#undef JSON_HEDLEY_CRAY_VERSION_CHECK
+#undef JSON_HEDLEY_C_DECL
+#undef JSON_HEDLEY_DEPRECATED
+#undef JSON_HEDLEY_DEPRECATED_FOR
+#undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL
+#undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_
+#undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED
+#undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES
+#undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS
+#undef JSON_HEDLEY_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION
+#undef JSON_HEDLEY_DIAGNOSTIC_POP
+#undef JSON_HEDLEY_DIAGNOSTIC_PUSH
+#undef JSON_HEDLEY_DMC_VERSION
+#undef JSON_HEDLEY_DMC_VERSION_CHECK
+#undef JSON_HEDLEY_EMPTY_BASES
+#undef JSON_HEDLEY_EMSCRIPTEN_VERSION
+#undef JSON_HEDLEY_EMSCRIPTEN_VERSION_CHECK
+#undef JSON_HEDLEY_END_C_DECLS
+#undef JSON_HEDLEY_FLAGS
+#undef JSON_HEDLEY_FLAGS_CAST
+#undef JSON_HEDLEY_GCC_HAS_ATTRIBUTE
+#undef JSON_HEDLEY_GCC_HAS_BUILTIN
+#undef JSON_HEDLEY_GCC_HAS_CPP_ATTRIBUTE
+#undef JSON_HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE
+#undef JSON_HEDLEY_GCC_HAS_EXTENSION
+#undef JSON_HEDLEY_GCC_HAS_FEATURE
+#undef JSON_HEDLEY_GCC_HAS_WARNING
+#undef JSON_HEDLEY_GCC_NOT_CLANG_VERSION_CHECK
+#undef JSON_HEDLEY_GCC_VERSION
+#undef JSON_HEDLEY_GCC_VERSION_CHECK
+#undef JSON_HEDLEY_GNUC_HAS_ATTRIBUTE
+#undef JSON_HEDLEY_GNUC_HAS_BUILTIN
+#undef JSON_HEDLEY_GNUC_HAS_CPP_ATTRIBUTE
+#undef JSON_HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE
+#undef JSON_HEDLEY_GNUC_HAS_EXTENSION
+#undef JSON_HEDLEY_GNUC_HAS_FEATURE
+#undef JSON_HEDLEY_GNUC_HAS_WARNING
+#undef JSON_HEDLEY_GNUC_VERSION
+#undef JSON_HEDLEY_GNUC_VERSION_CHECK
+#undef JSON_HEDLEY_HAS_ATTRIBUTE
+#undef JSON_HEDLEY_HAS_BUILTIN
+#undef JSON_HEDLEY_HAS_CPP_ATTRIBUTE
+#undef JSON_HEDLEY_HAS_CPP_ATTRIBUTE_NS
+#undef JSON_HEDLEY_HAS_DECLSPEC_ATTRIBUTE
+#undef JSON_HEDLEY_HAS_EXTENSION
+#undef JSON_HEDLEY_HAS_FEATURE
+#undef JSON_HEDLEY_HAS_WARNING
+#undef JSON_HEDLEY_IAR_VERSION
+#undef JSON_HEDLEY_IAR_VERSION_CHECK
+#undef JSON_HEDLEY_IBM_VERSION
+#undef JSON_HEDLEY_IBM_VERSION_CHECK
+#undef JSON_HEDLEY_IMPORT
+#undef JSON_HEDLEY_INLINE
+#undef JSON_HEDLEY_INTEL_CL_VERSION
+#undef JSON_HEDLEY_INTEL_CL_VERSION_CHECK
+#undef JSON_HEDLEY_INTEL_VERSION
+#undef JSON_HEDLEY_INTEL_VERSION_CHECK
+#undef JSON_HEDLEY_IS_CONSTANT
+#undef JSON_HEDLEY_IS_CONSTEXPR_
+#undef JSON_HEDLEY_LIKELY
+#undef JSON_HEDLEY_MALLOC
+#undef JSON_HEDLEY_MCST_LCC_VERSION
+#undef JSON_HEDLEY_MCST_LCC_VERSION_CHECK
+#undef JSON_HEDLEY_MESSAGE
+#undef JSON_HEDLEY_MSVC_VERSION
+#undef JSON_HEDLEY_MSVC_VERSION_CHECK
+#undef JSON_HEDLEY_NEVER_INLINE
+#undef JSON_HEDLEY_NON_NULL
+#undef JSON_HEDLEY_NO_ESCAPE
+#undef JSON_HEDLEY_NO_RETURN
+#undef JSON_HEDLEY_NO_THROW
+#undef JSON_HEDLEY_NULL
+#undef JSON_HEDLEY_PELLES_VERSION
+#undef JSON_HEDLEY_PELLES_VERSION_CHECK
+#undef JSON_HEDLEY_PGI_VERSION
+#undef JSON_HEDLEY_PGI_VERSION_CHECK
+#undef JSON_HEDLEY_PREDICT
+#undef JSON_HEDLEY_PRINTF_FORMAT
+#undef JSON_HEDLEY_PRIVATE
+#undef JSON_HEDLEY_PUBLIC
+#undef JSON_HEDLEY_PURE
+#undef JSON_HEDLEY_REINTERPRET_CAST
+#undef JSON_HEDLEY_REQUIRE
+#undef JSON_HEDLEY_REQUIRE_CONSTEXPR
+#undef JSON_HEDLEY_REQUIRE_MSG
+#undef JSON_HEDLEY_RESTRICT
+#undef JSON_HEDLEY_RETURNS_NON_NULL
+#undef JSON_HEDLEY_SENTINEL
+#undef JSON_HEDLEY_STATIC_ASSERT
+#undef JSON_HEDLEY_STATIC_CAST
+#undef JSON_HEDLEY_STRINGIFY
+#undef JSON_HEDLEY_STRINGIFY_EX
+#undef JSON_HEDLEY_SUNPRO_VERSION
+#undef JSON_HEDLEY_SUNPRO_VERSION_CHECK
+#undef JSON_HEDLEY_TINYC_VERSION
+#undef JSON_HEDLEY_TINYC_VERSION_CHECK
+#undef JSON_HEDLEY_TI_ARMCL_VERSION
+#undef JSON_HEDLEY_TI_ARMCL_VERSION_CHECK
+#undef JSON_HEDLEY_TI_CL2000_VERSION
+#undef JSON_HEDLEY_TI_CL2000_VERSION_CHECK
+#undef JSON_HEDLEY_TI_CL430_VERSION
+#undef JSON_HEDLEY_TI_CL430_VERSION_CHECK
+#undef JSON_HEDLEY_TI_CL6X_VERSION
+#undef JSON_HEDLEY_TI_CL6X_VERSION_CHECK
+#undef JSON_HEDLEY_TI_CL7X_VERSION
+#undef JSON_HEDLEY_TI_CL7X_VERSION_CHECK
+#undef JSON_HEDLEY_TI_CLPRU_VERSION
+#undef JSON_HEDLEY_TI_CLPRU_VERSION_CHECK
+#undef JSON_HEDLEY_TI_VERSION
+#undef JSON_HEDLEY_TI_VERSION_CHECK
+#undef JSON_HEDLEY_UNAVAILABLE
+#undef JSON_HEDLEY_UNLIKELY
+#undef JSON_HEDLEY_UNPREDICTABLE
+#undef JSON_HEDLEY_UNREACHABLE
+#undef JSON_HEDLEY_UNREACHABLE_RETURN
+#undef JSON_HEDLEY_VERSION
+#undef JSON_HEDLEY_VERSION_DECODE_MAJOR
+#undef JSON_HEDLEY_VERSION_DECODE_MINOR
+#undef JSON_HEDLEY_VERSION_DECODE_REVISION
+#undef JSON_HEDLEY_VERSION_ENCODE
+#undef JSON_HEDLEY_WARNING
+#undef JSON_HEDLEY_WARN_UNUSED_RESULT
+#undef JSON_HEDLEY_WARN_UNUSED_RESULT_MSG
+#undef JSON_HEDLEY_FALL_THROUGH
+
+
+
+#endif  // INCLUDE_NLOHMANN_JSON_HPP_

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -19,10 +19,13 @@
 #include "error.hpp"
 #include "log.hpp"
 #include "subcommand.hpp"
+#include "tdo_rsa.h"
 
 #include "CLI11.hpp"
 
+#include <exception>
 #include <locale>
+#include <stdexcept>
 
 
 static
@@ -133,6 +136,11 @@ generate_unpack_argparser(CLI::App        &app_,
     ->default_val("")
     ->check(CLI::ExistingDirectory)
     ->take_last();
+  subcmd->add_option("--layout",options_.layout)
+    ->description("layout metadata output file (default: layout.json in unpacked root)")
+    ->type_name("PATH")
+    ->default_val("")
+    ->take_last();
 
   subcmd->callback(std::bind(Subcommand::unpack,std::cref(options_)));
 }
@@ -145,8 +153,106 @@ generate_pack_argparser(CLI::App      &app_,
   CLI::App *subcmd;
 
   subcmd = app_.add_subcommand("pack","pack a directory into a 3DO disc image");
+  subcmd->add_option("filepath",options_.input)
+    ->description("path to source directory")
+    ->type_name("PATH")
+    ->check(CLI::ExistingDirectory)
+    ->required();
+  subcmd->add_option("-o,--output",options_.output)
+    ->description("output ISO file")
+    ->type_name("PATH")
+    ->required()
+    ->take_last();
+  subcmd->add_option("--layout",options_.layout)
+    ->description("layout metadata input file (default: layout.json in source root when present)")
+    ->type_name("PATH")
+    ->default_val("")
+    ->take_last();
+  subcmd->add_option("--volume-label",options_.volume_label)
+    ->description("disc volume label")
+    ->type_name("TEXT")
+    ->default_val("CD-ROM")
+    ->take_last();
+  subcmd->add_option("--volume-commentary",options_.volume_commentary)
+    ->description("disc volume commentary")
+    ->type_name("TEXT")
+    ->default_val("")
+    ->take_last();
+  subcmd->add_option("--volume-unique-id",options_.volume_unique_identifier)
+    ->description("disc volume unique identifier (0 selects random)")
+    ->type_name("UINT")
+    ->each([&options_](std::string){ options_.volume_unique_identifier_set = true; })
+    ->take_last();
+  subcmd->add_option("--root-unique-id",options_.root_unique_identifier)
+    ->description("root directory unique identifier (0 selects random)")
+    ->type_name("UINT")
+    ->each([&options_](std::string){ options_.root_unique_identifier_set = true; })
+    ->take_last();
+  subcmd->add_flag("--dry-run",options_.dry_run)
+    ->description("validate and report without writing an image");
+  subcmd->add_flag("--no-banner-romtag{false},--no-rsa-appsplash{false}",
+                   options_.banner_romtag)
+     ->description("do not generate an RSA_APPSPLASH ROMTag for BannerScreen");
+  subcmd->add_flag("--billstuff-romtag",
+                   options_.billstuff_romtag)
+     ->description("generate an RSA_BILLSTUFF ROMTag");
+  subcmd->add_option("--digest-check-count",
+                     options_.signature_digest_check_count)
+    ->description("RSA_SIGNATURE_BLOCK TypeSpecific digest check count")
+    ->type_name("UINT")
+    ->check(CLI::Range(0,255))
+    ->default_val("0")
+    ->take_last();
+  subcmd->add_option("--mark",options_.mark)
+    ->description("write a 3dt marker into the output image")
+    ->type_name("BOOL")
+    ->default_val("true")
+    ->take_last();
+  subcmd->add_flag("--sign",options_.sign)
+    ->description("sign the image after packing");
 
   subcmd->callback(std::bind(Subcommand::pack,std::cref(options_)));
+}
+
+static
+void
+generate_repack_argparser(CLI::App         &app_,
+                          Options::Repack &options_)
+{
+  CLI::App *subcmd;
+
+  subcmd = app_.add_subcommand("repack","repack a 3DO disc image compacting avatars and empty space");
+  subcmd->add_option("filepaths",options_.filepaths)
+    ->description("path to disc images")
+    ->type_name("PATH")
+    ->check(CLI::ExistingFile)
+    ->required();
+  subcmd->add_option("-o,--output",options_.output)
+    ->description("output image path; requires exactly one input")
+    ->type_name("PATH")
+    ->take_last();
+  subcmd->add_flag("--no-banner-romtag{false},--no-rsa-appsplash{false}",
+                   options_.banner_romtag)
+    ->description("do not generate an RSA_APPSPLASH ROMTag for BannerScreen");
+  subcmd->add_flag("--billstuff-romtag",
+                   options_.billstuff_romtag)
+     ->description("generate an RSA_BILLSTUFF ROMTag");
+  subcmd->add_option("--digest-check-count",
+                     options_.signature_digest_check_count)
+    ->description("RSA_SIGNATURE_BLOCK TypeSpecific digest check count")
+    ->type_name("UINT")
+    ->check(CLI::Range(0,255))
+    ->default_val("0")
+    ->take_last();
+  subcmd->add_option("--mark",options_.mark)
+    ->description("write a 3dt marker into the output image")
+    ->type_name("BOOL")
+    ->default_val("true")
+    ->take_last();
+  subcmd->add_flag("--sign",options_.sign)
+    ->description("sign the image after repacking");
+
+  subcmd->callback(std::bind(Subcommand::repack,std::cref(options_)));
 }
 
 static
@@ -214,6 +320,145 @@ generate_romtags_argparser(CLI::App         &app_,
 
 static
 void
+generate_verify_argparser(CLI::App        &app_,
+                          Options::Verify &opts_)
+{
+  CLI::App *subcmd;
+
+  subcmd = app_.add_subcommand("verify","verify RSA sigs");
+  subcmd->add_option("filepaths",opts_.filepaths)
+    ->description("path to disc images")
+    ->type_name("PATH")
+    ->check(CLI::ExistingFile)
+    ->required();
+  subcmd->add_option("-f,--format",opts_.format)
+    ->description("output format")
+    ->type_name("TEXT")
+    ->default_val("human")
+    ->take_last()
+    ->check(CLI::IsMember({"human","csv","json"}));
+  subcmd->add_flag("--no-digest-table{false}",opts_.digest_table)
+    ->description("skip signature digest table comparison");
+  subcmd->add_flag("--quiet",opts_.quiet)
+    ->description("print only per-image verification status");
+
+  subcmd->callback(std::bind(Subcommand::verify,
+                             std::cref(opts_)));
+}
+
+static
+void
+generate_sign_argparser(CLI::App      &app_,
+                        Options::Sign &opts_)
+{
+  CLI::App *subcmd;
+
+  subcmd = app_.add_subcommand("sign","sign 3DO ISO for retail system use");
+  subcmd->add_option("filepaths",opts_.filepaths)
+    ->description("path to disc images")
+    ->type_name("PATH")
+    ->check(CLI::ExistingFile)
+    ->required();
+  subcmd->add_option("-o,--output",opts_.output)
+    ->description("output image path; requires exactly one input")
+    ->type_name("PATH")
+    ->take_last();
+  subcmd->add_flag("--no-banner-romtag{false},--no-rsa-appsplash{false}",
+                   opts_.banner_romtag)
+    ->description("do not generate an RSA_APPSPLASH ROMTag for BannerScreen");
+  subcmd->add_flag("--billstuff-romtag",
+                   opts_.billstuff_romtag)
+     ->description("generate an RSA_BILLSTUFF ROMTag");
+  subcmd->add_flag("--force",opts_.force)
+    ->description("skip signing preflight checks for unusual images");
+  subcmd->add_option("--digest-check-count",
+                     opts_.signature_digest_check_count)
+    ->description("RSA_SIGNATURE_BLOCK TypeSpecific digest check count")
+    ->type_name("UINT")
+    ->check(CLI::Range(0,255))
+    ->default_val("0")
+    ->take_last();
+  subcmd->add_option("--mark",opts_.mark)
+    ->description("write a 3dt marker into the signed image")
+    ->type_name("BOOL")
+    ->default_val("true")
+    ->take_last();
+
+  subcmd->callback(std::bind(Subcommand::sign,
+                             std::cref(opts_)));
+}
+
+static
+void
+generate_signfile_argparser(CLI::App          &app_,
+                            Options::SignFile &opts_)
+{
+  CLI::App *subcmd;
+
+  subcmd = app_.add_subcommand("sign-file","sign file with 3DO or APP key");
+  subcmd->add_option("filepaths",opts_.filepaths)
+    ->description("path to file to sign")
+    ->type_name("PATH")
+    ->check(CLI::ExistingFile)
+    ->required();
+  subcmd->add_flag("--append",opts_.append)
+    ->description("append a new signature instead of replacing the existing trailer");
+  subcmd->add_flag("--replace",opts_.replace)
+    ->description("replace the existing signature trailer");
+  subcmd->add_flag("--verify",opts_.verify)
+    ->description("verify the existing signature trailer");
+  subcmd->add_flag("--write",opts_.write)
+    ->description("write the computed signature to the file");
+  subcmd->add_option("--signature-output",opts_.signature_output)
+    ->description("write computed signature bytes to a separate file; requires one input")
+    ->type_name("PATH")
+    ->take_last();
+  subcmd->add_option("--key-name",opts_.key_name)
+    ->default_val(TDO_KEY_APP)
+    ->check(CLI::IsMember({TDO_KEY_APP,TDO_KEY_3DO}));
+
+  subcmd->callback(std::bind(Subcommand::sign_file,
+                             std::cref(opts_)));
+}
+
+static
+void
+generate_decryptfile_argparser(CLI::App             &app_,
+                               Options::DecryptFile &opts_)
+{
+  CLI::App *subcmd;
+
+  subcmd = app_.add_subcommand("decrypt-file","decrypt CD-DIPIR boot payload (`src/dipir/cdipir.c`)");
+  subcmd->add_option("filepaths",opts_.filepaths)
+    ->description("path to file to decrypt")
+    ->type_name("PATH")
+    ->check(CLI::ExistingFile)
+    ->required();
+
+  subcmd->callback(std::bind(Subcommand::decrypt_file,
+                             std::cref(opts_)));
+}
+
+static
+void
+generate_encryptfile_argparser(CLI::App             &app_,
+                               Options::EncryptFile &opts_)
+{
+  CLI::App *subcmd;
+
+  subcmd = app_.add_subcommand("encrypt-file","encrypt CD-DIPIR boot payload (`src/dipir/cdipir.c`)");
+  subcmd->add_option("filepaths",opts_.filepaths)
+    ->description("path to file to encrypt")
+    ->type_name("PATH")
+    ->check(CLI::ExistingFile)
+    ->required();
+
+  subcmd->callback(std::bind(Subcommand::encrypt_file,
+                             std::cref(opts_)));
+}
+
+static
+void
 generate_argparser(CLI::App &app_,
                    Options  &options_)
 {
@@ -225,10 +470,16 @@ generate_argparser(CLI::App &app_,
   generate_info_argparser(app_,options_.info);
   generate_identify_argparser(app_,options_.identify);
   generate_unpack_argparser(app_,options_.unpack);
-  //  generate_pack_argparser(app_,options_.pack);
+  generate_pack_argparser(app_,options_.pack);
+  generate_repack_argparser(app_,options_.repack);
   generate_rename_argparser(app_,options_.rename);
   generate_to_iso_argparser(app_,options_.to_iso);
   generate_romtags_argparser(app_,options_.romtags);
+  generate_verify_argparser(app_,options_.verify);
+  generate_sign_argparser(app_,options_.sign);
+  generate_signfile_argparser(app_,options_.signfile);
+  generate_decryptfile_argparser(app_,options_.decryptfile);
+  generate_encryptfile_argparser(app_,options_.encryptfile);
 }
 
 static
@@ -264,9 +515,9 @@ main(int    argc_,
     {
       return app.exit(e);
     }
-  catch(const Error &err)
+  catch(const std::exception &e)
     {
-      Log::error(err);
+      Log::error({e.what()});
       return 1;
     }
 

--- a/src/md5.c
+++ b/src/md5.c
@@ -1,0 +1,295 @@
+/*
+ * A simple MD5 implementation based on RFC 1321[0] and Alexander Peslyak's
+ * version[1]. More typedefs for easier readability and portability
+ * and style changes.
+ *
+ * [0] https://tools.ietf.org/html/rfc1321
+ * [1] http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
+ */
+
+#include "md5.h"
+
+#include <string.h>
+
+/*
+ * The basic MD5 functions.
+ *
+ * F and G are optimized compared to their RFC 1321 definitions for
+ * architectures that lack an AND-NOT instruction, just like in Colin Plumb's
+ * implementation.
+ */
+#define F(x,y,z)  ((z) ^ ((x) & ((y) ^ (z))))
+#define G(x,y,z)  ((y) ^ ((z) & ((x) ^ (y))))
+#define H(x,y,z)  (((x) ^ (y)) ^ (z))
+#define H2(x,y,z) ((x) ^ ((y) ^ (z)))
+#define I(x,y,z)  ((y) ^ ((x) | ~(z)))
+
+#define ROTATE_LEFT(X,N) (((X) << (N)) | (((X) & 0xFFFFFFFF) >> (32 - (N))))
+
+/*
+ * The MD5 transformation for all four rounds.
+ */
+#define STEP(f,a,b,c,d,x,t,s)                   \
+  (a) += f((b),(c),(d)) + (x) + (t);            \
+  (a)  = ROTATE_LEFT(a,s);                      \
+  (a) += (b);
+
+/*
+ * SET reads 4 input bytes in little-endian byte order and stores them in a
+ * properly aligned word in host byte order.
+ *
+ * The check for little-endian architectures that tolerate unaligned memory
+ * accesses is just an optimization.  Nothing will break if it fails to detect
+ * a suitable architecture.
+ *
+ * Unfortunately, this optimization may be a C strict aliasing rules violation
+ * if the caller's data buffer has effective type that cannot be aliased by
+ * MD5_u32plus.  In practice, this problem may occur if these MD5 routines are
+ * inlined into a calling function, or with future and dangerously advanced
+ * link-time optimizations.  For the time being, keeping these MD5 routines in
+ * their own translation unit avoids the problem.
+ */
+#if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
+#define SET(n)                                  \
+  (*(md5_u32_t*)&ptr[(n) * 4])
+#define GET(n)                                  \
+  SET(n)
+#else
+#define SET(n)                                  \
+  (ctx->block[(n)] =                            \
+    (((md5_u32_t)ptr[(n) * 4 + 0] << 0x00) |    \
+     ((md5_u32_t)ptr[(n) * 4 + 1] << 0x08) |    \
+     ((md5_u32_t)ptr[(n) * 4 + 2] << 0x10) |    \
+     ((md5_u32_t)ptr[(n) * 4 + 3] << 0x18))
+#define GET(n)                                  \
+  (ctx->block[(n)])
+#endif
+
+/*
+ * This processes one or more 64-byte data blocks, but does NOT update the bit
+ * counters.  There are no alignment requirements.
+ */
+static
+const
+void*
+body(md5_ctx_t  *ctx_,
+     const void *data_,
+     md5_size_t  size_)
+{
+  const md5_u8_t *ptr;
+  md5_u32_t a,b,c,d;
+  md5_u32_t saved_a,saved_b,saved_c,saved_d;
+
+  ptr = (const md5_u8_t*)data_;
+
+  a = ctx_->a;
+  b = ctx_->b;
+  c = ctx_->c;
+  d = ctx_->d;
+
+  do
+    {
+      saved_a = a;
+      saved_b = b;
+      saved_c = c;
+      saved_d = d;
+
+      /* Round 1 */
+      STEP(F,a,b,c,d,SET(0), 0xd76aa478, 7);
+      STEP(F,d,a,b,c,SET(1), 0xe8c7b756,12);
+      STEP(F,c,d,a,b,SET(2), 0x242070db,17);
+      STEP(F,b,c,d,a,SET(3), 0xc1bdceee,22);
+      STEP(F,a,b,c,d,SET(4), 0xf57c0faf, 7);
+      STEP(F,d,a,b,c,SET(5), 0x4787c62a,12);
+      STEP(F,c,d,a,b,SET(6), 0xa8304613,17);
+      STEP(F,b,c,d,a,SET(7), 0xfd469501,22);
+      STEP(F,a,b,c,d,SET(8), 0x698098d8, 7);
+      STEP(F,d,a,b,c,SET(9), 0x8b44f7af,12);
+      STEP(F,c,d,a,b,SET(10),0xffff5bb1,17);
+      STEP(F,b,c,d,a,SET(11),0x895cd7be,22);
+      STEP(F,a,b,c,d,SET(12),0x6b901122, 7);
+      STEP(F,d,a,b,c,SET(13),0xfd987193,12);
+      STEP(F,c,d,a,b,SET(14),0xa679438e,17);
+      STEP(F,b,c,d,a,SET(15),0x49b40821,22);
+
+      /* Round 2 */
+      STEP(G,a,b,c,d,GET(1), 0xf61e2562, 5);
+      STEP(G,d,a,b,c,GET(6), 0xc040b340, 9);
+      STEP(G,c,d,a,b,GET(11),0x265e5a51,14);
+      STEP(G,b,c,d,a,GET(0), 0xe9b6c7aa,20);
+      STEP(G,a,b,c,d,GET(5), 0xd62f105d, 5);
+      STEP(G,d,a,b,c,GET(10),0x02441453, 9);
+      STEP(G,c,d,a,b,GET(15),0xd8a1e681,14);
+      STEP(G,b,c,d,a,GET(4), 0xe7d3fbc8,20);
+      STEP(G,a,b,c,d,GET(9), 0x21e1cde6, 5);
+      STEP(G,d,a,b,c,GET(14),0xc33707d6, 9);
+      STEP(G,c,d,a,b,GET(3), 0xf4d50d87,14);
+      STEP(G,b,c,d,a,GET(8), 0x455a14ed,20);
+      STEP(G,a,b,c,d,GET(13),0xa9e3e905, 5);
+      STEP(G,d,a,b,c,GET(2), 0xfcefa3f8, 9);
+      STEP(G,c,d,a,b,GET(7), 0x676f02d9,14);
+      STEP(G,b,c,d,a,GET(12),0x8d2a4c8a,20);
+
+      /* Round 3 */
+      STEP(H, a,b,c,d,GET(5), 0xfffa3942, 4);
+      STEP(H2,d,a,b,c,GET(8), 0x8771f681,11);
+      STEP(H, c,d,a,b,GET(11),0x6d9d6122,16);
+      STEP(H2,b,c,d,a,GET(14),0xfde5380c,23);
+      STEP(H, a,b,c,d,GET(1), 0xa4beea44, 4);
+      STEP(H2,d,a,b,c,GET(4), 0x4bdecfa9,11);
+      STEP(H, c,d,a,b,GET(7), 0xf6bb4b60,16);
+      STEP(H2,b,c,d,a,GET(10),0xbebfbc70,23);
+      STEP(H, a,b,c,d,GET(13),0x289b7ec6, 4);
+      STEP(H2,d,a,b,c,GET(0), 0xeaa127fa,11);
+      STEP(H, c,d,a,b,GET(3), 0xd4ef3085,16);
+      STEP(H2,b,c,d,a,GET(6), 0x04881d05,23);
+      STEP(H, a,b,c,d,GET(9), 0xd9d4d039, 4);
+      STEP(H2,d,a,b,c,GET(12),0xe6db99e5,11);
+      STEP(H, c,d,a,b,GET(15),0x1fa27cf8,16);
+      STEP(H2,b,c,d,a,GET(2), 0xc4ac5665,23);
+
+      /* Round 4 */
+      STEP(I,a,b,c,d,GET(0), 0xf4292244, 6);
+      STEP(I,d,a,b,c,GET(7), 0x432aff97,10);
+      STEP(I,c,d,a,b,GET(14),0xab9423a7,15);
+      STEP(I,b,c,d,a,GET(5), 0xfc93a039,21);
+      STEP(I,a,b,c,d,GET(12),0x655b59c3, 6);
+      STEP(I,d,a,b,c,GET(3), 0x8f0ccc92,10);
+      STEP(I,c,d,a,b,GET(10),0xffeff47d,15);
+      STEP(I,b,c,d,a,GET(1), 0x85845dd1,21);
+      STEP(I,a,b,c,d,GET(8), 0x6fa87e4f, 6);
+      STEP(I,d,a,b,c,GET(15),0xfe2ce6e0,10);
+      STEP(I,c,d,a,b,GET(6), 0xa3014314,15);
+      STEP(I,b,c,d,a,GET(13),0x4e0811a1,21);
+      STEP(I,a,b,c,d,GET(4), 0xf7537e82, 6);
+      STEP(I,d,a,b,c,GET(11),0xbd3af235,10);
+      STEP(I,c,d,a,b,GET(2), 0x2ad7d2bb,15);
+      STEP(I,b,c,d,a,GET(9), 0xeb86d391,21);
+
+      a += saved_a;
+      b += saved_b;
+      c += saved_c;
+      d += saved_d;
+
+      ptr += 64;
+    } while (size_ -= 64);
+
+  ctx_->a = a;
+  ctx_->b = b;
+  ctx_->c = c;
+  ctx_->d = d;
+
+  return ptr;
+}
+
+void
+md5_init(md5_ctx_t *ctx_)
+{
+  ctx_->a = 0x67452301;
+  ctx_->b = 0xefcdab89;
+  ctx_->c = 0x98badcfe;
+  ctx_->d = 0x10325476;
+
+  ctx_->low  = 0;
+  ctx_->high = 0;
+}
+
+void
+md5_update(md5_ctx_t  *ctx_,
+           const void *data_,
+           md5_size_t  size_)
+{
+  md5_u32_t saved_low;
+  unsigned long used,available;
+
+  saved_low = ctx_->low;
+  if((ctx_->low = (saved_low + size_) & 0x1fffffff) < saved_low)
+    ctx_->high++;
+  ctx_->high += size_ >> 29;
+
+  used = saved_low & 0x3f;
+
+  if(used)
+    {
+      available = 64 - used;
+
+      if(size_ < available)
+        {
+          memcpy(&ctx_->buffer[used],data_,size_);
+          return;
+        }
+
+      memcpy(&ctx_->buffer[used],data_,available);
+      data_ = (const md5_u8_t*)data_ + available;
+      size_ -= available;
+      body(ctx_,ctx_->buffer,64);
+    }
+
+  if(size_ >= 64)
+    {
+      data_ = body(ctx_,data_,(size_ & ~(md5_size_t)0x3f));
+      size_ &= 0x3f;
+    }
+
+  memcpy(ctx_->buffer,data_,size_);
+}
+
+static
+void
+copy_bytes_from_u32(md5_u8_t *dst_,
+                    md5_u32_t src_)
+{
+  dst_[0] = ((md5_u8_t)(src_ >> 0x00));
+  dst_[1] = ((md5_u8_t)(src_ >> 0x08));
+  dst_[2] = ((md5_u8_t)(src_ >> 0x10));
+  dst_[3] = ((md5_u8_t)(src_ >> 0x18));
+}
+
+void
+md5_finalize(md5_ctx_t    *ctx_,
+             md5_digest_t  digest_)
+{
+  unsigned long used;
+  unsigned long available;
+
+  used = (ctx_->low & 0x3f);
+
+  ctx_->buffer[used++] = 0x80;
+
+  available = 64 - used;
+
+  if(available < 8)
+    {
+      memset(&ctx_->buffer[used],0,available);
+      body(ctx_,ctx_->buffer,64);
+      used = 0;
+      available = 64;
+    }
+
+  memset(&ctx_->buffer[used],0,available - 8);
+
+  ctx_->low <<= 3;
+  copy_bytes_from_u32(&ctx_->buffer[56],ctx_->low);
+  copy_bytes_from_u32(&ctx_->buffer[60],ctx_->high);
+
+  body(ctx_,ctx_->buffer,64);
+
+  copy_bytes_from_u32(&digest_[0x0],ctx_->a);
+  copy_bytes_from_u32(&digest_[0x4],ctx_->b);
+  copy_bytes_from_u32(&digest_[0x8],ctx_->c);
+  copy_bytes_from_u32(&digest_[0xC],ctx_->d);
+
+  memset(ctx_,0,sizeof(*ctx_));
+}
+
+void
+md5_calc(const void   *data_,
+         md5_size_t    size_,
+         md5_digest_t  digest_)
+{
+  md5_ctx_t ctx;
+
+  md5_init(&ctx);
+  md5_update(&ctx,data_,size_);
+  md5_finalize(&ctx,digest_);
+}

--- a/src/md5.h
+++ b/src/md5.h
@@ -1,0 +1,61 @@
+/*
+ * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.
+ * MD5 Message-Digest Algorithm (RFC 1321).
+ *
+ * Homepage:
+ * http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
+ *
+ * Author:
+ * Alexander Peslyak, better known as Solar Designer <solar at openwall.com>
+ *
+ * This software was written by Alexander Peslyak in 2001.  No copyright is
+ * claimed, and the software is hereby placed in the public domain.
+ * In case this attempt to disclaim copyright and place the software in the
+ * public domain is deemed null and void, then the software is
+ * Copyright (c) 2001 Alexander Peslyak and it is hereby released to the
+ * general public under the following terms:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted.
+ *
+ * There's ABSOLUTELY NO WARRANTY, express or implied.
+ *
+ * See md5.c for more information.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+typedef uint8_t  md5_u8_t;
+typedef uint32_t md5_u32_t;
+typedef size_t   md5_size_t;
+typedef uint8_t  md5_digest_t[16];
+
+typedef struct md5_ctx_s md5_ctx_t;
+struct md5_ctx_s
+{
+  md5_u32_t low;
+  md5_u32_t high;
+  md5_u32_t a;
+  md5_u32_t b;
+  md5_u32_t c;
+  md5_u32_t d;
+  md5_u32_t block[16];
+  md5_u8_t  buffer[64];
+};
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+extern void md5_init(md5_ctx_t *ctx);
+extern void md5_update(md5_ctx_t *ctx, const void *data, md5_size_t size);
+extern void md5_finalize(md5_ctx_t *ctx, md5_digest_t digest);
+extern void md5_calc(const void *data, md5_size_t size, md5_digest_t digest);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/nonstd/string.hpp
+++ b/src/nonstd/string.hpp
@@ -1,0 +1,2311 @@
+//
+// Copyright (c) 2021-2021 Martin Moene
+//
+// https://github.com/martinmoene/string-lite
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef NONSTD_STRING_LITE_HPP
+#define NONSTD_STRING_LITE_HPP
+
+#define string_lite_MAJOR  0
+#define string_lite_MINOR  0
+#define string_lite_PATCH  0
+
+#define string_lite_VERSION  string_STRINGIFY(string_lite_MAJOR) "." string_STRINGIFY(string_lite_MINOR) "." string_STRINGIFY(string_lite_PATCH)
+
+#define string_STRINGIFY(  x )  string_STRINGIFY_( x )
+#define string_STRINGIFY_( x )  #x
+
+// tweak header support:
+
+#ifdef __has_include
+# if __has_include(<nonstd/string.tweak.hpp>)
+#  include <nonstd/string.tweak.hpp>
+# endif
+#define string_HAVE_TWEAK_HEADER  1
+#else
+#define string_HAVE_TWEAK_HEADER  0
+//# pragma message("string.hpp: Note: Tweak header not supported.")
+#endif
+
+#ifdef __has_include
+# if __has_include( <string_view> )
+#  define string_HAVE_STD_STRING_VIEW  1
+# else
+#  define string_HAVE_STD_STRING_VIEW  0
+# endif
+#else
+# define  string_HAVE_STD_STRING_VIEW  0
+#endif
+
+// Control presence of exception handling (try and auto discover):
+
+#ifndef string_CONFIG_NO_EXCEPTIONS
+# if defined(_MSC_VER)
+# include <cstddef>     // for _HAS_EXCEPTIONS
+# endif
+# if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || (_HAS_EXCEPTIONS)
+#  define string_CONFIG_NO_EXCEPTIONS  0
+# else
+#  define string_CONFIG_NO_EXCEPTIONS  1
+# endif
+#endif
+
+// TODO Switch between various versions of string_view:
+// - minimal version: nonstd::string::string_view
+// - lite version: nonstd::string_view
+// - std version: std::string_view
+
+#define  string_CONFIG_SELECT_STRING_VIEW_INTERNAL  1
+#define  string_CONFIG_SELECT_STRING_VIEW_NONSTD    2
+#define  string_CONFIG_SELECT_STRING_VIEW_STD       3
+
+#ifndef  string_CONFIG_SELECT_STRING_VIEW
+# define string_CONFIG_SELECT_STRING_VIEW string_CONFIG_SELECT_STRING_VIEW_INTERNAL
+#endif
+
+#if      string_CONFIG_SELECT_STRING_VIEW==string_CONFIG_SELECT_STRING_VIEW_STD && !string_HAVE_STD_STRING_VIEW
+# error  string-lite: std::string_view selected but is not available: C++17?
+#elif   0 // string_CONFIG_SELECT_STRING_VIEW==string_CONFIG_SELECT_STRING_VIEW_NONSTD && !defined(NONSTD_SV_LITE_H_INCLUDED)
+# error  string-lite: string-view-lite selected but is not available: nonstd/string_view.hpp included before nonstd/string.hpp?
+#endif
+
+// C++ language version detection (C++23 is speculative):
+// Note: VC14.0/1900 (VS2015) lacks too much from C++14.
+
+#ifndef   string_CPLUSPLUS
+# if defined(_MSVC_LANG ) && !defined(__clang__)
+#  define string_CPLUSPLUS  (_MSC_VER == 1900 ? 201103L : _MSVC_LANG )
+# else
+#  define string_CPLUSPLUS  __cplusplus
+# endif
+#endif
+
+#define string_CPP98_OR_GREATER  ( string_CPLUSPLUS >= 199711L )
+#define string_CPP11_OR_GREATER  ( string_CPLUSPLUS >= 201103L )
+#define string_CPP14_OR_GREATER  ( string_CPLUSPLUS >= 201402L )
+#define string_CPP17_OR_GREATER  ( string_CPLUSPLUS >= 201703L )
+#define string_CPP20_OR_GREATER  ( string_CPLUSPLUS >= 202002L )
+#define string_CPP23_OR_GREATER  ( string_CPLUSPLUS >= 202300L )
+
+// MSVC version:
+
+#if defined(_MSC_VER ) && !defined(__clang__)
+# define string_COMPILER_MSVC_VER           (_MSC_VER )
+# define string_COMPILER_MSVC_VERSION       (_MSC_VER / 10 - 10 * ( 5 + (_MSC_VER < 1900 ) ) )
+# define string_COMPILER_MSVC_VERSION_FULL  (_MSC_VER - 100 * ( 5 + (_MSC_VER < 1900 ) ) )
+#else
+# define string_COMPILER_MSVC_VER           0
+# define string_COMPILER_MSVC_VERSION       0
+# define string_COMPILER_MSVC_VERSION_FULL  0
+#endif
+
+// clang version:
+
+#define string_COMPILER_VERSION( major, minor, patch ) ( 10 * ( 10 * (major) + (minor) ) + (patch) )
+
+#if defined( __apple_build_version__ )
+# define string_COMPILER_APPLECLANG_VERSION string_COMPILER_VERSION( __clang_major__, __clang_minor__, __clang_patchlevel__ )
+# define string_COMPILER_CLANG_VERSION 0
+#elif defined( __clang__ )
+# define string_COMPILER_APPLECLANG_VERSION 0
+# define string_COMPILER_CLANG_VERSION string_COMPILER_VERSION( __clang_major__, __clang_minor__, __clang_patchlevel__ )
+#else
+# define string_COMPILER_APPLECLANG_VERSION 0
+# define string_COMPILER_CLANG_VERSION 0
+#endif
+
+// GNUC version:
+
+#if defined(__GNUC__) && !defined(__clang__)
+# define string_COMPILER_GNUC_VERSION string_COMPILER_VERSION( __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__ )
+#else
+# define string_COMPILER_GNUC_VERSION 0
+#endif
+
+// half-open range [lo..hi):
+#define string_BETWEEN( v, lo, hi ) ( (lo) <= (v) && (v) < (hi) )
+
+// Presence of language and library features:
+
+#define string_CPP11_100  (string_CPP11_OR_GREATER || string_COMPILER_MSVC_VER >= 1600)
+#define string_CPP11_110  (string_CPP11_OR_GREATER || string_COMPILER_MSVC_VER >= 1700)
+#define string_CPP11_120  (string_CPP11_OR_GREATER || string_COMPILER_MSVC_VER >= 1800)
+#define string_CPP11_140  (string_CPP11_OR_GREATER || string_COMPILER_MSVC_VER >= 1900)
+#define string_CPP11_141  (string_CPP11_OR_GREATER || string_COMPILER_MSVC_VER >= 1910)
+
+#define string_CPP11_000  (string_CPP11_OR_GREATER)
+
+#define string_CPP14_000  (string_CPP14_OR_GREATER)
+#define string_CPP14_120  (string_CPP14_OR_GREATER || string_COMPILER_MSVC_VER >= 1800)
+
+#define string_CPP17_000  (string_CPP17_OR_GREATER)
+#define string_CPP17_120  (string_CPP17_OR_GREATER || string_COMPILER_MSVC_VER >= 1800)
+#define string_CPP17_140  (string_CPP17_OR_GREATER || string_COMPILER_MSVC_VER >= 1900)
+
+#define string_CPP20_000  (string_CPP20_OR_GREATER)
+
+// Presence of C++11 language features:
+
+#define string_HAVE_FREE_BEGIN              string_CPP14_120
+#define string_HAVE_CONSTEXPR_11           (string_CPP11_000 && !string_BETWEEN(string_COMPILER_MSVC_VER, 1, 1910))
+#define string_HAVE_NOEXCEPT                string_CPP11_140
+#define string_HAVE_NULLPTR                 string_CPP11_100
+#define string_HAVE_DEFAULT_FN_TPL_ARGS     string_CPP11_120
+#define string_HAVE_EXPLICIT_CONVERSION     string_CPP11_120
+#define string_HAVE_CHAR16_T                string_CPP11_000
+#define string_HAVE_CHAR32_T                string_HAVE_CHAR16_T
+
+// Presence of C++14 language features:
+
+#define string_HAVE_CONSTEXPR_14            string_CPP14_000
+#define string_HAVE_FREE_BEGIN              string_CPP14_120
+
+// Presence of C++17 language features:
+
+#define string_HAVE_FREE_SIZE               string_CPP17_140
+#define string_HAVE_NODISCARD               string_CPP17_000
+
+// Presence of C++20 language features:
+
+#define string_HAVE_CHAR8_T                 string_CPP20_000
+
+// Presence of C++ library features:
+
+#define string_HAVE_REGEX                  (string_CPP11_000 && !string_BETWEEN(string_COMPILER_GNUC_VERSION, 1, 490))
+#define string_HAVE_TYPE_TRAITS             string_CPP11_110
+
+// Usage of C++ language features:
+
+#if string_HAVE_CONSTEXPR_11
+# define string_constexpr constexpr
+#else
+# define string_constexpr /*constexpr*/
+#endif
+
+#if string_HAVE_CONSTEXPR_14
+# define string_constexpr14  constexpr
+#else
+# define string_constexpr14  /*constexpr*/
+#endif
+
+#if string_HAVE_EXPLICIT_CONVERSION
+# define string_explicit  explicit
+#else
+# define string_explicit  /*explicit*/
+#endif
+
+#if string_HAVE_NOEXCEPT && !string_CONFIG_NO_EXCEPTIONS
+# define string_noexcept noexcept
+#else
+# define string_noexcept /*noexcept*/
+#endif
+
+#if string_HAVE_NODISCARD
+# define string_nodiscard [[nodiscard]]
+#else
+# define string_nodiscard /*[[nodiscard]]*/
+#endif
+
+#if string_HAVE_NULLPTR
+# define string_nullptr nullptr
+#else
+# define string_nullptr NULL
+#endif
+
+#if string_HAVE_EXPLICIT_CONVERSION
+# define string_explicit_cv explicit
+#else
+# define string_explicit_cv /*explicit*/
+#endif
+
+#define string_HAS_ENABLE_IF_          (string_HAVE_TYPE_TRAITS && string_HAVE_DEFAULT_FN_TPL_ARGS)
+#define string_TEST_STRING_CONTAINS    (string_HAS_ENABLE_IF_ && !string_BETWEEN(string_COMPILER_MSVC_VER, 1, 1910))
+#define string_TEST_STRING_STARTS_WITH  string_TEST_STRING_CONTAINS
+#define string_TEST_STRING_ENDS_WITH    string_TEST_STRING_CONTAINS
+
+// Method enabling (return type):
+
+#if string_HAVE_TYPE_TRAITS
+# define string_ENABLE_IF_R_(VA, R)  typename std::enable_if< (VA), R >::type
+#else
+# define string_ENABLE_IF_R_(VA, R)  R
+#endif
+
+// Method enabling (function template argument):
+
+#if string_HAS_ENABLE_IF_
+
+// VS 2013 seems to have trouble with SFINAE for default non-type arguments:
+# if !string_BETWEEN( string_COMPILER_MSVC_VER, 1, 1900 )
+#  define string_ENABLE_IF_(VA) , typename std::enable_if< (VA), int >::type = 0
+# else
+#  define string_ENABLE_IF_(VA) , typename = typename std::enable_if< (VA), ::nonstd::string::detail::enabler >::type
+# endif
+
+# define string_ENABLE_IF_HAS_METHOD_(  type, method)  string_ENABLE_IF_(  string_HAS_METHOD_( type, method) )
+# define string_DISABLE_IF_HAS_METHOD_( type, method)  string_ENABLE_IF_( !string_HAS_METHOD_( type, method) )
+
+#else
+# define  string_ENABLE_IF_(VA)
+# define  string_ENABLE_IF_HAS_METHOD_( type, member)
+# define  string_DISABLE_IF_HAS_METHOD_(type, member)
+#endif
+
+// Additional includes:
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <iterator>
+#include <locale>
+#include <string>
+#include <vector>
+
+#if string_HAVE_REGEX
+# include <regex>
+#endif
+
+#if ! string_CONFIG_NO_EXCEPTIONS
+# include <stdexcept>
+#endif
+
+#if string_HAVE_TYPE_TRAITS
+# include <type_traits>
+#elif string_HAVE_TR1_TYPE_TRAITS
+# include <tr1/type_traits>
+#endif
+
+#if    string_CONFIG_SELECT_STRING_VIEW == string_CONFIG_SELECT_STRING_VIEW_INTERNAL
+// noop
+#elif  string_CONFIG_SELECT_STRING_VIEW == string_CONFIG_SELECT_STRING_VIEW_NONSTD
+# define nssv_CONFIG_SELECT_STRING_VIEW    nssv_STRING_VIEW_NONSTD
+# include "nonstd/string_view.hpp"
+#elif  string_CONFIG_SELECT_STRING_VIEW == string_CONFIG_SELECT_STRING_VIEW_STD
+# include <string_view>
+#endif
+
+// Method detection:
+
+#define string_HAS_METHOD_( T, M )  \
+    ::nonstd::string::has_##M<T>::value
+
+#if string_CPP11_OR_GREATER && !string_BETWEEN(string_COMPILER_GNUC_VERSION, 1, 500)
+
+# define string_MAKE_HAS_METHOD_( M )                   \
+    template< typename T >                              \
+    using M##_t = decltype(std::declval<T>().M());      \
+                                                        \
+    template<typename T >                               \
+    using has_##M = std23::is_detected<M##_t, T>;
+
+#else // string_CPP11_OR_GREATER
+
+# define string_MAKE_HAS_METHOD_( M )                   \
+    template< typename T >                              \
+    struct has_##M                                      \
+    {                                                   \
+        typedef char yes[1];                            \
+        typedef char no[2];                             \
+                                                        \
+        template< typename U >                          \
+        static yes & test( int (*)[sizeof(std98::declval<U>().M(), 1)] );    \
+                                                        \
+        template< typename U >                          \
+        static no & test(...);                          \
+                                                        \
+        static const bool value = sizeof( test<T>(NULL) ) == sizeof(yes); \
+    };
+
+#endif
+
+// Type traits:
+namespace nonstd {
+namespace string {
+
+namespace std98 {
+
+template< typename T, T v > struct integral_constant { enum { value = v }; };
+typedef integral_constant< bool, true  > true_type;
+typedef integral_constant< bool, false > false_type;
+
+template< typename T, typename U >
+struct is_same { enum dummy { value = false }; };
+
+template< typename T >
+struct is_same<T, T> { enum dummy { value = true }; };
+
+template< typename T >
+T declval();
+
+} // namespace std98
+
+#if string_CPP11_OR_GREATER
+
+namespace std11 {
+
+template< bool B, typename T, typename F >
+struct conditional { typedef T type; };
+
+template< typename T, typename F >
+struct conditional<false, T, F> { typedef F type; };
+
+template< typename T > struct remove_const          { typedef T type; };
+template< typename T > struct remove_const<const T> { typedef T type; };
+
+template< typename T > struct remove_volatile             { typedef T type; };
+template< typename T > struct remove_volatile<volatile T> { typedef T type; };
+
+template< typename T > struct remove_cv { typedef typename remove_volatile<typename remove_const<T>::type>::type type; };
+
+// template< typename T > struct is_const          : std98::false_type {};
+// template< typename T > struct is_const<const T> : std98::true_type {};
+
+template< typename T > struct is_pointer_helper     : std98::false_type {};
+template< typename T > struct is_pointer_helper<T*> : std98::true_type {};
+template< typename T > struct is_pointer : is_pointer_helper<typename remove_cv<T>::type> {};
+
+} // C++11
+
+namespace std14 {
+
+template< bool B, typename T, typename F >
+using conditional_t = typename std11::conditional<B,T,F>::type;
+
+} // namespace c++14
+
+namespace std17 {
+
+template< typename... >
+using void_t = void;
+
+} // namespace c++17
+
+namespace std20 {
+
+// type identity, to establish non-deduced contexts in template argument deduction:
+
+template< typename T >
+struct type_identity
+{
+    typedef T type;
+};
+
+#if string_CPP11_100
+
+struct identity
+{
+    template< typename T >
+    string_constexpr T && operator ()( T && arg ) const string_noexcept
+    {
+        return std::forward<T>( arg );
+    }
+};
+
+#endif // string_CPP11_100
+
+} // namespace c++20
+
+namespace std23 {
+namespace detail {
+
+template< typename Default, typename AlwaysVoid, template<class...> class Op, typename... Args >
+struct detector
+{
+    using value_t = std::false_type;
+    using type = Default;
+};
+
+template< typename Default, template<class...> class Op, typename... Args >
+struct detector<Default, std17::void_t<Op<Args...>>, Op, Args...>
+{
+    using value_t = std::true_type;
+    using type = Op<Args...>;
+};
+
+} // namespace detail
+
+struct nonesuch
+{
+    ~nonesuch() = delete;
+    nonesuch( nonesuch const & ) = delete;
+    void operator=( nonesuch const & ) = delete;
+};
+
+// pre-C+17 requires `class Op`:
+template< template<typename...> class Op, typename... Args >
+using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
+
+} // std23
+
+#endif // string_CPP11_OR_GREATER
+
+// for string_HAS_METHOD_:
+
+string_MAKE_HAS_METHOD_( begin )
+string_MAKE_HAS_METHOD_( clear )
+string_MAKE_HAS_METHOD_( contains )
+string_MAKE_HAS_METHOD_( empty )
+string_MAKE_HAS_METHOD_( starts_with )
+string_MAKE_HAS_METHOD_( ends_with )
+string_MAKE_HAS_METHOD_( replace )
+
+// string-lite API functions:
+
+// Utilities:
+
+template< typename CharT >
+string_nodiscard CharT nullchr() string_noexcept
+{
+    return 0;
+}
+
+// free function min():
+
+template< typename T >
+inline T min( T a, typename std20::type_identity<T>::type b )
+{
+    return a < b ? a : b;
+}
+
+// free function length():
+
+template< typename Coll >
+string_nodiscard size_t length( Coll const & coll )
+{
+    return coll.length();
+}
+
+#if string_HAVE_FREE_SIZE
+
+using std::size;
+
+#else // string_HAVE_FREE_SIZE
+
+template< typename Cont >
+string_nodiscard inline size_t size( Cont const & c )
+{
+    return c.size();
+}
+
+#endif // string_HAVE_FREE_SIZE
+
+// nonstd size(C-string)
+
+// TODO Add char16_t, char32_t, wchar_t variations - size()
+
+string_nodiscard inline size_t size( char * s )
+{
+    return strlen( s );
+}
+
+string_nodiscard inline size_t size( char const * s )
+{
+    return strlen( s );
+}
+
+string_nodiscard inline size_t size( wchar_t * s )
+{
+    return wcslen( s );
+}
+
+string_nodiscard inline size_t size( wchar_t const * s )
+{
+    return wcslen( s );
+}
+
+#if string_HAVE_CHAR16_T
+#endif
+
+// non-standard begin(), end() for char*:
+
+// TODO Add char16_t, char32_t, wchar_t variations - begin(), end()
+
+template< typename PCharT >
+string_nodiscard inline
+string_ENABLE_IF_R_(std11::is_pointer<PCharT>::value, PCharT)
+begin( PCharT text )
+{
+    return text;
+}
+
+template< typename PCharT >
+string_nodiscard inline
+string_ENABLE_IF_R_(std11::is_pointer<PCharT>::value, PCharT)
+end( PCharT text )
+{
+    return text + size( text );
+}
+
+template< typename CharT >
+string_nodiscard inline CharT const *
+cbegin( CharT const * text )
+{
+    return text;
+}
+
+template< typename CharT >
+string_nodiscard inline CharT const *
+cend( CharT const * text )
+{
+    return text + size( text );
+}
+
+// standard begin() and end():
+
+#if string_HAVE_FREE_BEGIN
+
+using std::begin;
+using std::cbegin;
+using std::crbegin;
+using std::end;
+using std::cend;
+using std::crend;
+
+#else // string_HAVE_FREE_BEGIN
+
+template< typename StringT >
+string_nodiscard inline typename StringT::iterator begin( StringT & text )
+{
+    return text.begin();
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::iterator end( StringT & text )
+{
+    return text.end();
+}
+
+#if string_CPP11_000
+
+template< typename StringT >
+string_nodiscard inline typename StringT::const_iterator begin( StringT const & text )
+{
+    return text.cbegin();
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::const_iterator end( StringT const & text )
+{
+    return text.cend();
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::const_iterator cbegin( StringT const & text )
+{
+    return text.cbegin();
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::const_iterator cend( StringT const & text )
+{
+    return text.cend();
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::reverse_iterator rbegin( StringT const & text )
+{
+    return text.rbegin();
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::reverse_iterator rend( StringT const & text )
+{
+    return text.rend();
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::const_reverse_iterator crbegin( StringT const & text )
+{
+    return text.crbegin();
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::const_reverse_iterator crend( StringT const & text )
+{
+    return text.crend();
+}
+
+#else // string_CPP11_000
+
+template< typename StringT >
+string_nodiscard inline typename StringT::const_iterator cbegin( StringT const & text )
+{
+    typedef typename StringT::const_iterator const_iterator;
+    return const_iterator( text.begin() );
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::const_iterator cend( StringT const & text )
+{
+    typedef typename StringT::const_iterator const_iterator;
+    return const_iterator( text.end() );
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::const_reverse_iterator crbegin( StringT const & text )
+{
+    typedef typename StringT::const_reverse_iterator const_reverse_iterator;
+    return const_reverse_iterator( text.rbegin() );
+}
+
+template< typename StringT >
+string_nodiscard inline typename StringT::const_reverse_iterator crend( StringT const & text )
+{
+    typedef typename StringT::const_reverse_iterator const_reverse_iterator;
+    return const_reverse_iterator( text.rend() );
+}
+
+#endif // string_CPP11_000
+#endif // string_HAVE_FREE_BEGIN
+
+// Minimal internal string_view for string algorithm library, when requested:
+
+#if string_CONFIG_SELECT_STRING_VIEW == string_CONFIG_SELECT_STRING_VIEW_INTERNAL
+
+template
+<
+    class CharT,
+    class Traits = std::char_traits<CharT>
+>
+class basic_string_view
+{
+public:
+    // Member types:
+
+    typedef Traits traits_type;
+    typedef CharT  value_type;
+
+    typedef CharT       * pointer;
+    typedef CharT const * const_pointer;
+    typedef CharT       & reference;
+    typedef CharT const & const_reference;
+
+    typedef const_pointer iterator;
+    typedef const_pointer const_iterator;
+    typedef std::reverse_iterator< const_iterator > reverse_iterator;
+    typedef	std::reverse_iterator< const_iterator > const_reverse_iterator;
+
+    typedef std::size_t     size_type;
+    typedef std::ptrdiff_t  difference_type;
+
+    // 24.4.2.1 Construction and assignment:
+
+    string_constexpr basic_string_view() string_noexcept
+        : data_( string_nullptr )
+        , size_( 0 )
+    {}
+
+    string_constexpr basic_string_view( CharT const * s ) string_noexcept // non-standard noexcept
+        : data_( s )
+        , size_( Traits::length(s) )
+    {}
+
+    string_constexpr basic_string_view( CharT const * s, size_type count ) string_noexcept // non-standard noexcept
+        : data_( s )
+        , size_( count )
+    {}
+
+    string_constexpr basic_string_view( CharT const * b, CharT const * e ) string_noexcept // non-standard noexcept
+        : data_( b )
+        , size_( e - b )
+    {}
+
+    string_constexpr basic_string_view( std::basic_string<CharT> & s ) string_noexcept // non-standard noexcept
+        : data_( s.data() )
+        , size_( s.size() )
+    {}
+
+    string_constexpr basic_string_view( std::basic_string<CharT> const & s ) string_noexcept // non-standard noexcept
+        : data_( s.data() )
+        , size_( s.size() )
+    {}
+
+// #if string_HAVE_EXPLICIT_CONVERSION
+
+    template< class Allocator >
+    string_explicit operator std::basic_string<CharT, Traits, Allocator>() const
+    {
+        return to_string( Allocator() );
+    }
+
+// #endif // string_HAVE_EXPLICIT_CONVERSION
+
+#if string_CPP11_OR_GREATER
+
+    template< class Allocator = std::allocator<CharT> >
+    std::basic_string<CharT, Traits, Allocator>
+    to_string( Allocator const & a = Allocator() ) const
+    {
+        return std::basic_string<CharT, Traits, Allocator>( begin(), end(), a );
+    }
+
+#else
+
+    std::basic_string<CharT, Traits>
+    to_string() const
+    {
+        return std::basic_string<CharT, Traits>( begin(), end() );
+    }
+
+    template< class Allocator >
+    std::basic_string<CharT, Traits, Allocator>
+    to_string( Allocator const & a ) const
+    {
+        return std::basic_string<CharT, Traits, Allocator>( begin(), end(), a );
+    }
+
+#endif // string_CPP11_OR_GREATER
+
+
+    string_constexpr14 size_type find( basic_string_view v, size_type pos = 0 ) const string_noexcept  // (1)
+    {
+        return assert( v.size() == 0 || v.data() != string_nullptr )
+            , pos >= size()
+            ? npos
+            : to_pos( std::search( cbegin() + pos, cend(), v.cbegin(), v.cend(), Traits::eq ) );
+    }
+
+    string_constexpr14 size_type find( CharT c, size_type pos = 0 ) const string_noexcept  // (2)
+    {
+        return find( basic_string_view( &c, 1 ), pos );
+    }
+
+    string_constexpr size_type find_first_of( basic_string_view v, size_type pos = 0 ) const string_noexcept  // (1)
+    {
+        return pos >= size()
+            ? npos
+            : to_pos( std::find_first_of( cbegin() + pos, cend(), v.cbegin(), v.cend(), Traits::eq ) );
+    }
+
+    string_constexpr size_type     size()   const string_noexcept { return size_; }
+    string_constexpr size_type     length() const string_noexcept { return size_; }
+    string_constexpr const_pointer data()   const string_noexcept { return data_; }
+
+    string_constexpr14 basic_string_view substr( size_type pos = 0, size_type n = npos ) const
+    {
+#if string_CONFIG_NO_EXCEPTIONS
+        assert( pos <= size() );
+#else
+        if ( pos > size() )
+        {
+            throw std::out_of_range("string_view::substr()");
+        }
+#endif
+        return basic_string_view( data() + pos, (std::min)( n, size() - pos ) );
+    }
+
+    string_constexpr const_iterator begin()  const string_noexcept { return data_;         }
+    string_constexpr const_iterator end()    const string_noexcept { return data_ + size_; }
+
+    string_constexpr const_iterator cbegin() const string_noexcept { return begin(); }
+    string_constexpr const_iterator cend()   const string_noexcept { return end();   }
+
+    string_constexpr const_reverse_iterator rbegin()  const string_noexcept { return const_reverse_iterator( end() );   }
+    string_constexpr const_reverse_iterator rend()    const string_noexcept { return const_reverse_iterator( begin() ); }
+
+    string_constexpr const_reverse_iterator crbegin() const string_noexcept { return rbegin(); }
+    string_constexpr const_reverse_iterator crend()   const string_noexcept { return rend();   }
+
+    string_constexpr size_type to_pos( const_iterator it ) const
+    {
+        return it == cend() ? npos : size_type( it - cbegin() );
+    }
+
+    // Constants:
+
+#if string_CPP17_OR_GREATER
+    static string_constexpr size_type npos = size_type(-1);
+#elif string_CPP11_OR_GREATER
+    enum : size_type { npos = size_type(-1) };
+#else
+    enum { npos = size_type(-1) };
+#endif
+
+private:
+    const_pointer data_;
+    size_type     size_;
+};
+
+typedef basic_string_view<char>      string_view;
+typedef basic_string_view<wchar_t>   wstring_view;
+
+#if string_HAVE_CHAR16_T
+
+typedef basic_string_view<char16_t>  u16string_view;
+typedef basic_string_view<char32_t>  u32string_view;
+#endif
+
+template< typename T >
+string_nodiscard inline size_t size( basic_string_view<T> const & sv )
+{
+    return sv.size();
+}
+
+template< typename T >
+string_nodiscard inline typename basic_string_view<T>::const_reverse_iterator
+crbegin( basic_string_view<T> const & sv )
+{
+    typedef typename basic_string_view<T>::const_reverse_iterator const_reverse_iterator;
+    return const_reverse_iterator( sv.rbegin() );
+}
+
+template< typename T >
+string_nodiscard inline typename basic_string_view<T>::const_reverse_iterator
+crend( basic_string_view<T> const & sv )
+{
+    typedef typename basic_string_view<T>::const_reverse_iterator const_reverse_iterator;
+    return const_reverse_iterator( sv.rend() );
+}
+
+#elif string_CONFIG_SELECT_STRING_VIEW == string_CONFIG_SELECT_STRING_VIEW_NONSTD
+
+using nonstd::sv_lite::basic_string_view;
+using nonstd::sv_lite::string_view;
+using nonstd::sv_lite::wstring_view;
+
+#if nssv_HAVE_WCHAR16_T
+using nonstd::sv_lite::u16string_view;
+#endif
+#if nssv_HAVE_WCHAR32_T
+using nonstd::sv_lite::u32string_view;
+#endif
+
+#elif string_CONFIG_SELECT_STRING_VIEW == string_CONFIG_SELECT_STRING_VIEW_STD
+
+using std::basic_string_view;
+using std::string_view;
+using std::wstring_view;
+#if string_HAVE_CHAR16_T
+using std::u16string_view;
+using std::u32string_view;
+#endif
+
+#endif // string_CONFIG_SELECT_STRING_VIEW_INTERNAL
+
+// Convert string_view to std::string:
+
+#if string_CONFIG_SELECT_STRING_VIEW != string_CONFIG_SELECT_STRING_VIEW_NONSTD
+
+template< class CharT, class Traits >
+std::basic_string<CharT, Traits>
+to_string( basic_string_view<CharT, Traits> v )
+{
+    return std::basic_string<CharT, Traits>( v.begin(), v.end() );
+}
+
+template< class CharT, class Traits, class Allocator >
+std::basic_string<CharT, Traits, Allocator>
+to_string( basic_string_view<CharT, Traits> v, Allocator const & a )
+{
+    return std::basic_string<CharT, Traits, Allocator>( v.begin(), v.end(), a );
+}
+
+#endif // string_CONFIG_SELECT_STRING_VIEW
+
+// to_identity() - let nonstd::string_view operate with pre-std::string_view std::string methods:
+
+template< class CharT >
+CharT const * to_identity( CharT const * s )
+{
+    return s;
+}
+
+template< class CharT, class Traits, class Allocator >
+std::basic_string<CharT, Traits, Allocator>
+to_identity( std::basic_string<CharT, Traits, Allocator> const & s )
+{
+    return s;
+}
+
+#if string_CONFIG_SELECT_STRING_VIEW == string_CONFIG_SELECT_STRING_VIEW_STD
+
+template< class CharT, class Traits >
+basic_string_view<CharT, Traits>
+to_identity( basic_string_view<CharT, Traits> v )
+{
+    return v;
+}
+
+#else
+
+template< class CharT, class Traits >
+std::basic_string<CharT, Traits>
+to_identity( basic_string_view<CharT, Traits> v )
+{
+    return to_string( v );
+}
+
+#endif // string_CONFIG_SELECT_STRING_VIEW
+
+// namespace detail:
+
+namespace detail {
+
+// for string_ENABLE_IF_():
+
+/*enum*/ class enabler{};
+
+template< typename CharT >
+string_nodiscard inline CharT as_lowercase( CharT chr )
+{
+    return std::tolower( chr, std::locale() );
+}
+
+template< typename CharT >
+string_nodiscard inline CharT as_uppercase( CharT chr )
+{
+    return std::toupper( chr, std::locale() );
+}
+
+// case conversion:
+
+// Note: serve both CharT* and StringT&:
+
+template< typename StringT, typename Fn >
+StringT & to_case( StringT & text, Fn fn ) string_noexcept
+{
+    std::transform(
+        string::begin( text ), string::end( text )
+        , string::begin( text )
+        , fn
+    );
+
+    return text;
+}
+
+// find_first():
+
+template< typename StringT, typename SubT >
+typename StringT::iterator find_first( StringT & text, SubT const & seek )
+{
+    return std::search(
+        string::begin(text), string::end(text)
+        , string::cbegin(seek), string::cend(seek)
+    );
+}
+
+template< typename StringT, typename SubT >
+typename StringT::const_iterator find_first( StringT const & text, SubT const & seek )
+{
+    return std::search(
+        string::cbegin(text), string::cend(text)
+        , string::cbegin(seek), string::cend(seek)
+    );
+}
+
+// find_last():
+
+template< typename StringIt, typename SubIt, typename PredicateT >
+StringIt find_last( StringIt text_pos, StringIt text_end, SubIt seek_pos, SubIt seek_end, PredicateT compare )
+{
+    if ( seek_pos == seek_end )
+        return text_end;
+
+    StringIt result = text_end;
+
+    while ( true )
+    {
+        StringIt new_result = std::search( text_pos, text_end, seek_pos, seek_end, compare );
+
+        if ( new_result == text_end )
+        {
+            break;
+        }
+        else
+        {
+            result = new_result;
+            text_pos = result;
+            ++text_pos;
+        }
+    }
+    return result;
+}
+
+template< typename StringT, typename SubT, typename PredicateT >
+typename StringT::iterator find_last( StringT & text, SubT const & seek, PredicateT compare )
+{
+    return detail::find_last(
+        string::begin(text), string::end(text)
+        , string::cbegin(seek), string::cend(seek)
+        , compare
+    );
+}
+
+template< typename StringT, typename SubT, typename PredicateT >
+typename StringT::const_iterator find_last( StringT const & text, SubT const & seek, PredicateT compare )
+{
+    return detail::find_last(
+        string::cbegin(text), string::cend(text)
+        , string::cbegin(seek), string::cend(seek)
+        , compare
+    );
+}
+
+// starts_with():
+
+template< typename StringIt, typename SubIt, typename PredicateT >
+bool starts_with( StringIt text_pos, StringIt text_end, SubIt seek_pos, SubIt seek_end, PredicateT compare )
+{
+    for( ; text_pos != text_end && seek_pos != seek_end; ++text_pos, ++seek_pos )
+    {
+        if( !compare( *text_pos, *seek_pos ) )
+            return false;
+    }
+
+    return seek_pos == seek_end;
+}
+
+template< typename StringT, typename SubT, typename PredicateT >
+bool starts_with( StringT const & text, SubT const & seek, PredicateT compare )
+{
+    return detail::starts_with(
+        string::cbegin(text), string::cend(text)
+        , string::cbegin(seek), string::cend(seek)
+        , compare
+    );
+}
+
+// ends_with():
+
+template< typename StringT, typename SubT, typename PredicateT >
+bool ends_with( StringT const & text, SubT const & seek, PredicateT compare )
+{
+    return detail::starts_with(
+        string::crbegin(text), string::crend(text)
+        , string::crbegin(seek), string::crend(seek)
+        , compare
+    );
+}
+
+// replace_all():
+
+// TODO replace_all() - alg:
+
+template< typename StringIt, typename FromIt, typename ToIt, typename PredicateT >
+bool replace_all
+(
+    StringIt text_pos, StringIt text_end
+    , FromIt from_pos, FromIt from_end
+    , ToIt to_pos, ToIt to_end
+    , PredicateT compare
+)
+{
+    return true; // error
+}
+
+template< typename CharT, typename FromT, typename ToT >
+std::basic_string<CharT> & replace_all( std::basic_string<CharT> & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    for ( ;; )
+    {
+        const size_t pos = text.find( from );
+
+        if ( pos == std::string::npos )
+            return text;
+
+        text.replace( pos, ::nonstd::string::size(from), to_identity(to) );
+    }
+}
+
+template< typename StringT, typename FromT, typename ToT >
+StringT & replace_all( StringT & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    typedef typename StringT::value_type A;
+
+    (void) detail::replace_all(
+        string::begin(text), string::end(text)
+        , string::cbegin(from), string::cend(from)
+        , string::cbegin(to), string::cend(to)
+        , std::equal_to<A>()
+    );
+
+    return text;
+}
+
+// replace_first():
+
+template< typename CharT, typename FromT, typename ToT >
+std::basic_string<CharT> & replace_first( std::basic_string<CharT> & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    const size_t pos = text.find( to_identity(from) );
+
+    if ( pos == std::string::npos )
+        return text;
+
+    return text.replace( pos, ::nonstd::string::size(from), to_identity(to) );
+}
+
+// replace_last():
+
+template< typename CharT, typename FromT, typename ToT >
+std::basic_string<CharT> &
+replace_last( std::basic_string<CharT> & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    const size_t pos = text.rfind( to_identity(from) );
+
+    if ( pos == std::string::npos )
+        return text;
+
+    return text.replace( pos, ::nonstd::string::size(from), to_identity(to) );
+}
+
+// append():
+
+template< typename CharT, typename TailT >
+string_constexpr CharT *
+append( CharT * text, TailT const & tail ) string_noexcept
+{
+    return std::strcat( text, to_identity(tail) );
+}
+
+template< typename CharT, typename TailT >
+string_constexpr std::basic_string<CharT> &
+append( std::basic_string<CharT> & text, TailT const & tail ) string_noexcept
+{
+    return text.append( to_identity(tail) );
+}
+
+// TODO trim() - alg
+
+template< typename CharT, typename SetT >
+string_constexpr14 CharT *
+trim_left( CharT * text, SetT const * set ) string_noexcept
+{
+    // TODO trim() - strspn(CharT), adapt std::strspn to CharT
+    const int pos = std::strspn( text, set );
+
+    memmove( text, text + pos, 1 + size( text ) - pos );
+
+    return text;
+}
+
+template< typename CharT, typename SetT >
+string_constexpr std::basic_string<CharT> &
+trim_left( std::basic_string<CharT> & text, SetT const & set ) string_noexcept
+{
+    return text.erase( 0, text.find_first_not_of( set ) );
+}
+
+template< typename StringT, typename SetT >
+string_constexpr StringT &
+trim_left( StringT & text, SetT const & /*set*/ ) string_noexcept
+{
+    //  TODO trim() - make generic version
+    return text;
+}
+
+template< typename CharT, typename SetT >
+string_constexpr14 CharT *
+trim_right( CharT * text, SetT const * set ) string_noexcept
+{
+    std::size_t length = size( text );
+
+    if ( !length )
+        return text;
+
+    char * end = text + length - 1;
+
+    // TODO trim() - strspn(CharT), adapt std::strchr to CharT
+    while ( end >= text && std::strchr( set, *end ) )
+        end--;
+
+    *( end + 1 ) = '\0';
+
+    return text;
+}
+
+template< typename CharT, typename SetT >
+string_constexpr std::basic_string<CharT> &
+trim_right( std::basic_string<CharT> & text, SetT const & set ) string_noexcept
+{
+    return text.erase( text.find_last_not_of( set ) + 1 );
+}
+
+template< typename StringT, typename SetT >
+string_constexpr StringT &
+trim_right( StringT & text, SetT const & /*set*/ ) string_noexcept
+{
+    //  TODO trim() - make generic version
+    return text;
+}
+
+template< typename CharT, typename SetT >
+string_constexpr CharT *
+trim( CharT * text, SetT const * set ) string_noexcept
+{
+    return trim_right( trim_left( text, set ), set);
+}
+
+template< typename CharT, typename SetT >
+string_constexpr std::basic_string<CharT> &
+trim( std::basic_string<CharT> & text, SetT const & set ) string_noexcept
+{
+    return trim_right( trim_left( text, set ), set);
+}
+
+template< typename StringT, typename SetT >
+string_constexpr StringT &
+trim( StringT & text, SetT const & set ) string_noexcept
+{
+    return trim_right( trim_left( text, set ), set);
+}
+
+// TODO join() - alg
+
+// split():
+
+template< typename CharT, typename Delimiter >
+std::vector<basic_string_view<CharT> >
+split(basic_string_view<CharT> text, Delimiter delimiter)
+{
+    std::vector<basic_string_view<CharT> > result;
+
+    size_t pos = 0;
+
+    for( basic_string_view<CharT> sv = delimiter(text, pos); sv.cbegin() != text.cend(); sv = delimiter(text, pos) )
+    {
+        result.push_back(sv);
+        pos = (sv.end() - text.begin()) + length(delimiter);
+    }
+
+    return result;
+}
+
+} // namespace detail
+
+// Observers:
+
+// is_empty():
+
+template< typename CharT >
+string_nodiscard bool is_empty( CharT const * cp ) string_noexcept
+{
+    assert( cp != string_nullptr );
+    return *cp == nullchr<CharT>();
+}
+
+template< typename StringT
+    string_ENABLE_IF_HAS_METHOD_(StringT, empty)
+>
+string_nodiscard bool is_empty( StringT const & text ) string_noexcept
+{
+    return text.empty();
+}
+
+// find_first():
+
+template< typename StringT, typename SubT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+string_constexpr typename StringT::iterator find_first( StringT & text, SubT const & seek )
+{
+    return detail::find_first( text, seek );
+}
+
+template< typename StringT, typename SubT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+string_constexpr typename StringT::const_iterator find_first( StringT const & text, SubT const & seek )
+{
+    return detail::find_first( text, seek );
+}
+
+template< typename CharT, typename SubT >
+string_constexpr CharT * find_first( CharT * text, SubT const & seek )
+{
+    return detail::find_first( text, seek );
+}
+
+// find_last():
+
+template< typename StringT, typename SubT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+string_constexpr typename StringT::iterator find_last( StringT & text, SubT const & seek )
+{
+    typedef typename StringT::value_type A;
+
+    return detail::find_last( text, seek, std::equal_to<A>() );
+}
+
+template< typename StringT, typename SubT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+string_constexpr typename StringT::const_iterator find_last( StringT const & text, SubT const & seek )
+{
+    typedef typename StringT::value_type A;
+
+    return detail::find_last( text, seek, std::equal_to<A>() );
+}
+
+template< typename CharT, typename SubT >
+string_constexpr CharT * find_last( CharT * text, SubT const & seek )
+{
+    return detail::find_last( text, seek, std::equal_to<CharT>() );
+}
+
+// contains(); C++23-like string::contains():
+
+#if string_TEST_STRING_CONTAINS
+
+template< typename StringT, typename SubT
+    string_ENABLE_IF_HAS_METHOD_(StringT, contains)
+>
+string_nodiscard string_constexpr bool contains( StringT const & text, SubT const & seek ) string_noexcept
+{
+    return text.contains( seek );
+}
+
+template< typename StringT, typename SubT
+    string_DISABLE_IF_HAS_METHOD_(StringT, contains)
+    string_ENABLE_IF_( !std::is_arithmetic<SubT>::value )
+>
+string_nodiscard string_constexpr bool contains( StringT const & text, SubT const & seek ) string_noexcept
+{
+    return string::end( text ) != find_first( text, seek );
+}
+
+template< typename StringT, typename CharT
+    string_DISABLE_IF_HAS_METHOD_(StringT, contains)
+    string_ENABLE_IF_( std::is_arithmetic<CharT>::value )
+>
+string_nodiscard string_constexpr14 bool contains( StringT const & text, CharT seek ) string_noexcept
+{
+    CharT look[] = { seek, nullchr<CharT>() };
+    return string::end( text ) != find_first( text, look );
+}
+
+#else // string_TEST_STRING_CONTAINS
+
+template< typename StringT, typename SubT >
+string_nodiscard string_constexpr bool contains( StringT const & text, SubT const & seek ) string_noexcept
+{
+    return string::cend( text ) != find_first( text, seek );
+}
+
+template< typename StringT >
+string_nodiscard string_constexpr bool contains( StringT const & text, char const * seek ) string_noexcept
+{
+    return string::cend( text ) != find_first( text, seek );
+}
+
+template< typename StringT >
+string_nodiscard string_constexpr bool contains( StringT const & text, char seek ) string_noexcept
+{
+    char look[] = { seek, nullchr<char>() };
+    return string::cend( text ) != find_first( text, look );
+}
+
+#endif // string_TEST_STRING_CONTAINS
+
+#if string_HAVE_REGEX
+
+template< typename StringT >
+string_nodiscard string_constexpr bool contains( StringT const & text, std::regex const & re ) string_noexcept
+{
+    return std::regex_search( text, re );
+}
+
+template< typename StringT, typename ReT >
+string_nodiscard string_constexpr bool contains_re( StringT const & text, ReT const & re ) string_noexcept
+{
+    return contains( text, std::regex(re) );
+}
+
+#endif // string_HAVE_REGEX
+
+// starts_with():
+
+#if string_TEST_STRING_STARTS_WITH
+
+template< typename StringT, typename SubT
+    string_ENABLE_IF_HAS_METHOD_(StringT, starts_with)
+>
+string_nodiscard string_constexpr bool starts_with( StringT const & text, SubT const & seek ) string_noexcept
+{
+    return text.starts_with( seek );
+}
+
+template< typename StringT, typename SubT
+    string_DISABLE_IF_HAS_METHOD_(StringT, starts_with)
+    string_ENABLE_IF_( !std::is_arithmetic<SubT>::value )
+>
+string_nodiscard string_constexpr bool starts_with( StringT const & text, SubT const & seek ) string_noexcept
+{
+    typedef typename StringT::value_type A;
+
+    return detail::starts_with( text, seek, std::equal_to<A>() );
+}
+
+template< typename StringT, typename CharT
+    string_DISABLE_IF_HAS_METHOD_(StringT, starts_with)
+    string_ENABLE_IF_( std::is_arithmetic<CharT>::value )
+>
+string_nodiscard string_constexpr14 bool starts_with( StringT const & text, CharT seek ) string_noexcept
+{
+    CharT look[] = { seek, nullchr<CharT>() };
+
+    // return detail::starts_with( text, look, std::equal_to<CharT>() );
+    return detail::starts_with( text, StringT(look), std::equal_to<CharT>() );
+}
+
+#else // string_TEST_STRING_STARTS_WITH
+
+template< typename StringT, typename SubT >
+string_nodiscard string_constexpr bool starts_with( StringT const & text, SubT const & seek ) string_noexcept
+{
+    typedef typename StringT::value_type A;
+
+    return detail::starts_with( text, seek, std::equal_to<A>() );
+}
+
+template< typename StringT >
+string_nodiscard string_constexpr bool starts_with( StringT const & text, char const * seek ) string_noexcept
+{
+    typedef typename StringT::value_type A;
+
+    return detail::starts_with( text, seek, std::equal_to<A>() );
+}
+
+template< typename StringT >
+string_nodiscard string_constexpr14 bool starts_with( StringT const & text, char seek ) string_noexcept
+{
+    char look[] = { seek, nullchr<char>() };
+
+    return detail::starts_with( text, StringT(look), std::equal_to<char>() );
+}
+
+#endif // string_TEST_STRING_STARTS_WITH
+
+// ends_with():
+
+#if string_TEST_STRING_ENDS_WITH
+
+template< typename StringT, typename SubT
+    string_ENABLE_IF_HAS_METHOD_(StringT, ends_with)
+>
+string_nodiscard string_constexpr bool ends_with( StringT const & text, SubT const & seek ) string_noexcept
+{
+    return text.ends_with( seek );
+}
+
+template< typename StringT, typename SubT
+    string_DISABLE_IF_HAS_METHOD_(StringT, ends_with)
+    string_ENABLE_IF_( !std::is_arithmetic<SubT>::value )
+>
+string_nodiscard string_constexpr bool ends_with( StringT const & text, SubT const & seek ) string_noexcept
+{
+    typedef typename StringT::value_type A;
+
+    return detail::ends_with( text, StringT(seek), std::equal_to<A>() );
+}
+
+template< typename StringT, typename CharT
+    string_DISABLE_IF_HAS_METHOD_(StringT, ends_with)
+    string_ENABLE_IF_( std::is_arithmetic<CharT>::value )
+>
+string_nodiscard string_constexpr14 bool ends_with( StringT const & text, CharT seek ) string_noexcept
+{
+    CharT look[] = { seek, nullchr<CharT>() };
+
+    return detail::ends_with( text, StringT(look), std::equal_to<CharT>() );
+}
+
+#else // string_TEST_STRING_ENDS_WITH
+
+template< typename StringT, typename SubT >
+string_nodiscard string_constexpr bool ends_with( StringT const & text, SubT const & seek ) string_noexcept
+{
+    typedef typename StringT::value_type A;
+
+    return detail::ends_with( text, seek, std::equal_to<A>() );
+}
+
+template< typename StringT >
+string_nodiscard string_constexpr bool ends_with( StringT const & text, char const * seek ) string_noexcept
+{
+    typedef typename StringT::value_type A;
+
+    return detail::ends_with( text, StringT(seek), std::equal_to<A>() );
+}
+
+template< typename StringT >
+string_nodiscard string_constexpr bool ends_with( StringT const & text, char seek ) string_noexcept
+{
+    char look[] = { seek, nullchr<char>() };
+
+    return detail::ends_with( text, StringT(look), std::equal_to<char>() );
+}
+
+#endif // string_TEST_STRING_ENDS_WITH
+
+// Modifiers:
+
+// replace_all():
+
+template< typename CharT, typename FromT, typename ToT
+    // string_ENABLE_IF_HAS_METHOD_(StringT, replace)
+>
+string_nodiscard string_constexpr std::basic_string<CharT> &
+replace_all( std::basic_string<CharT> & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    return detail::replace_all( text, from, to );
+}
+
+template< typename StringT, typename FromT, typename ToT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+string_nodiscard string_constexpr StringT &
+replace_all( StringT & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    return detail::replace_all( text, from, to );
+}
+
+// replaced_all():
+
+template< typename CharT, typename FromT, typename ToT >
+string_nodiscard string_constexpr std::basic_string<CharT>
+replaced_all( CharT const * text, FromT const & from, ToT const & to ) string_noexcept
+{
+    std::basic_string<CharT> result( text );
+
+    return replace_all( result, from, to );
+}
+
+template< typename StringT, typename FromT, typename ToT >
+string_nodiscard string_constexpr StringT
+replaced_all( StringT const & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    StringT result( text );
+
+    return replace_all( result, from, to );
+}
+
+// replace_first():
+
+template< typename CharT, typename FromT, typename ToT >
+string_nodiscard string_constexpr CharT *
+replace_first( CharT * text, FromT const & from, ToT const & to ) string_noexcept
+{
+    return detail::replace_first( text, from, to );
+}
+
+template< typename CharT, typename FromT, typename ToT >
+string_nodiscard string_constexpr std::basic_string<CharT> &
+replace_first( std::basic_string<CharT> & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    return detail::replace_first( text, from, to );
+}
+
+template< typename StringT, typename FromT, typename ToT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+string_nodiscard string_constexpr StringT &
+replace_first( StringT & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    return detail::replace_first( text, from, to );
+}
+
+// replaced_first():
+
+template< typename CharT, typename FromT, typename ToT >
+string_nodiscard string_constexpr std::basic_string<CharT>
+replaced_first( CharT const * text, FromT const & from, ToT const & to ) string_noexcept
+{
+    std::basic_string<CharT> result( text );
+
+    return replace_first( result, from, to );
+}
+
+template< typename StringT, typename FromT, typename ToT >
+string_nodiscard string_constexpr StringT
+replaced_first( StringT const & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    StringT result( text );
+
+    return replace_first( result, from, to );
+}
+
+// replace_last():
+
+template< typename CharT, typename FromT, typename ToT >
+string_nodiscard string_constexpr CharT *
+replace_last( CharT * text, FromT const & from, ToT const & to ) string_noexcept
+{
+    return detail::replace_last( text, from, to );
+}
+
+template< typename CharT, typename FromT, typename ToT >
+string_nodiscard string_constexpr std::basic_string<CharT> &
+replace_last( std::basic_string<CharT> & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    return detail::replace_last( text, from, to );
+}
+
+template< typename StringT, typename FromT, typename ToT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+string_nodiscard string_constexpr StringT &
+replace_last( StringT & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    return detail::replace_last( text, from, to );
+}
+
+// replaced_last():
+
+template< typename CharT, typename FromT, typename ToT >
+string_nodiscard string_constexpr std::basic_string<CharT>
+replaced_last( CharT const * text, FromT const & from, ToT const & to ) string_noexcept
+{
+    std::basic_string<CharT> result( text );
+
+    return replace_last( result, from, to );
+}
+
+template< typename StringT, typename FromT, typename ToT >
+string_nodiscard string_constexpr StringT
+replaced_last( StringT const & text, FromT const & from, ToT const & to ) string_noexcept
+{
+    StringT result( text );
+
+    return replace_last( result, from, to );
+}
+
+// clear():
+
+template< typename CharT >
+CharT * clear( CharT * cp ) string_noexcept
+{
+    *cp = nullchr<CharT>();
+    return cp;
+}
+
+template< typename StringT
+    string_ENABLE_IF_HAS_METHOD_(StringT, clear)
+>
+StringT & clear( StringT & text ) string_noexcept
+{
+    text.clear();
+    return text;
+}
+
+// to_lowercase(), to_uppercase():
+
+template< typename CharT >
+CharT * to_lowercase( CharT * cp ) string_noexcept
+{
+    return detail::to_case( cp, detail::as_lowercase<CharT> );
+}
+
+template< typename CharT >
+CharT * to_uppercase( CharT * cp ) string_noexcept
+{
+    return detail::to_case( cp, detail::as_uppercase<CharT> );
+}
+
+template< typename StringT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+StringT & to_lowercase( StringT & text ) string_noexcept
+{
+    return detail::to_case( text, detail::as_lowercase<typename StringT::value_type> );
+}
+
+template< typename StringT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+StringT & to_uppercase( StringT & text ) string_noexcept
+{
+    return detail::to_case( text, detail::as_uppercase<typename StringT::value_type> );
+}
+
+template< typename StringT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+string_nodiscard StringT as_lowercase( StringT const & text ) string_noexcept
+{
+    StringT result( text );
+    to_lowercase( result );
+    return result;
+}
+
+template< typename StringT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+string_nodiscard StringT as_uppercase( StringT const & text ) string_noexcept
+{
+    StringT result( text );
+    to_uppercase( result );
+    return result;
+}
+
+// append():
+
+template< typename CharT, typename TailT >
+string_constexpr CharT *
+append( CharT * text, TailT const & tail ) string_noexcept
+{
+    return detail::append( text, tail );
+}
+
+template< typename StringT, typename TailT >
+string_constexpr StringT &
+append( StringT & text, TailT const & tail ) string_noexcept
+{
+    return detail::append( text, tail );
+}
+
+// appended():
+
+template< typename StringT, typename TailT
+    string_ENABLE_IF_HAS_METHOD_(StringT, begin)
+>
+string_nodiscard string_constexpr StringT
+appended( StringT const & text, TailT const & tail ) string_noexcept
+{
+    StringT result( text );
+
+    return detail::append( result, tail );
+}
+
+// TODO trim()
+
+// trim_left():
+
+template< typename StringT >
+inline StringT const default_trim_set()
+{
+    return " \t\n";
+}
+
+template< typename CharT, typename SetT >
+string_constexpr CharT *
+trim_left( CharT * text, SetT const * set ) string_noexcept
+{
+    return detail::trim_left( text, set );
+}
+
+template< typename CharT >
+string_constexpr CharT *
+trim_left( CharT * text ) string_noexcept
+{
+    return trim_left( text, default_trim_set<CharT const *>() );
+}
+
+template< typename StringT, typename SetT >
+string_constexpr StringT &
+trim_left( StringT & text, SetT const & set ) string_noexcept
+{
+    return detail::trim_left( text, set );
+}
+
+template< typename StringT >
+string_constexpr StringT &
+trim_left( StringT & text ) string_noexcept
+{
+    return trim_left( text, default_trim_set<StringT>() );
+}
+
+template< typename StringT, typename SetT >
+string_constexpr14 StringT
+trimmed_left( StringT const & text, SetT const & set ) string_noexcept
+{
+    StringT result( text );
+    return detail::trim_left( result, set );
+}
+
+template< typename StringT >
+string_constexpr StringT
+trimmed_left( StringT const & text ) string_noexcept
+{
+    return trimmed_left( text, default_trim_set<StringT>() );
+}
+
+// trim_right():
+
+template< typename CharT, typename SetT >
+string_constexpr CharT *
+trim_right( CharT * text, SetT const * set ) string_noexcept
+{
+    return detail::trim_right( text, set );
+}
+
+template< typename CharT >
+string_constexpr CharT *
+trim_right( CharT * text ) string_noexcept
+{
+    return trim_right( text, default_trim_set<CharT const *>() );
+}
+
+template< typename StringT, typename SetT >
+string_constexpr StringT &
+trim_right( StringT & text, SetT const & set ) string_noexcept
+{
+    return detail::trim_right( text, set );
+}
+
+template< typename StringT >
+string_constexpr StringT &
+trim_right( StringT & text ) string_noexcept
+{
+    return trim_right( text, default_trim_set<StringT>() );
+}
+
+template< typename StringT, typename SetT >
+string_constexpr14 StringT
+trimmed_right( StringT const & text, SetT const & set ) string_noexcept
+{
+    StringT result( text );
+    return detail::trim_right( result, set );
+}
+
+template< typename StringT >
+string_constexpr StringT
+trimmed_right( StringT const & text ) string_noexcept
+{
+    return trimmed_right( text, default_trim_set<StringT>() );
+}
+
+// trim():
+
+template< typename CharT, typename SetT >
+string_constexpr CharT *
+trim( CharT * text, SetT const * set ) string_noexcept
+{
+    return detail::trim( text, set );
+}
+
+template< typename CharT >
+string_constexpr CharT *
+trim( CharT * text ) string_noexcept
+{
+    return trim( text, default_trim_set<CharT const *>() );
+}
+
+template< typename StringT, typename SetT >
+string_constexpr StringT &
+trim( StringT & text, SetT const & set ) string_noexcept
+{
+    return detail::trim( text, set );
+}
+
+template< typename StringT >
+string_constexpr StringT &
+trim( StringT & text ) string_noexcept
+{
+    return trim( text, default_trim_set<StringT>() );
+}
+
+template< typename StringT, typename SetT >
+string_constexpr StringT
+trimmed( StringT const & text, SetT const & set ) string_noexcept
+{
+    StringT result( text );
+    return detail::trim( result, set );
+}
+
+template< typename StringT >
+string_constexpr StringT
+trimmed( StringT const & text ) string_noexcept
+{
+    return trimmed( text, default_trim_set<StringT>() );
+}
+
+// TODO join():
+
+// Note: add way to defined return type:
+
+template< typename Coll, typename SepT
+//    string_ENABLE_IF_( !std::is_pointer<typename Coll::value_type>::value )
+>
+string_nodiscard string_constexpr14
+typename Coll::value_type
+join( Coll const & coll, SepT const & sep ) string_noexcept
+{
+    typename Coll::value_type result;
+
+    typename Coll::const_iterator const coll_begin = string::cbegin(coll);
+    typename Coll::const_iterator const coll_end   = string::cend(coll);
+
+    typename Coll::const_iterator pos = coll_begin;
+
+    if ( pos != coll_end )
+    {
+        append( result, *pos++ );
+    }
+
+    for ( ; pos != coll_end; ++pos )
+    {
+        append( append( result,  sep ), *pos );
+    }
+
+    return result;
+}
+
+// split():
+
+// Various kinds of delimiters:
+// - literal_delimiter - a single string delimiter
+// - any_of_delimiter - any of given characters as delimiter
+// - fixed_delimiter - fixed length delimiter
+// - limit_delimiter - not implemented
+// - regex_delimiter - regular expression delimiter
+// - char_delimiter - single-char delimiter
+
+template< typename CharT >
+basic_string_view<CharT> basic_delimiter_end(basic_string_view<CharT> sv)
+{
+#if string_CONFIG_SELECT_STRING_VIEW != string_CONFIG_SELECT_STRING_VIEW_STD
+    return basic_string_view<CharT>(sv.cend(), size_t(0));
+#else
+    return basic_string_view<CharT>(sv.data() + sv.size(), size_t(0));
+#endif
+}
+
+// a single string delimiter:
+
+template< typename CharT >
+class basic_literal_delimiter
+{
+    const std::basic_string<CharT> delimiter_;
+    mutable size_t found_;
+
+public:
+    explicit basic_literal_delimiter(basic_string_view<CharT> sv)
+        : delimiter_(to_string(sv))
+        , found_(0)
+    {}
+
+    size_t length() const
+    {
+        return delimiter_.length();
+    }
+
+    basic_string_view<CharT> operator()(basic_string_view<CharT> text, size_t pos) const
+    {
+        return find(text, pos);
+    }
+
+    basic_string_view<CharT> find(basic_string_view<CharT> text, size_t pos) const
+    {
+        // out of range, return 'empty' if last match was at end of text, else return 'done':
+        if ( pos >= text.length())
+        {
+            // last delimiter match at end of text?
+            if ( found_ != text.length() - 1 )
+                return basic_delimiter_end(text);
+
+            found_ = 0;
+            return text.substr(text.length() - 1, 0);
+        }
+
+        // a single character at a time:
+        if (0 == delimiter_.length())
+        {
+            return text.substr(pos, 1);
+        }
+
+        found_ = text.find(delimiter_, pos);
+
+        // at a delimiter, or searching past the last delimiter:
+        if (found_ == pos || pos == text.length())
+        {
+            return text.substr(pos, 0);
+        }
+
+        // no delimiter found:
+        if (found_ == basic_string_view<CharT>::npos)
+        {
+            // return remaining text:
+            if (pos < text.length())
+            {
+                return text.substr(pos);
+            }
+
+            // nothing left, return 'done':
+            return basic_delimiter_end(text);
+        }
+
+        // delimited text:
+        return text.substr(pos, found_ - pos);
+    }
+};
+
+// any of given characters as delimiter:
+
+template< typename CharT >
+class basic_any_of_delimiter
+{
+    const std::basic_string<CharT> delimiters_;
+
+public:
+    explicit basic_any_of_delimiter(basic_string_view<CharT> sv)
+        : delimiters_(to_string(sv)) {}
+
+    size_t length() const
+    {
+        return (min)( size_t(1), delimiters_.length());
+    }
+
+    basic_string_view<CharT> operator()(basic_string_view<CharT> text, size_t pos) const
+    {
+        return find(text, pos);
+    }
+
+    basic_string_view<CharT> find(basic_string_view<CharT> text, size_t pos) const
+    {
+        // out of range, return 'done':
+        if ( pos > text.length())
+            return basic_delimiter_end(text);
+
+        // a single character at a time:
+        if (0 == delimiters_.length())
+        {
+            return text.substr(pos, 1);
+        }
+
+        size_t found = text.find_first_of(delimiters_, pos);
+
+        // at a delimiter, or searching past the last delimiter:
+        if (found == pos || (pos == text.length()))
+        {
+            return basic_string_view<CharT>();
+        }
+
+        // no delimiter found:
+        if (found == basic_string_view<CharT>::npos)
+        {
+            // return remaining text:
+            if (pos < text.length())
+            {
+                return text.substr(pos);
+            }
+
+            // nothing left, return 'done':
+            return basic_delimiter_end(text);
+        }
+
+        // delimited text:
+        return text.substr(pos, found - pos);
+    }
+};
+
+// fixed length delimiter:
+
+template< typename CharT >
+class basic_fixed_delimiter
+{
+    size_t len_;
+
+public:
+    explicit basic_fixed_delimiter(size_t len)
+        : len_(len) {}
+
+    size_t length() const
+    {
+        return 0;
+    }
+
+    string_view operator()(basic_string_view<CharT> text, size_t pos) const
+    {
+        return find(text, pos);
+    }
+
+    string_view find(basic_string_view<CharT> text, size_t pos) const
+    {
+        // out of range, return 'done':
+        if ( pos > text.length())
+            return basic_delimiter_end(text);
+
+        // current slice:
+        return text.substr(pos, len_);
+    }
+};
+
+// TODO limit_delimiter - Delimiter template would take another Delimiter and a size_t limiting
+// the given delimiter to matching a max numbers of times. This is similar to the 3rd argument to
+// perl's split() function.
+
+template< typename CharT, typename DelimiterT >
+class basic_limit_delimiter;
+
+// regular expression delimiter:
+
+#if string_HAVE_REGEX
+
+template< typename CharT >
+class basic_regex_delimiter
+{
+    std::regex     delimiter_re_;               // regular expression designating delimiters
+    size_t         delimiter_len_;              // length of regular expression
+    mutable size_t matched_delimiter_length_;   // length of the actually matched delimiter
+    mutable bool   trailing_delimiter_seen;     // whether to provide last empty result
+
+public:
+    explicit basic_regex_delimiter(basic_string_view<CharT> sv)
+        : delimiter_re_(to_string(sv))
+        , delimiter_len_(sv.length())
+        , matched_delimiter_length_(0u)
+        , trailing_delimiter_seen(false)
+    {}
+
+    size_t length() const
+    {
+        return matched_delimiter_length_;
+    }
+
+    basic_string_view<CharT> operator()(basic_string_view<CharT> text, size_t pos) const
+    {
+        return find(text, pos);
+    }
+
+    basic_string_view<CharT> find(basic_string_view<CharT> text, size_t pos) const
+    {
+        // trailing empty entry:
+        // TODO this feels like a hack, don't know any better at this moment
+        if (trailing_delimiter_seen)
+        {
+            trailing_delimiter_seen = false;
+            return basic_string_view<CharT>();
+        }
+
+        // out of range, return 'done':
+        if ( pos > text.length())
+            return basic_delimiter_end(text);
+
+        // a single character at a time:
+        if (0 == delimiter_len_)
+        {
+            return text.substr(pos, 1);
+        }
+
+        std::smatch m;
+        std::basic_string<CharT> s = to_string(text.substr(pos));
+
+        const bool found = std::regex_search(s, m, delimiter_re_);
+
+        matched_delimiter_length_ = m.length();
+
+        // no delimiter found:
+        if (!found)
+        {
+            // return remaining text:
+            if (pos < text.length())
+            {
+                return text.substr(pos);
+            }
+
+            // nothing left, return 'done':
+            return basic_delimiter_end(text);
+        }
+
+        // at a trailing delimiter, remember for next round:
+        else if ((size_t(m.position()) == s.length() - 1))
+        {
+            trailing_delimiter_seen = true;
+        }
+
+        // delimited text, the match in the input string:
+        return text.substr(pos, m.position());
+    }
+};
+
+#endif // string_HAVE_REGEX
+
+// single-char delimiter:
+
+template< typename CharT >
+class basic_char_delimiter
+{
+    CharT c_;
+
+public:
+    explicit basic_char_delimiter(CharT c)
+        : c_(c) {}
+
+    size_t length() const
+    {
+        return 1;
+    }
+
+    basic_string_view<CharT> operator()(basic_string_view<CharT> text, size_t pos) const
+    {
+        return find(text, pos);
+    }
+
+    basic_string_view<CharT> find(basic_string_view<CharT> text, size_t pos) const
+    {
+        size_t found = text.find(c_, pos);
+
+        // nothing left, return 'done':
+        if (found == basic_string_view<CharT>::npos)
+            return basic_delimiter_end(text);
+
+        // the c_ in the input string:
+        return text.substr(found, 1);
+    }
+};
+
+ // typedefs:
+
+typedef basic_literal_delimiter< char  >  literal_delimiter;
+typedef basic_literal_delimiter<wchar_t> wliteral_delimiter;
+typedef basic_any_of_delimiter<  char  >  any_of_delimiter;
+typedef basic_any_of_delimiter< wchar_t> wany_of_delimiter;
+typedef basic_fixed_delimiter<   char  >  fixed_delimiter;
+typedef basic_fixed_delimiter<  wchar_t> wfixed_delimiter;
+typedef basic_char_delimiter<    char  >  char_delimiter;
+typedef basic_char_delimiter<   wchar_t> wchar_t_delimiter;
+// typedef basic_limit_delimiter<   char  >  limit_delimiter;
+// typedef basic_limit_delimiter<  wchar_t> wlimit_delimiter;
+
+#if string_HAVE_REGEX
+typedef basic_regex_delimiter<   char  >  regex_delimiter;
+typedef basic_regex_delimiter<  wchar_t> wregex_delimiter;
+#endif
+
+#if string_HAVE_CHAR16_T
+
+typedef basic_literal_delimiter<char16_t> u16literal_delimiter;
+typedef basic_literal_delimiter<char32_t> u32literal_delimiter;
+typedef basic_any_of_delimiter< char16_t> u16any_of_delimiter;
+typedef basic_any_of_delimiter< char32_t> u32any_of_delimiter;
+typedef basic_fixed_delimiter<  char16_t> u16fixed_delimiter;
+typedef basic_fixed_delimiter<  char32_t> u32fixed_delimiter;
+typedef basic_char_delimiter<   char16_t> u16char_delimiter;
+typedef basic_char_delimiter<   char32_t> u32char_delimiter;
+// typedef basic_limit_delimiter<  char16_t> u16limit_delimiter;
+// typedef basic_limit_delimiter<  char32_t> u32limit_delimiter;
+
+#if string_HAVE_REGEX
+typedef basic_regex_delimiter<  char16_t> u16regex_delimiter;
+typedef basic_regex_delimiter<  char32_t> u32regex_delimiter;
+#endif
+
+#endif // string_HAVE_CHAR16_T
+
+// split():
+
+template<typename Delimiter> std::vector< string_view> split( string_view text, Delimiter delimiter) { return detail::split(text, delimiter); }
+template<typename Delimiter> std::vector<wstring_view> split(wstring_view text, Delimiter delimiter) { return detail::split(text, delimiter); }
+
+#if string_HAVE_CHAR16_T
+template<typename Delimiter> std::vector<u16string_view> split(u16string_view text, Delimiter delimiter) { return detail::split(text, delimiter); }
+template<typename Delimiter> std::vector<u32string_view> split(u32string_view text, Delimiter delimiter) { return detail::split(text, delimiter); }
+#endif
+
+inline std::vector<string_view> split(string_view text, char const * d) { return detail::split(text, literal_delimiter(d)); }
+
+} // namespace string
+} // namespace nonstd
+
+namespace nonstd {
+
+// using string::clear;
+
+} // namespace nonstd
+
+#endif // NONSTD_STRING_LITE_HPP

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -52,22 +53,44 @@ public:
   {
     PathVec     filepaths;
     Path        output;
+    Path        layout;
     std::string format;
   };
 
   struct Pack
   {
+    Path        input;
+    Path        output;
+    Path        layout;
+    std::string volume_commentary;
+    std::string volume_label;
+    bool        banner_romtag = true;
+    bool        billstuff_romtag = false;
+    bool        dry_run = false;
+    bool        mark = true;
+    bool        sign = false;
+    bool        root_unique_identifier_set = false;
+    bool        volume_unique_identifier_set = false;
+    uint32_t    root_unique_identifier = 0;
+    uint32_t    signature_digest_check_count = 0;
+    uint32_t    volume_unique_identifier = 0;
+  };
+
+  struct Repack
+  {
+    PathVec     filepaths;
+    Path        output;
+    bool        banner_romtag = true;
+    bool        billstuff_romtag = false;
+    bool        mark = true;
+    bool        sign = false;
+    uint32_t    signature_digest_check_count = 0;
   };
 
   struct Rename
   {
     PathVec filepaths;
     bool    take_first;
-  };
-
-  struct Crc32b
-  {
-    PathVec filepaths;
   };
 
   struct ToISO
@@ -82,13 +105,58 @@ public:
     std::string format;
   };
 
+  struct Verify
+  {
+    PathVec     filepaths;
+    std::string format = "human";
+    bool        digest_table = true;
+    bool        quiet = false;
+  };
+
+  struct Sign
+  {
+    PathVec  filepaths;
+    Path     output;
+    bool     banner_romtag = true;
+    bool     billstuff_romtag = false;
+    bool     force = false;
+    bool     mark = true;
+    uint32_t signature_digest_check_count = 0;
+  };
+
+  struct SignFile
+  {
+    PathVec     filepaths;
+    Path        signature_output;
+    std::string key_name;
+    bool        append = false;
+    bool        replace = false;
+    bool        verify = false;
+    bool        write = false;
+  };
+
+  struct DecryptFile
+  {
+    PathVec     filepaths;
+  };
+
+  struct EncryptFile
+  {
+    PathVec     filepaths;
+  };
+
   List     list     = {};
   Info     info     = {};
   Identify identify = {};
   Unpack   unpack   = {};
   Pack     pack     = {};
+  Repack   repack   = {};
   Rename   rename   = {};
-  Crc32b   crc32b   = {};
   ToISO    to_iso   = {};
   ROMTags  romtags  = {};
+  Verify   verify   = {};
+  Sign     sign     = {};
+  SignFile signfile = {};
+  DecryptFile decryptfile = {};
+  EncryptFile encryptfile = {};
 };

--- a/src/pathvec.hpp
+++ b/src/pathvec.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/subcommand.hpp
+++ b/src/subcommand.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -28,8 +28,13 @@ namespace Subcommand
   void identify(const Options::Identify &options);
   void unpack(const Options::Unpack &options);
   void pack(const Options::Pack &options);
+  void repack(const Options::Repack &options);
   void rename(const Options::Rename &options);
-  void crc32b(const Options::Crc32b &options);
   void to_iso(const Options::ToISO &options);
   void romtags(const Options::ROMTags &options);
+  void verify(const Options::Verify &options);
+  void sign(const Options::Sign &options);
+  void sign_file(const Options::SignFile &);
+  void decrypt_file(const Options::DecryptFile &);
+  void encrypt_file(const Options::EncryptFile &);
 }

--- a/src/subcommand_decrypt_file.cpp
+++ b/src/subcommand_decrypt_file.cpp
@@ -1,0 +1,104 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "subcommand.hpp"
+
+#include "error.hpp"
+#include "options.hpp"
+#include "tdo_boot_code_crypto.hpp"
+#include "tdo_safe_narrow.hpp"
+
+#include "fmt.hpp"
+
+#include <fstream>
+#include <vector>
+
+static
+void
+_decrypt_file(std::fstream &fs_)
+{
+  // Mirrors Portfolio OS CD-DIPIR boot-file deobfuscation in
+  // `portfolio_os/src/dipir/cdipir.c` (DecryptBlock()).
+  std::vector<char> data;
+
+  fs_.seekg(0,std::ios::end);
+  if(fs_.fail())
+    throw Error("decrypt-file: failed to seek to end of file");
+
+  const std::streampos end_pos = fs_.tellg();
+  if(end_pos == std::streampos(-1))
+    throw Error("decrypt-file: failed to read file size");
+
+  fs_.seekg(0,std::ios::beg);
+  if(fs_.fail())
+    throw Error("decrypt-file: failed to seek to start of file");
+
+  // OperaFS targets a 32-bit platform; any input file must fit in u32
+  // bytes. Route through checked_narrow_s64_to_u32 so an oversized
+  // file (or a -1 sentinel from a failed tellg that slipped past the
+  // explicit check above) produces a clear error rather than a
+  // bad_alloc from data.resize(SIZE_MAX) or a silent wrap downstream.
+  const s64 filesize_signed = static_cast<s64>(end_pos);
+  if(filesize_signed < 0)
+    throw Error("decrypt-file: negative file size");
+  const u32 filesize =
+    TDO::checked_narrow_s64_to_u32(filesize_signed,"decrypt-file file size");
+
+  data.resize(filesize);
+
+  fs_.read(data.data(),static_cast<std::streamsize>(filesize));
+  if(fs_.fail() && !fs_.eof())
+    throw Error("decrypt-file: failed to read file contents");
+
+  TDO::decrypt_boot_code_range(data.data(),
+                               TDO::boot_code_crypto_aligned_size(data.size()));
+
+  fs_.seekp(0,std::ios::beg);
+  if(fs_.fail())
+    throw Error("decrypt-file: failed to seek for write");
+  fs_.write(data.data(),static_cast<std::streamsize>(filesize));
+  if(fs_.fail())
+    throw Error("decrypt-file: failed to write file contents");
+}
+
+void
+Subcommand::decrypt_file(const Options::DecryptFile &opts_)
+{
+  bool failed;
+
+  failed = false;
+  for(const auto &filepath : opts_.filepaths)
+    {
+      std::fstream fs;
+
+      fs.open(filepath,std::ios::binary|std::ios::in|std::ios::out);
+      if(!fs.is_open())
+        {
+          fmt::print(stderr,"3dt: error opening {}\n",filepath);
+          failed = true;
+          continue;
+        }
+
+      ::_decrypt_file(fs);
+
+      fs.close();
+    }
+
+  if(failed)
+    throw Error("decrypt-file failed");
+}

--- a/src/subcommand_encrypt_file.cpp
+++ b/src/subcommand_encrypt_file.cpp
@@ -1,0 +1,104 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "subcommand.hpp"
+
+#include "error.hpp"
+#include "options.hpp"
+#include "tdo_boot_code_crypto.hpp"
+#include "tdo_safe_narrow.hpp"
+
+#include "fmt.hpp"
+
+#include <fstream>
+#include <vector>
+
+static
+void
+_encrypt_file(std::fstream &fs_)
+{
+  // Mirrors Portfolio OS CD-DIPIR inverse transform for boot payloads in
+  // `portfolio_os/src/dipir/cdipir.c` (DecryptBlock()).
+  std::vector<char> data;
+
+  fs_.seekg(0,std::ios::end);
+  if(fs_.fail())
+    throw Error("encrypt-file: failed to seek to end of file");
+
+  const std::streampos end_pos = fs_.tellg();
+  if(end_pos == std::streampos(-1))
+    throw Error("encrypt-file: failed to read file size");
+
+  fs_.seekg(0,std::ios::beg);
+  if(fs_.fail())
+    throw Error("encrypt-file: failed to seek to start of file");
+
+  // OperaFS targets a 32-bit platform; any input file must fit in u32
+  // bytes. Route through checked_narrow_s64_to_u32 so an oversized
+  // file (or a -1 sentinel from a failed tellg that slipped past the
+  // explicit check above) produces a clear error rather than a
+  // bad_alloc from data.resize(SIZE_MAX) or a silent wrap downstream.
+  const s64 filesize_signed = static_cast<s64>(end_pos);
+  if(filesize_signed < 0)
+    throw Error("encrypt-file: negative file size");
+  const u32 filesize =
+    TDO::checked_narrow_s64_to_u32(filesize_signed,"encrypt-file file size");
+
+  data.resize(filesize);
+
+  fs_.read(data.data(),static_cast<std::streamsize>(filesize));
+  if(fs_.fail() && !fs_.eof())
+    throw Error("encrypt-file: failed to read file contents");
+
+  TDO::encrypt_boot_code_range(data.data(),
+                               TDO::boot_code_crypto_aligned_size(data.size()));
+
+  fs_.seekp(0,std::ios::beg);
+  if(fs_.fail())
+    throw Error("encrypt-file: failed to seek for write");
+  fs_.write(data.data(),static_cast<std::streamsize>(filesize));
+  if(fs_.fail())
+    throw Error("encrypt-file: failed to write file contents");
+}
+
+void
+Subcommand::encrypt_file(const Options::EncryptFile &opts_)
+{
+  bool failed;
+
+  failed = false;
+  for(const auto &filepath : opts_.filepaths)
+    {
+      std::fstream fs;
+
+      fs.open(filepath,std::ios::binary|std::ios::in|std::ios::out);
+      if(!fs.is_open())
+        {
+          fmt::print(stderr,"3dt: error opening {}\n",filepath);
+          failed = true;
+          continue;
+        }
+
+      _encrypt_file(fs);
+
+      fs.close();
+    }
+
+  if(failed)
+    throw Error("encrypt-file failed");
+}

--- a/src/subcommand_identify.cpp
+++ b/src/subcommand_identify.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -154,18 +154,15 @@ namespace
   }
 
   static
-  Error
+  void
   identify(const PrintFunc &printfunc_,
            const fs::path  &filepath_,
-           std::istream    &is_)
+           std::iostream   &ios_)
   {
-    Error err;
     PrintData data;
     TDO::DiscIdentifier identifier;
 
-    err = identifier.identify(is_);
-    if(err)
-      return err;
+    identifier.identify(ios_);
 
     data.filename        = filepath_;
     data.label           = identifier.label;
@@ -175,8 +172,6 @@ namespace
     data.partial_matches = identifier.partial_matches;
 
     printfunc_(data);
-
-    return {};
   }
 
   static
@@ -184,18 +179,18 @@ namespace
   identify(const PrintFunc &printfunc_,
            const fs::path  &filepath_)
   {
-    Error err;
-    std::ifstream ifs;
+    std::fstream fs;
 
-    ifs.open(filepath_,std::ios::binary);
-    if(!ifs.good())
-      return Log::error_stream_open(filepath_);
+    fs.open(filepath_,std::ios::binary|std::ios::in);
+    if(!fs.good())
+      {
+        Log::error_stream_open(filepath_);
+        throw Error("failed to open");
+      }
 
-    err = ::identify(printfunc_,filepath_,ifs);
-    if(err)
-      Log::error(err);
+    ::identify(printfunc_,filepath_,fs);
 
-    ifs.close();
+    fs.close();
   }
 
   static
@@ -216,11 +211,26 @@ namespace Subcommand
   void
   identify(const Options::Identify &options_)
   {
+    bool failed;
     PrintFunc printfunc;
 
     printfunc = get_print_func(options_.format);
+    failed = false;
 
     for(auto &filepath : options_.filepaths)
-      ::identify(printfunc,filepath);
+      {
+        try
+          {
+            ::identify(printfunc,filepath);
+          }
+        catch(const std::exception &e)
+          {
+            fmt::print(stderr,"3dt: {} - {}\n",e.what(),filepath);
+            failed = true;
+          }
+      }
+
+    if(failed)
+      throw Error("identify failed");
   }
 }

--- a/src/subcommand_info.cpp
+++ b/src/subcommand_info.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -76,13 +76,33 @@ namespace
                label_.root_directory_block_count,
                label_.root_directory_block_size,
                label_.root_directory_last_avatar_index);
-    for(unsigned int i = 0; i <= label_.root_directory_last_avatar_index; i++)
+    // Cap the iteration by the avatar_list's fixed capacity rather
+    // than trusting root_directory_last_avatar_index, which on a
+    // malformed/odd label may exceed the on-disc array (-> OOB read)
+    // or even be UINT32_MAX (-> the original `i <= last_idx` form
+    // looped forever once unsigned i wrapped past UINT_MAX). Cast
+    // through u64 so the `+ 1` cannot itself wrap when last_idx is
+    // UINT32_MAX. Print what the array actually holds; warn if the
+    // disc label says there are more.
+    const auto avatar_capacity = label_.root_directory_avatar_list.size();
+    const uint32_t last_idx    = label_.root_directory_last_avatar_index;
+    const bool last_idx_oob =
+      (static_cast<uint64_t>(last_idx) + 1 > avatar_capacity);
+    const uint32_t print_count =
+      last_idx_oob
+      ? static_cast<uint32_t>(avatar_capacity)
+      : (last_idx + 1);
+    for(uint32_t i = 0; i < print_count; i++)
       fmt::print("   - {}\n",label_.root_directory_avatar_list[i]);
-    if(label_.volume_flags & VOLUME_FLAG_M2)
-      fmt::print(" - num_rom_tags: {}\n"
-                 " - application_id: {}\n",
-                 label_.num_rom_tags,
-                 label_.application_id);
+    if(last_idx_oob)
+      fmt::print("   (note: root_directory_last_avatar_index={} "
+                 "exceeds avatar_list capacity {})\n",
+                 last_idx,avatar_capacity);
+    // if(label_.volume_flags & VOLUME_FLAG_M2)
+    //   fmt::print(" - num_rom_tags: {}\n"
+    //              " - application_id: {}\n",
+    //              label_.num_rom_tags,
+    //              label_.application_id);
     fmt::print(" - file_count: {}\n"
 
                " - total_data_size: {}\n",
@@ -150,65 +170,44 @@ namespace
   }
 
   static
-  Error
+  void
   get_label(TDO::FileStream &stream_,
             TDO::DiscLabel  &label_)
   {
-    try
-      {
-        stream_.data_byte_seek(0);
-        stream_.read(label_);
-
-        return {};
-      }
-    catch(const Error &err)
-      {
-        return err;
-      }
+    stream_.data_byte_seek(0);
+    stream_.read(label_);
   }
 
   static
-  Error
+  void
   get_extra_info(TDO::FileStream &stream_,
                  uint32_t        &file_count_,
                  uint32_t        &total_data_size_)
   {
-    Error err;
     TDO::FilesystemStats fsstats;
 
-    err = fsstats.collect(stream_);
-    if(err)
-      return err;
+    fsstats.collect(stream_);
 
     file_count_      = fsstats.file_count;
     total_data_size_ = fsstats.total_data_size;
-
-    return {};
   }
 
   static
-  Error
+  void
   info(const PrintFunc &printfunc_,
        TDO::FileStream &stream_)
   {
-    Error err;
     uint32_t file_count;
     uint32_t total_data_size;
     TDO::DiscLabel label;
 
-    err = ::get_label(stream_,label);
-    if(err)
-      return err;
+    ::get_label(stream_,label);
 
     file_count = 0;
     total_data_size = 0;
-    err = ::get_extra_info(stream_,file_count,total_data_size);
-    if(err)
-      return err;
+    ::get_extra_info(stream_,file_count,total_data_size);
 
     printfunc_(stream_.filepath(),label,file_count,total_data_size);
-
-    return {};
   }
 
   static
@@ -216,19 +215,17 @@ namespace
   info(const PrintFunc &printfunc_,
        const fs::path  &filepath_)
   {
-    Error err;
     TDO::FileStream stream;
 
-    err = stream.open(filepath_);
-    if(err)
-      return Log::error(err);
+    stream.open(filepath_);
 
     if(!stream.good())
-      return Log::error_stream_open(filepath_);
+      {
+        Log::error_stream_open(filepath_);
+        throw Error("failed to open");
+      }
 
-    err = ::info(printfunc_,stream);
-    if(err)
-      return Log::error(err);
+    ::info(printfunc_,stream);
 
     stream.close();
   }
@@ -240,11 +237,26 @@ namespace Subcommand
   void
   info(const Options::Info &options_)
   {
+    bool failed;
     PrintFunc printfunc;
 
     printfunc = get_print_function(options_);
+    failed = false;
 
     for(auto &filepath : options_.filepaths)
-      ::info(printfunc,filepath);
+      {
+        try
+          {
+            ::info(printfunc,filepath);
+          }
+        catch(const std::exception &e)
+          {
+            fmt::print(stderr,"3dt: {} - {}\n",e.what(),filepath);
+            failed = true;
+          }
+      }
+
+    if(failed)
+      throw Error("info failed");
   }
 }

--- a/src/subcommand_list.cpp
+++ b/src/subcommand_list.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -19,13 +19,14 @@
 #include "log.hpp"
 #include "options.hpp"
 #include "tdo_fs_walker.hpp"
+#include "tdo_safe_narrow.hpp"
 
 #include "fmt.hpp"
 
 #include <fstream>
 
 namespace fs = std::filesystem;
-typedef std::function<void(const fs::path&,const TDO::DirectoryRecord&,const uint32_t,TDO::DevStream&)> Printer;
+typedef std::function<void(const std::string&,const TDO::DirectoryRecord&,const uint32_t,TDO::DevStream&)> Printer;
 
 
 static
@@ -51,6 +52,24 @@ starts_with(const fs::path &base_,
 }
 
 static
+std::string
+display_path(const fs::path    &parent_,
+             const std::string &filename_)
+{
+  std::string path;
+
+  path = parent_.generic_string();
+  if(!path.empty() && !filename_.empty() && (filename_[0] != '/'))
+    path += "/";
+  if(filename_.empty())
+    path += "<invalid empty filename>";
+  else
+    path += filename_;
+
+  return path;
+}
+
+static
 void
 default_header()
 {
@@ -59,7 +78,7 @@ default_header()
 
 static
 void
-default_printer(const fs::path             &filepath_,
+default_printer(const std::string          &filepath_,
                 const TDO::DirectoryRecord &record_,
                 const uint32_t              record_pos_,
                 TDO::DevStream             &stream_)
@@ -90,7 +109,7 @@ offset_header()
 
 static
 void
-file_offset_printer(const fs::path             &filepath_,
+file_offset_printer(const std::string          &filepath_,
                     const TDO::DirectoryRecord &record_,
                     const uint32_t              record_pos_,
                     TDO::DevStream             &stream_)
@@ -103,7 +122,32 @@ file_offset_printer(const fs::path             &filepath_,
   dir_char      = (record_.is_directory() ? 'd' : '-');
   readonly_char = (record_.is_readonly() ? 'r' : '-');
   for_fs_char   = (record_.is_for_fs() ? 'f' : '-');
-  avatar        = stream_.data_block_to_file_offset(record_.avatar_list[0]);
+  if(record_.avatar_list.empty())
+    {
+      avatar = 0u;
+    }
+  else
+    {
+      // OperaFS targets a 32-bit platform; the avatar's file offset
+      // must fit in u32. Compute in s64 so we can detect overflow.
+      // The list subcommand surfaces what's in the image, including
+      // malformed entries: catch the helper's throw so one bad row
+      // does not abort the whole listing (Subcommand::list has no
+      // try/catch around walker.walk()), warn to stderr, and display
+      // 0 in place of the unrepresentable offset.
+      const s64 file_offset =
+        stream_.data_block_to_file_offset(record_.avatar_list[0]);
+      try
+        {
+          avatar = TDO::checked_narrow_s64_to_u32(file_offset,
+                                                  "avatar file offset for " + filepath_);
+        }
+      catch(const Error &e)
+        {
+          fmt::print(stderr,"3dt: warning: {}, displaying 0\n",e.what());
+          avatar = 0u;
+        }
+    }
   fmt::print("{}{}{} {:11L} {:#010x} {:4s} {:#010x} {:#010x} {}\n",
              dir_char,
              readonly_char,
@@ -118,7 +162,7 @@ file_offset_printer(const fs::path             &filepath_,
 
 static
 void
-block_offset_printer(const fs::path             &filepath_,
+block_offset_printer(const std::string          &filepath_,
                      const TDO::DirectoryRecord &record_,
                      const uint32_t              record_pos_,
                      TDO::DevStream             &stream_)
@@ -126,10 +170,43 @@ block_offset_printer(const fs::path             &filepath_,
   char dir_char;
   char readonly_char;
   char for_fs_char;
+  std::uint32_t record_block;
+  std::uint32_t avatar;
 
   dir_char      = (record_.is_directory() ? 'd' : '-');
   readonly_char = (record_.is_readonly() ? 'r' : '-');
   for_fs_char   = (record_.is_for_fs() ? 'f' : '-');
+
+  // Defensive: a malformed image can produce device_block_size() == 0
+  // (volume_block_size on disc was 0). Listing is a lenient inspection
+  // path -- warn, display 0, continue rather than SIGFPE on
+  // integer-divide-by-zero.
+  const u64 dev_block_size = stream_.device_block_size();
+  if(dev_block_size == 0)
+    {
+      fmt::print(stderr,
+                 "3dt: warning: device_block_size is 0 for {}, "
+                 "displaying 0 for record block index\n",
+                 filepath_);
+      record_block = 0u;
+    }
+  else
+    {
+      // record_pos_ is u32 and dev_block_size is u64, so the quotient
+      // is bounded by record_pos_ -- a direct narrow back to u32 is
+      // safe.
+      record_block =
+        static_cast<u32>(static_cast<u64>(record_pos_) / dev_block_size);
+    }
+
+  // Mirror file_offset_printer's empty-avatar guard: indexing [0] on
+  // an empty std::vector is UB. The listing path tolerates a record
+  // with no avatars by displaying 0.
+  if(record_.avatar_list.empty())
+    avatar = 0u;
+  else
+    avatar = record_.avatar_list[0];
+
   fmt::print("{}{}{} {:11L} {:#010x} {:4s} {:#010x} {:#010x} {}\n",
              dir_char,
              readonly_char,
@@ -137,8 +214,8 @@ block_offset_printer(const fs::path             &filepath_,
              record_.byte_count,
              record_.unique_identifier,
              record_.type_str(),
-             record_pos_ / stream_.device_block_size(),
-             record_.avatar_list[0],
+             record_block,
+             avatar,
              filepath_);
 }
 
@@ -192,7 +269,27 @@ public:
     if(!starts_with(base_filter,filepath_))
       return;
 
-    _printer(filepath_,record_,record_pos_,stream_);
+    _printer(filepath_.generic_string(),record_,record_pos_,stream_);
+  }
+
+  Error
+  invalid_filename(const std::filesystem::path &parent_,
+                   const std::string           &filename_,
+                   const TDO::DirectoryRecord  &record_,
+                   const uint32_t               record_pos_,
+                   const Error                 &err_,
+                   TDO::DevStream              &stream_)
+  {
+    std::string filepath;
+
+    if(!starts_with(base_filter,parent_))
+      return Error();
+
+    filepath = display_path(parent_,filename_);
+    _printer(filepath,record_,record_pos_,stream_);
+    fmt::print(stderr,"3dt: {} - {}\n",err_.str,filepath);
+
+    return Error();
   }
 
 public:
@@ -207,19 +304,19 @@ namespace Subcommand
   void
   list(const Options::List &opts_)
   {
-    Error err;
-    std::ifstream ifs;
+    std::fstream fs;
     ListCallbacks callbacks(opts_);
-    TDO::FSWalker walker(ifs,callbacks);
+    TDO::FSWalker walker(fs,callbacks);
 
-    ifs.open(opts_.filepath,std::ios::binary);
-    if(!ifs.good())
-      return  Log::error_stream_open(opts_.filepath);
+    fs.open(opts_.filepath,std::ios::binary|std::ios::in);
+    if(!fs.good())
+      {
+        Log::error_stream_open(opts_.filepath);
+        throw Error("list failed");
+      }
 
-    err = walker.walk();
-    if(err)
-      Log::error(err);
+    walker.walk();
 
-    ifs.close();
+    fs.close();
   }
 }

--- a/src/subcommand_pack.cpp
+++ b/src/subcommand_pack.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -16,13 +16,1734 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
+#include "log.hpp"
+#include "fmt.hpp"
+#include "json.hpp"
 #include "options.hpp"
+#include "subcommand.hpp"
+#include "temp_path.hpp"
+#include "tdo_directory_record.hpp"
+#include "tdo_disc_format.hpp"
+#include "tdo_disc_label.hpp"
+#include "tdo_disc_packer.hpp"
+#include "tdo_disc_signer.hpp"
+#include "tdo_file_stream.hpp"
+#include "tdo_fs_walker.hpp"
+#include "tdo_rsa.h"
+#include "tdo_safe_narrow.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <random>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+  using json = nlohmann::json;
+  using Entry = TDO::DiscManifestEntry;
+  using EntryKind = TDO::DiscManifestEntryKind;
+
+  static constexpr u32 FIRST_FILE_BLOCK = 2;
+  static constexpr const char *DEFAULT_LAYOUT_FILENAME = "layout.json";
+
+  struct LayoutRecord
+  {
+    std::string path;
+    u32         flags;
+    u32         unique_identifier;
+    u32         type;
+    u32         block_size;
+    u32         byte_count;
+    u32         block_count;
+    u32         burst;
+    u32         gap;
+    u32         start_block;
+    u32         record_file_offset;
+    u32         record_size;
+    std::vector<u32> avatar_list;
+    u32         order;
+  };
+
+  struct AllocatedRange
+  {
+    u64         start_block;
+    u64         end_block;
+    std::string label;
+    std::string special_key;
+    bool        implicit;
+  };
+
+  typedef std::unordered_map<std::string,LayoutRecord> LayoutMap;
+
+  static
+  std::string
+  lowercase(const std::string &str_)
+  {
+    std::string rv;
+
+    rv.reserve(str_.size());
+    for(unsigned char c : str_)
+      rv.push_back(std::tolower(c));
+
+    return rv;
+  }
+
+  static
+  std::string
+  path_key(const fs::path &path_)
+  {
+    return lowercase(path_.lexically_normal().generic_string());
+  }
+
+  static
+  std::string
+  display_path(const fs::path &path_)
+  {
+    std::string path;
+
+    path = path_.generic_string();
+    return path.empty() ? std::string("/") : path;
+  }
+
+  static
+  std::string
+  special_key(const fs::path &path_)
+  {
+    std::string key;
+
+    key = path_key(path_);
+    if((key == "disc label") || (key == "rom_tags"))
+      return key;
+
+    return {};
+  }
+
+  static
+  bool
+  is_unpacked_metadata_file(const fs::path &path_)
+  {
+    const std::string key = lowercase(path_.filename().string());
+
+    return ((key == DEFAULT_LAYOUT_FILENAME) ||
+            (key == "disc label") ||
+            (key == "rom_tags") ||
+            (key == "signatures"));
+  }
+
+  static
+  std::string
+  range_string(const AllocatedRange &range_)
+  {
+    if(range_.end_block == (range_.start_block + 1))
+      return std::to_string(range_.start_block);
+
+    return (std::to_string(range_.start_block) + "-" +
+            std::to_string(range_.end_block - 1));
+  }
+
+  static
+  bool
+  same_name(const Entry      &entry_,
+            const char *const name_)
+  {
+    return (lowercase(entry_.name) == name_);
+  }
+
+  static
+  u32
+  random_unique_identifier()
+  {
+    std::random_device random_device;
+    std::uniform_int_distribution<u32> distribution(1,std::numeric_limits<u32>::max());
+
+    return distribution(random_device);
+  }
+
+  static
+  void
+  apply_pack_unique_identifiers(const Options::Pack &options_,
+                                TDO::DiscManifest  &manifest_,
+                                const bool          preserve_unspecified_ = false)
+  {
+    if(!preserve_unspecified_ || options_.volume_unique_identifier_set)
+      manifest_.disc_label.volume_unique_identifier =
+        options_.volume_unique_identifier != 0 ?
+        options_.volume_unique_identifier : random_unique_identifier();
+    if(!preserve_unspecified_ || options_.root_unique_identifier_set)
+      manifest_.disc_label.root_unique_identifier =
+        options_.root_unique_identifier != 0 ?
+        options_.root_unique_identifier : random_unique_identifier();
+    manifest_.root.unique_identifier = manifest_.disc_label.root_unique_identifier;
+  }
+
+  static
+  u32
+  block_count_for_size(u64 size_,
+                       u32 block_size_ = TDO::BLOCK_SIZE)
+  {
+    if(size_ == 0)
+      return 0;
+    if(block_size_ == 0)
+      throw Error("block size must be non-zero");
+
+    return TDO::checked_narrow_u64_to_u32(((size_ + block_size_ - 1) / block_size_),
+                                          "block count");
+  }
+
+  static
+  u32
+  physical_block_count(const Entry &entry_)
+  {
+    u64 bytes;
+
+    if(entry_.block_count == 0)
+      return 0;
+    if(entry_.block_size == 0)
+      throw Error("block size must be non-zero");
+
+    bytes = static_cast<u64>(entry_.block_count) * entry_.block_size;
+
+    return TDO::checked_narrow_u64_to_u32(((bytes + TDO::BLOCK_SIZE - 1) / TDO::BLOCK_SIZE),
+                                          "physical block count");
+  }
+
+  static
+  u32
+  type_from_string(const std::string &str_)
+  {
+    u32 type;
+    std::string padded;
+
+    type = 0;
+    padded = str_;
+    padded.resize(4,' ');
+    for(char c : padded)
+      type = ((type << 8) | static_cast<u8>(c));
+
+    return type;
+  }
+
+  static
+  u32
+  file_type(const fs::path &path_)
+  {
+    std::string ext;
+
+    ext = path_.extension().string();
+    if(ext.empty())
+      return 0;
+    if(ext[0] == '.')
+      ext.erase(ext.begin());
+    if(ext.empty())
+      return 0;
+    if(ext.size() > 4)
+      ext.resize(4);
+
+    return type_from_string(ext);
+  }
+
+  static
+  bool
+  is_supported_source(const fs::directory_entry &entry_)
+  {
+    return (entry_.is_directory() || entry_.is_regular_file());
+  }
+
+  static
+  void
+  reject_symlink(const fs::directory_entry &entry_)
+  {
+    std::error_code ec;
+    const bool is_link = fs::is_symlink(entry_.path(),ec);
+    // Match reject_symlink_path: fs::is_symlink(path, ec) returns false
+    // in both the "not a symlink" and "status query failed" cases.
+    // Treat any error as fail-closed to avoid silently passing a real
+    // symlink whose stat() failed for a permission/race reason. The
+    // throwing directory_entry::is_symlink() overload would surface a
+    // generic filesystem_error for the same condition.
+    if(ec)
+      throw Error("failed to determine symlink status of pack source: " +
+                  entry_.path().string() + ": " + ec.message());
+    if(is_link)
+      throw Error("symlinks are not supported as pack sources: " +
+                  entry_.path().string());
+  }
+
+  static
+  void
+  reject_symlink_path(const fs::path &path_)
+  {
+    std::error_code ec;
+    const bool is_link = fs::is_symlink(path_,ec);
+    // fs::is_symlink(path, ec) returns false in both the "not a
+    // symlink" and "status query failed" cases. Treat any error as
+    // fail-closed to avoid silently passing a real symlink whose
+    // stat() failed for a permission/race reason.
+    if(ec)
+      throw Error("failed to determine symlink status of pack source: " +
+                  path_.string() + ": " + ec.message());
+    if(is_link)
+      throw Error("symlinks are not supported as pack sources: " +
+                  path_.string());
+  }
+
+  static
+  std::string
+  printable_filename(const std::string &name_)
+  {
+    std::string out;
+    out.reserve(name_.size());
+    for(char c : name_)
+      {
+        const unsigned char uc = static_cast<unsigned char>(c);
+        if(uc < 0x20 || uc == 0x7f)
+          {
+            char buf[5];
+            std::snprintf(buf,sizeof(buf),"\\x%02x",uc);
+            out.append(buf);
+          }
+        else
+          {
+            out.push_back(c);
+          }
+      }
+    return out;
+  }
+
+  static
+  void
+  validate_filename(const std::string &name_)
+  {
+    if(name_.empty())
+      throw Error("empty filename is not supported");
+    if(name_.size() >= FILESYSTEM_MAX_NAME_LEN)
+      throw Error("filename is too long for OperaFS: " + printable_filename(name_));
+    if((name_ == ".") || (name_ == ".."))
+      throw Error("reserved filename is not supported: " + name_);
+    for(char c : name_)
+      {
+        const unsigned char uc = static_cast<unsigned char>(c);
+        if(uc < 0x20 || uc == 0x7f)
+          throw Error("filename contains control character: " + printable_filename(name_));
+        if(c == '/' || c == '\\')
+          throw Error("filename contains path separator: " + printable_filename(name_));
+      }
+  }
+
+  static
+  std::unique_ptr<Entry>
+  make_entry(const fs::directory_entry &dirent_)
+  {
+    auto entry = std::make_unique<Entry>();
+
+    entry->src_path           = dirent_.path();
+    entry->name               = dirent_.path().filename().string();
+    entry->kind               = EntryKind::Normal;
+    entry->directory          = dirent_.is_directory();
+    entry->unique_identifier  = 0;
+    entry->type               = (entry->directory ? DR_TYPE_DIRECTORY : file_type(dirent_.path()));
+    entry->flags              = DR_FLAG_IS_READONLY;
+    entry->block_size         = TDO::BLOCK_SIZE;
+    entry->byte_count         = 0;
+    entry->data_byte_count    = 0;
+    entry->block_count        = 0;
+    entry->burst              = 0;
+    entry->gap                = 0;
+    entry->start_block        = 0;
+    entry->record_file_offset = 0;
+    entry->record_size        = 0;
+
+    validate_filename(entry->name);
+
+    if(entry->directory)
+      {
+        entry->flags |= (DR_FLAG_IS_DIRECTORY | DR_FLAG_IS_FOR_FILESYSTEM);
+      }
+    else
+      {
+        u64 size;
+        std::error_code ec;
+
+        size = fs::file_size(dirent_.path(),ec);
+        if(ec)
+          throw Error("failed to stat input file: " +
+                      dirent_.path().string() + ": " + ec.message());
+        entry->byte_count      = TDO::checked_narrow_u64_to_u32(size,"file size");
+        entry->data_byte_count = entry->byte_count;
+        entry->block_count     = block_count_for_size(size);
+        if(lowercase(entry->name) == "launchme")
+          entry->type = DR_TYPE_CATAPULT;
+      }
+
+    return entry;
+  }
+
+  static
+  void
+  read_directory(const fs::path &path_,
+                 Entry         &parent_,
+                 bool           root_ = true)
+  {
+    std::vector<fs::directory_entry> dirents;
+
+    for(const auto &dirent : fs::directory_iterator(path_))
+      {
+        reject_symlink(dirent);
+        if(root_ && dirent.is_regular_file() && is_unpacked_metadata_file(dirent.path()))
+          continue;
+        if(!is_supported_source(dirent))
+          throw Error("unsupported filesystem entry: " + dirent.path().string());
+        dirents.emplace_back(dirent);
+      }
+
+    std::sort(dirents.begin(),
+              dirents.end(),
+              [](const fs::directory_entry &lhs_,
+                 const fs::directory_entry &rhs_)
+              {
+                return lhs_.path().filename() < rhs_.path().filename();
+              });
+
+    for(const auto &dirent : dirents)
+      {
+        auto entry = make_entry(dirent);
+
+        if(entry->directory)
+          read_directory(dirent.path(),*entry,false);
+
+        parent_.children.emplace_back(std::move(entry));
+      }
+  }
+
+  static
+  Entry*
+  find_root_child(Entry       &root_,
+                  const char  *name_)
+  {
+    for(auto &entry : root_.children)
+      {
+        if(same_name(*entry,name_))
+          return entry.get();
+      }
+
+    return nullptr;
+  }
+
+  static
+  Entry&
+  add_root_child(Entry       &root_,
+                 const char  *name_)
+  {
+    auto entry = std::make_unique<Entry>();
+
+    entry->name               = name_;
+    entry->kind               = EntryKind::Normal;
+    entry->directory          = false;
+    entry->unique_identifier  = 0;
+    entry->type               = 0;
+    entry->flags              = DR_FLAG_IS_READONLY;
+    entry->block_size         = TDO::BLOCK_SIZE;
+    entry->byte_count         = 0;
+    entry->data_byte_count    = 0;
+    entry->block_count        = 0;
+    entry->burst              = 0;
+    entry->gap                = 0;
+    entry->start_block        = 0;
+    entry->record_file_offset = 0;
+    entry->record_size        = 0;
+
+    root_.children.emplace_back(std::move(entry));
+
+    return *root_.children.back();
+  }
+
+  static
+  void
+  setup_disc_label_entry(Entry &entry_)
+  {
+    entry_.name            = "Disc label";
+    entry_.kind            = EntryKind::DiscLabel;
+    entry_.directory       = false;
+    entry_.type            = DR_TYPE_LABEL;
+    entry_.flags           = (DR_FLAG_IS_READONLY | DR_FLAG_IS_FOR_FILESYSTEM);
+    entry_.block_size      = TDO::BLOCK_SIZE;
+    entry_.byte_count      = sizeof(TDO::DiscLabel);
+    entry_.data_byte_count = 0;
+    entry_.block_count     = 1;
+    entry_.burst           = 0;
+    entry_.gap             = 0;
+    entry_.start_block     = 0;
+    entry_.avatar_list     = {0};
+    entry_.children.clear();
+  }
+
+  static
+  void
+  setup_romtags_entry(Entry &entry_)
+  {
+    entry_.name            = "rom_tags";
+    entry_.kind            = EntryKind::ROMTags;
+    entry_.directory       = false;
+    entry_.type            = 0;
+    entry_.flags           = DR_FLAG_IS_READONLY;
+    entry_.block_size      = TDO::BLOCK_SIZE;
+    entry_.byte_count      = 0;
+    entry_.data_byte_count = 0;
+    entry_.block_count     = 1;
+    entry_.burst           = 0;
+    entry_.gap             = 0;
+    entry_.start_block     = 1;
+    entry_.avatar_list     = {1};
+    entry_.children.clear();
+  }
+
+  static
+  void
+  setup_signatures_entry(Entry &entry_)
+  {
+    entry_.name            = "signatures";
+    entry_.kind            = EntryKind::Signatures;
+    entry_.directory       = false;
+    entry_.type            = 0;
+    entry_.flags           = DR_FLAG_IS_READONLY;
+    entry_.block_size      = TDO::BLOCK_SIZE;
+    entry_.data_byte_count = 0;
+    entry_.burst           = 0;
+    entry_.gap             = 0;
+    entry_.children.clear();
+  }
+
+  static
+  void
+  sort_root_entries(Entry &root_)
+  {
+    std::sort(root_.children.begin(),
+              root_.children.end(),
+              [](const std::unique_ptr<Entry> &lhs_,
+                 const std::unique_ptr<Entry> &rhs_)
+              {
+                if(lhs_->kind == EntryKind::DiscLabel)
+                  return true;
+                if(rhs_->kind == EntryKind::DiscLabel)
+                  return false;
+                return (lhs_->name < rhs_->name);
+              });
+  }
+
+  static
+  void
+  add_or_replace_synthetic_entries(Entry &root_,
+                                   bool   reserve_signing_space_)
+  {
+    Entry *entry;
+
+    entry = find_root_child(root_,"disc label");
+    if(entry == nullptr)
+      entry = &add_root_child(root_,"Disc label");
+    setup_disc_label_entry(*entry);
+
+    entry = find_root_child(root_,"rom_tags");
+    if(entry == nullptr)
+      entry = &add_root_child(root_,"rom_tags");
+    setup_romtags_entry(*entry);
+
+    if(reserve_signing_space_)
+      {
+        entry = find_root_child(root_,"signatures");
+        if(entry == nullptr)
+          entry = &add_root_child(root_,"signatures");
+        setup_signatures_entry(*entry);
+      }
+
+    sort_root_entries(root_);
+  }
+
+  static
+  void
+  assign_unique_identifiers(Entry &entry_,
+                            u32   &next_id_)
+  {
+    for(auto &child : entry_.children)
+      {
+        child->unique_identifier = next_id_++;
+        if(child->directory)
+          assign_unique_identifiers(*child,next_id_);
+      }
+  }
+
+  static
+  u32
+  parse_u32(const std::string &str_,
+            const char        *label_)
+  {
+    char *end;
+    unsigned long value;
+
+    end = nullptr;
+    value = std::strtoul(str_.c_str(),&end,0);
+    if((end == str_.c_str()) || (*end != '\0'))
+      throw Error(std::string("invalid layout ") + label_ + ": " + str_);
+    if(value > std::numeric_limits<u32>::max())
+      throw Error(std::string("layout ") + label_ + " is too large");
+
+    return static_cast<u32>(value);
+  }
+
+  static
+  u32
+  json_u32(const json &json_,
+           const char *label_)
+  {
+    if(json_.is_string())
+      return parse_u32(json_.get<std::string>(),label_);
+    // nlohmann/json's get<u32> truncates silently when the JSON value
+    // exceeds UINT32_MAX. Route both signed and unsigned integer
+    // representations through the canonical checked-narrow helpers so
+    // overflow throws with the offending value in the message, matching
+    // the string path's parse_u32 behavior. Reject non-integer types
+    // explicitly so floats / nulls / objects don't slip through as 0.
+    if(json_.is_number_unsigned())
+      return TDO::checked_narrow_u64_to_u32(json_.get<u64>(),
+                                            std::string("layout ") + label_);
+    if(json_.is_number_integer())
+      return TDO::checked_narrow_s64_to_u32(json_.get<s64>(),
+                                            std::string("layout ") + label_);
+    throw Error(std::string("layout ") + label_ + " is not an integer");
+  }
+
+  static
+  u32
+  json_u32_value(const json &json_,
+                 const char *key_,
+                 u32         default_)
+  {
+    if(!json_.contains(key_))
+      return default_;
+    return json_u32(json_.at(key_),key_);
+  }
+
+  static
+  std::vector<u32>
+  json_u32_vec(const json &json_)
+  {
+    std::vector<u32> rv;
+
+    for(const auto &value : json_)
+      rv.emplace_back(json_u32(value,"avatar_list"));
+
+    return rv;
+  }
+
+  static
+  void
+  read_fixed_string(const json        &json_,
+                    const char        *key_,
+                    std::array<char,32> &dst_)
+  {
+    std::string value;
+
+    dst_.fill(0);
+    value = json_.value(key_,std::string());
+    memcpy(&dst_[0],value.c_str(),std::min<std::size_t>(value.size(),dst_.size() - 1));
+  }
+
+  static
+  void
+  apply_layout_disc_label(TDO::DiscManifest &manifest_,
+                          const json        &layout_)
+  {
+    const json &label = layout_.at("disc_label");
+
+    manifest_.disc_label.record_type =
+      TDO::checked_narrow_u32_to_u8(json_u32_value(label,"record_type",RECORD_STD_VOLUME),
+                                    "record_type");
+    manifest_.disc_label.volume_sync_bytes.fill(VOLUME_SYNC_BYTE);
+    if(label.contains("volume_sync_bytes"))
+      {
+        auto values = json_u32_vec(label.at("volume_sync_bytes"));
+        if(values.size() > manifest_.disc_label.volume_sync_bytes.size())
+          throw Error("layout volume_sync_bytes is too long");
+        for(std::size_t i = 0; i < values.size(); i++)
+          {
+            // VSBArray slots are char (8-bit). The JSON values pass
+            // through json_u32_vec, so silently truncating here would
+            // mask out-of-range layout entries. Reject them instead.
+            if(values[i] > std::numeric_limits<uint8_t>::max())
+              throw Error("layout volume_sync_bytes value is out of range");
+            manifest_.disc_label.volume_sync_bytes[i] = static_cast<char>(values[i]);
+          }
+      }
+    manifest_.disc_label.volume_structure_version =
+      TDO::checked_narrow_u32_to_u8(json_u32_value(label,"volume_structure_version",VOLUME_STRUCTURE_OPERA_READONLY),
+                                    "volume_structure_version");
+    manifest_.disc_label.volume_flags =
+      TDO::checked_narrow_u32_to_u8(json_u32_value(label,"volume_flags",0),
+                                    "volume_flags");
+    read_fixed_string(label,"volume_commentary",manifest_.disc_label.volume_commentary);
+    read_fixed_string(label,"volume_identifier",manifest_.disc_label.volume_identifier);
+    manifest_.disc_label.volume_unique_identifier = json_u32_value(label,"volume_unique_identifier",0);
+    manifest_.disc_label.volume_block_size = json_u32_value(label,"volume_block_size",TDO::BLOCK_SIZE);
+    manifest_.disc_label.volume_block_count = json_u32_value(label,"volume_block_count",0);
+    manifest_.disc_label.root_unique_identifier = json_u32_value(label,"root_unique_identifier",2);
+    manifest_.disc_label.root_directory_block_count = json_u32_value(label,"root_directory_block_count",0);
+    manifest_.disc_label.root_directory_block_size = json_u32_value(label,"root_directory_block_size",TDO::BLOCK_SIZE);
+    manifest_.disc_label.root_directory_last_avatar_index = json_u32_value(label,"root_directory_last_avatar_index",0);
+    if(manifest_.disc_label.root_directory_last_avatar_index >= manifest_.disc_label.root_directory_avatar_list.size())
+      throw Error("layout root directory avatar list is too large");
+    manifest_.disc_label.root_directory_avatar_list.fill(0);
+    if(label.contains("root_directory_avatar_list"))
+      {
+        auto values = json_u32_vec(label.at("root_directory_avatar_list"));
+        for(std::size_t i = 0; (i < values.size()) && (i < manifest_.disc_label.root_directory_avatar_list.size()); i++)
+          manifest_.disc_label.root_directory_avatar_list[i] = values[i];
+      }
+
+    manifest_.root.unique_identifier = manifest_.disc_label.root_unique_identifier;
+    manifest_.root.block_size = manifest_.disc_label.root_directory_block_size;
+    manifest_.root.block_count = manifest_.disc_label.root_directory_block_count;
+    manifest_.root.byte_count =
+      TDO::checked_narrow_u64_to_u32(static_cast<u64>(manifest_.root.block_count) * manifest_.root.block_size,
+                                     "root directory byte count");
+    manifest_.root.avatar_list.clear();
+    for(std::size_t i = 0; i <= manifest_.disc_label.root_directory_last_avatar_index; i++)
+      manifest_.root.avatar_list.emplace_back(manifest_.disc_label.root_directory_avatar_list[i]);
+    if(!manifest_.root.avatar_list.empty())
+      manifest_.root.start_block = manifest_.root.avatar_list[0];
+  }
+
+  static
+  LayoutMap
+  read_layout(const fs::path    &layout_,
+              TDO::DiscManifest &manifest_)
+  {
+    LayoutMap records;
+    std::ifstream is;
+    u32 order;
+    json layout;
+
+    is.open(layout_);
+    if(!is)
+      throw Error("failed to open layout file: " + layout_.string());
+
+    is >> layout;
+    if(layout.value("format",std::string()) != "3dt-operafs-layout")
+      throw Error("unsupported layout manifest format");
+    if(layout.contains("image") &&
+       (layout["image"].value("device_block_data_size",TDO::BLOCK_SIZE) != TDO::BLOCK_SIZE))
+      throw Error("packing NVRAM or other non-2048-byte images is not supported yet");
+    apply_layout_disc_label(manifest_,layout);
+    manifest_.total_blocks = manifest_.disc_label.volume_block_count;
+    manifest_.replay_layout = true;
+
+    order = 0;
+    for(const auto &entry_json : layout.at("entries"))
+      {
+        LayoutRecord record;
+
+        record.path               = fs::path(entry_json.at("path").get<std::string>()).lexically_normal().generic_string();
+        record.flags              = json_u32(entry_json.at("flags"),"flags");
+        record.unique_identifier  = json_u32(entry_json.at("unique_identifier"),"unique_identifier");
+        record.type               = json_u32(entry_json.at("type"),"type");
+        record.block_size         = json_u32_value(entry_json,"block_size",TDO::BLOCK_SIZE);
+        record.byte_count         = json_u32_value(entry_json,"byte_count",0);
+        record.block_count        = json_u32_value(entry_json,"block_count",0);
+        record.burst              = json_u32_value(entry_json,"burst",0);
+        record.gap                = json_u32_value(entry_json,"gap",0);
+        record.start_block        = json_u32_value(entry_json,"start_block",0);
+        record.record_file_offset = json_u32_value(entry_json,"record_file_offset",0);
+        record.record_size        = json_u32_value(entry_json,"record_size",0);
+        if(entry_json.contains("avatar_list"))
+          record.avatar_list = json_u32_vec(entry_json.at("avatar_list"));
+        if(record.avatar_list.empty())
+          record.avatar_list = {record.start_block};
+        record.start_block = record.avatar_list[0];
+        record.order = order++;
+
+        records[path_key(record.path)] = record;
+      }
+
+    return records;
+  }
+
+  static
+  void
+  apply_layout_record(Entry              &entry_,
+                      const LayoutRecord &record_)
+  {
+    entry_.unique_identifier  = record_.unique_identifier;
+    entry_.type               = record_.type;
+    entry_.flags              = (record_.flags & ~DR_FLAG_LAST_IN_MASK);
+    entry_.block_size         = record_.block_size;
+    entry_.byte_count         = record_.byte_count;
+    entry_.data_byte_count    = record_.byte_count;
+    entry_.block_count        = record_.block_count;
+    entry_.burst              = record_.burst;
+    entry_.gap                = record_.gap;
+    entry_.start_block        = record_.start_block;
+    entry_.record_file_offset = record_.record_file_offset;
+    entry_.record_size        = record_.record_size;
+    entry_.avatar_list        = record_.avatar_list;
+    if(entry_.directory)
+      entry_.flags |= DR_FLAG_IS_DIRECTORY;
+    else
+      entry_.flags &= ~DR_FLAG_IS_DIRECTORY;
+  }
+
+  static
+  u32
+  layout_order(const Entry     &entry_,
+               const fs::path  &path_,
+               const LayoutMap &layout_)
+  {
+    u32 order;
+
+    order = std::numeric_limits<u32>::max();
+
+    auto it = layout_.find(path_key(path_));
+    if(it != layout_.end())
+      order = std::min(order,it->second.order);
+
+    for(const auto &child : entry_.children)
+      order = std::min(order,layout_order(*child,path_ / child->name,layout_));
+
+    return order;
+  }
+
+  static
+  bool
+  apply_layout(Entry           &entry_,
+               const fs::path  &entry_path_,
+               const LayoutMap &layout_)
+  {
+    std::vector<Entry::Ptr> children;
+
+    for(auto &child : entry_.children)
+      {
+        fs::path child_path;
+        bool keep;
+
+        child_path = entry_path_ / child->name;
+
+        auto it = layout_.find(path_key(child_path));
+        keep = (it != layout_.end());
+        if(keep)
+          apply_layout_record(*child,it->second);
+
+        if(child->directory)
+          keep = (apply_layout(*child,child_path,layout_) || keep);
+
+        if(keep)
+          children.emplace_back(std::move(child));
+      }
+
+    std::vector<std::pair<u32,Entry::Ptr>> ordered;
+    ordered.reserve(children.size());
+    for(auto &child : children)
+      ordered.emplace_back(layout_order(*child,entry_path_ / child->name,layout_),
+                             std::move(child));
+
+    std::sort(ordered.begin(),
+              ordered.end(),
+              [](const auto &lhs_,
+                 const auto &rhs_)
+              {
+                if(lhs_.first != rhs_.first)
+                  return (lhs_.first < rhs_.first);
+                return (lhs_.second->name < rhs_.second->name);
+              });
+
+    children.clear();
+    for(auto &p : ordered)
+      children.emplace_back(std::move(p.second));
+
+    entry_.children = std::move(children);
+
+    return !entry_.children.empty();
+  }
+
+  static
+  void
+  validate_replay_file_sizes(Entry          &entry_,
+                             const fs::path &entry_path_)
+  {
+    if((entry_.block_count > 0) && (entry_.block_size == 0))
+      throw Error("layout entry has zero block size: " +
+                               display_path(entry_path_));
+
+    if(entry_.directory)
+      {
+        u32 required_blocks;
+
+        required_blocks = TDO::directory_block_count(entry_);
+        if(entry_.block_count < required_blocks)
+          throw Error("layout directory allocation too small: " +
+                                   display_path(entry_path_) + " needs " +
+                                   std::to_string(required_blocks) +
+                                   " blocks but has " +
+                                   std::to_string(entry_.block_count));
+        entry_.byte_count = TDO::checked_narrow_u64_to_u32(static_cast<u64>(entry_.block_count) * entry_.block_size,
+                                                           "directory byte count");
+      }
+    else if(entry_.kind == EntryKind::Normal)
+      {
+        u64 capacity;
+        u64 source_size;
+        u32 required_blocks;
+        std::error_code ec;
+
+        if(entry_.src_path.empty())
+          throw Error("layout entry has no source file: " + entry_path_.generic_string());
+
+        source_size = fs::file_size(entry_.src_path,ec);
+        if(ec)
+          throw Error("failed to stat layout source file: " +
+                      entry_.src_path.string() + " (" +
+                      display_path(entry_path_) + "): " + ec.message());
+        capacity = static_cast<u64>(entry_.block_count) * entry_.block_size;
+        if(source_size > capacity)
+          throw Error("layout byte count exceeds allocation: " +
+                                   display_path(entry_path_));
+        required_blocks = block_count_for_size(source_size,entry_.block_size);
+        if(entry_.block_count < required_blocks)
+          throw Error("layout file allocation too small: " +
+                                   display_path(entry_path_) + " needs " +
+                                   std::to_string(required_blocks) +
+                                   " blocks but has " +
+                                   std::to_string(entry_.block_count));
+
+        entry_.byte_count = TDO::checked_narrow_u64_to_u32(source_size,"file byte count");
+        entry_.data_byte_count = entry_.byte_count;
+      }
+
+    for(auto &child : entry_.children)
+      validate_replay_file_sizes(*child,entry_path_ / child->name);
+  }
+
+  static
+  void
+  compute_directory_sizes(Entry &entry_)
+  {
+    if(!entry_.directory)
+      return;
+
+    entry_.block_count = TDO::directory_block_count(entry_);
+    entry_.byte_count  = TDO::checked_narrow_u64_to_u32(static_cast<u64>(entry_.block_count) * TDO::BLOCK_SIZE,
+                                                        "directory byte count");
+
+    for(auto &child : entry_.children)
+      compute_directory_sizes(*child);
+  }
+
+  static
+  u32
+  sum_directory_blocks(const Entry &entry_)
+  {
+    u64 blocks;
+
+    blocks = (entry_.directory ? entry_.block_count : 0);
+    for(const auto &child : entry_.children)
+      blocks += sum_directory_blocks(*child);
+
+    return TDO::checked_narrow_u64_to_u32(blocks,"sum of directory blocks");
+  }
+
+  static
+  u32
+  sum_file_blocks_without_signatures(const Entry &entry_)
+  {
+    u64 blocks;
+
+    blocks = 0;
+    if(!entry_.directory)
+      {
+        if((entry_.kind != EntryKind::DiscLabel) &&
+           (entry_.kind != EntryKind::ROMTags) &&
+           (entry_.kind != EntryKind::Signatures))
+          blocks += entry_.block_count;
+      }
+
+    for(const auto &child : entry_.children)
+      blocks += sum_file_blocks_without_signatures(*child);
+
+    return TDO::checked_narrow_u64_to_u32(blocks,"sum of file blocks");
+  }
+
+  static
+  u32
+  signature_digest_count_for_volume(u32 volume_blocks_)
+  {
+    u64 padded_blocks;
+
+    padded_blocks   = TDO::round_up(volume_blocks_,(TDO::LOG_BLOCK_SIZE / TDO::BLOCK_SIZE));
+
+    return TDO::checked_narrow_u64_to_u32((padded_blocks * TDO::BLOCK_SIZE) / TDO::LOG_BLOCK_SIZE,"signature digest count");
+  }
+
+  static
+  u32
+  required_signature_file_size_for_volume(u32 volume_blocks_)
+  {
+    return TDO::checked_narrow_u64_to_u32(TDO::signature_file_size_for_digest_count(signature_digest_count_for_volume(volume_blocks_)),
+                                          "signatures file size");
+  }
+
+  static
+  u32
+  required_signature_blocks_for_volume(u32 volume_blocks_)
+  {
+    return TDO::checked_narrow_u64_to_u32(required_signature_file_size_for_volume(volume_blocks_) / TDO::BLOCK_SIZE,
+                                          "signatures file block count");
+  }
+
+  static
+  u32
+  required_signature_blocks(u32 base_blocks_)
+  {
+    u32 sig_blocks;
+
+    sig_blocks = 1;
+    while(true)
+      {
+        u32 next_sig_blocks;
+
+        next_sig_blocks = required_signature_blocks_for_volume(base_blocks_ + sig_blocks);
+        if(next_sig_blocks == sig_blocks)
+          return sig_blocks;
+        sig_blocks = next_sig_blocks;
+      }
+  }
+
+  static
+  Entry*
+  find_signatures_entry(Entry &entry_)
+  {
+    if(entry_.kind == EntryKind::Signatures)
+      return &entry_;
+
+    for(auto &child : entry_.children)
+      {
+        Entry *rv;
+
+        rv = find_signatures_entry(*child);
+        if(rv != nullptr)
+          return rv;
+      }
+
+    return nullptr;
+  }
+
+  static
+  void
+  reserve_signatures_file(Entry &root_,
+                          u32    volume_blocks_ = 0)
+  {
+    Entry *entry;
+    u32 base_blocks;
+    u32 num_digests;
+    u32 record_size;
+    u32 sig_blocks;
+
+    entry = find_signatures_entry(root_);
+    if(entry == nullptr)
+      throw Error("layout removed required signatures file");
+
+    if(volume_blocks_ != 0)
+      {
+        num_digests = signature_digest_count_for_volume(volume_blocks_);
+        sig_blocks = TDO::checked_narrow_u64_to_u32(TDO::signature_file_size_for_digest_count(num_digests) / TDO::BLOCK_SIZE,
+                                                    "signatures file block count");
+        record_size = TDO::signature_record_size_for_digest_count(num_digests);
+      }
+    else
+      {
+        u64 acc = FIRST_FILE_BLOCK;
+        acc += sum_directory_blocks(root_);
+        acc += sum_file_blocks_without_signatures(root_);
+        base_blocks = TDO::checked_narrow_u64_to_u32(acc,"base block count");
+        sig_blocks  = required_signature_blocks(base_blocks);
+        num_digests = signature_digest_count_for_volume(
+                        TDO::checked_narrow_u64_to_u32(static_cast<u64>(base_blocks) + sig_blocks,
+                                                       "volume block count"));
+        record_size = TDO::signature_record_size_for_digest_count(num_digests);
+      }
+
+    entry->block_count = std::max(entry->block_count,sig_blocks);
+    entry->byte_count  = std::max(entry->byte_count,record_size);
+  }
+
+  static
+  u32
+  max_allocated_block(const Entry &entry_)
+  {
+    u32 max_block;
+    u32 physical_blocks;
+
+    max_block = 0;
+    physical_blocks = physical_block_count(entry_);
+    for(auto avatar : entry_.avatar_list)
+      max_block = std::max(max_block,
+                           TDO::checked_narrow_u64_to_u32(static_cast<u64>(avatar) + physical_blocks,
+                                                          "allocated block"));
+    if(entry_.avatar_list.empty() && (entry_.block_count > 0))
+      max_block = std::max(max_block,
+                           TDO::checked_narrow_u64_to_u32(static_cast<u64>(entry_.start_block) + physical_blocks,
+                                                          "allocated block"));
+    for(const auto &child : entry_.children)
+      max_block = std::max(max_block,max_allocated_block(*child));
+
+    return max_block;
+  }
+
+  static
+  void
+  ensure_replay_signatures_entry(Entry &root_,
+                                 u32   &next_id_,
+                                 u32    total_blocks_)
+  {
+    Entry *entry;
+
+    entry = find_signatures_entry(root_);
+    if(entry != nullptr)
+      return;
+
+    entry = &add_root_child(root_,"signatures");
+    setup_signatures_entry(*entry);
+    entry->unique_identifier = next_id_++;
+    entry->start_block = std::max(total_blocks_,max_allocated_block(root_));
+    entry->avatar_list = {entry->start_block};
+  }
+
+  static
+  std::vector<u32>
+  allocated_avatars(const Entry &entry_)
+  {
+    if(!entry_.avatar_list.empty())
+      return entry_.avatar_list;
+    if(entry_.block_count > 0)
+      return {entry_.start_block};
+
+    return {};
+  }
+
+  static
+  void
+  validate_special_placement(const Entry           &entry_,
+                             const fs::path        &entry_path_,
+                             const std::vector<u32> &avatars_)
+  {
+    std::string key;
+
+    key = special_key(entry_path_);
+    if(key.empty())
+      return;
+
+    if(key == "disc label")
+      {
+        if((entry_.block_count != 1) || avatars_.empty())
+          throw Error("layout cannot resize special file: " +
+                                   display_path(entry_path_));
+        if(avatars_[0] != 0)
+          throw Error("layout cannot relocate Disc label; it must use block 0");
+      }
+    else if(key == "rom_tags")
+      {
+        if((entry_.block_count > 1) || avatars_.empty())
+          throw Error("layout cannot resize special file: " +
+                                   display_path(entry_path_));
+        if(avatars_[0] != 1)
+          throw Error("layout cannot relocate rom_tags; it must use block 1");
+      }
+  }
+
+  static
+  void
+  add_allocated_range(std::vector<AllocatedRange> &ranges_,
+                      u64                         start_block_,
+                      u64                         block_count_,
+                      const std::string          &label_,
+                      const std::string          &special_key_,
+                      bool                        implicit_)
+  {
+    u64 end_block;
+
+    if(block_count_ == 0)
+      return;
+
+    end_block = start_block_ + block_count_;
+    if((end_block < start_block_) || (end_block > std::numeric_limits<u32>::max()))
+      throw Error("layout allocation is too large: " + label_);
+
+    ranges_.push_back({start_block_,end_block,label_,special_key_,implicit_});
+  }
+
+  static
+  void
+  collect_allocated_ranges(const Entry                 &entry_,
+                           const fs::path              &entry_path_,
+                           std::vector<AllocatedRange> &ranges_)
+  {
+    std::string key;
+    std::string label;
+    std::vector<u32> avatars;
+
+    key     = special_key(entry_path_);
+    label   = display_path(entry_path_);
+    avatars = allocated_avatars(entry_);
+
+    validate_special_placement(entry_,entry_path_,avatars);
+
+    // Original 3DO-packed images can contain zero-byte file records with a
+    // stale avatar that aliases another file. They have no logical data, so
+    // do not treat their block_count as an allocated range.
+    if(!entry_.directory &&
+       (entry_.kind == EntryKind::Normal) &&
+       (entry_.byte_count == 0))
+      return;
+
+    for(auto avatar : avatars)
+      add_allocated_range(ranges_,
+                          avatar,
+                          physical_block_count(entry_),
+                          label,
+                          key,
+                          false);
+
+    for(const auto &child : entry_.children)
+      collect_allocated_ranges(*child,entry_path_ / child->name,ranges_);
+  }
+
+  static
+  bool
+  same_implicit_special_range(const AllocatedRange &lhs_,
+                              const AllocatedRange &rhs_)
+  {
+    return ((lhs_.implicit != rhs_.implicit) &&
+            !lhs_.special_key.empty() &&
+            (lhs_.special_key == rhs_.special_key));
+  }
+
+  static
+  void
+  validate_no_block_overlaps(std::vector<AllocatedRange> &ranges_)
+  {
+    std::sort(ranges_.begin(),
+              ranges_.end(),
+              [](const AllocatedRange &lhs_,
+                 const AllocatedRange &rhs_)
+              {
+                if(lhs_.start_block != rhs_.start_block)
+                  return (lhs_.start_block < rhs_.start_block);
+                return (lhs_.end_block < rhs_.end_block);
+              });
+
+    for(std::size_t i = 0; i < ranges_.size(); i++)
+      {
+        for(std::size_t j = i; j > 0; j--)
+          {
+            const auto &lhs = ranges_[j - 1];
+            const auto &rhs = ranges_[i];
+
+            if(lhs.end_block <= rhs.start_block)
+              continue;
+            if(same_implicit_special_range(lhs,rhs))
+              continue;
+
+            throw Error("layout block overlap: " +
+                                     lhs.label + " blocks " + range_string(lhs) +
+                                     " overlaps " +
+                                     rhs.label + " blocks " + range_string(rhs));
+          }
+      }
+  }
+
+  static
+  void
+  validate_layout_allocations(const Entry &root_)
+  {
+    std::vector<AllocatedRange> ranges;
+
+    add_allocated_range(ranges,0,1,"Disc label","disc label",true);
+    add_allocated_range(ranges,1,1,"rom_tags","rom_tags",true);
+    collect_allocated_ranges(root_,fs::path(),ranges);
+    validate_no_block_overlaps(ranges);
+  }
+
+  static
+  void
+  allocate_directory_blocks(Entry &entry_,
+                            u32   &next_block_)
+  {
+    if(!entry_.directory)
+      return;
+
+    if(entry_.block_count > 0)
+      {
+        entry_.start_block = next_block_;
+        entry_.avatar_list = {entry_.start_block};
+        next_block_ = TDO::checked_add_u32(next_block_,
+                                           entry_.block_count,
+                                           "directory next_block accumulator");
+      }
+
+    for(auto &child : entry_.children)
+      allocate_directory_blocks(*child,next_block_);
+  }
+
+  static
+  void
+  allocate_file_blocks(Entry &entry_,
+                       u32   &next_block_)
+  {
+    if(!entry_.directory)
+      {
+        switch(entry_.kind)
+          {
+          case EntryKind::DiscLabel:
+          case EntryKind::ROMTags:
+            return;
+          case EntryKind::Normal:
+          case EntryKind::Signatures:
+            break;
+          }
+
+        if(entry_.block_count > 0)
+          {
+            entry_.start_block = next_block_;
+            entry_.avatar_list = {entry_.start_block};
+            next_block_ = TDO::checked_add_u32(next_block_,
+                                               entry_.block_count,
+                                               "file next_block accumulator");
+          }
+      }
+
+    for(auto &child : entry_.children)
+      allocate_file_blocks(*child,next_block_);
+  }
+
+  static
+  u32
+  allocate_blocks(Entry &root_)
+  {
+    u32 next_block;
+
+    next_block = FIRST_FILE_BLOCK;
+    allocate_directory_blocks(root_,next_block);
+    allocate_file_blocks(root_,next_block);
+
+    return next_block;
+  }
+
+  static
+  fs::path
+  canonicalize_for_containment(const fs::path &path_)
+  {
+    std::error_code ec;
+    // Absolutize first so weakly_canonical operates on an absolute path
+    // even when the input is a bare relative filename (e.g. `-o out.iso`).
+    // libstdc++'s weakly_canonical preserves a relative input verbatim
+    // when no on-disk prefix exists, which would let
+    // validate_output_location's iterator-prefix check silently miss
+    // containment violations (the relative output starts with "out.iso"
+    // while the input canonicalizes to "/abs/path/...", and the loop
+    // returns on the first segment mismatch).
+    fs::path absolute = fs::absolute(path_,ec);
+    if(ec || absolute.empty())
+      throw Error("failed to absolutize path for containment check: " +
+                  path_.string() +
+                  (ec ? (": " + ec.message()) : std::string()));
+    fs::path canonical = fs::weakly_canonical(absolute,ec);
+    // Fail closed. Falling back to lexically_normal on the unresolved
+    // path would let a symlinked input or an EACCES-on-traverse hide
+    // input/output overlap from validate_output_location, and an empty
+    // canonical_ would bypass the prefix check entirely (the loop runs
+    // zero iterations and the function returns silently).
+    if(ec || canonical.empty())
+      throw Error("failed to canonicalize path for containment check: " +
+                  path_.string() +
+                  (ec ? (": " + ec.message()) : std::string()));
+    return canonical;
+  }
+
+  static
+  void
+  validate_output_location(const fs::path &input_,
+                           const fs::path &output_)
+  {
+    fs::path input_abs;
+    fs::path output_abs;
+
+    input_abs  = canonicalize_for_containment(input_);
+    output_abs = canonicalize_for_containment(output_);
+
+    auto input_it = input_abs.begin();
+    auto output_it = output_abs.begin();
+    while((input_it != input_abs.end()) && (output_it != output_abs.end()))
+      {
+        if(*input_it != *output_it)
+          return;
+        ++input_it;
+        ++output_it;
+      }
+
+    if(input_it == input_abs.end())
+      throw Error("output image cannot be inside the input directory");
+  }
+
+  static
+  fs::path
+  layout_path_for(const Options::Pack &options_)
+  {
+    fs::path layout;
+
+    if(!options_.layout.empty())
+      return options_.layout;
+
+    layout = options_.input / DEFAULT_LAYOUT_FILENAME;
+    if(!fs::exists(layout))
+      return {};
+    if(!fs::is_regular_file(layout))
+      throw Error("layout path is not a regular file: " + layout.string());
+
+    std::error_code ec;
+    const std::uintmax_t sz = fs::file_size(layout,ec);
+    if(ec)
+      throw Error("failed to stat layout file: " +
+                  layout.string() + ": " + ec.message());
+    if(sz == 0)
+      {
+        // Auto-discovered layout file (no --layout argument). A
+        // 0-byte file most often comes from a killed unpack/repack
+        // that wrote the path before the body. Restore the prior
+        // behavior of treating that as "no layout, fresh pack" so
+        // the user is not forced to manually rm the stale file
+        // before pack will run, but warn so the stale file does not
+        // go unnoticed.
+        fmt::print(stderr,
+                   "3dt: warning: ignoring empty auto-discovered layout file: {}\n",
+                   layout.string());
+        return {};
+      }
+
+    return layout;
+  }
+
+
+
+  static
+  void
+  preflight_input_files(const Entry &entry_)
+  {
+    if(!entry_.directory && (entry_.kind == EntryKind::Normal))
+      {
+        std::ifstream is;
+
+        is.open(entry_.src_path,std::ios::binary);
+        if(!is)
+          throw Error("failed to open input file: " + entry_.src_path.string());
+      }
+
+    for(const auto &child : entry_.children)
+      preflight_input_files(*child);
+  }
+
+  static
+  void
+  verify_operafs_structure_file(const fs::path &path_)
+  {
+    TDO::FSWalker::Callbacks callbacks;
+    TDO::FileStream stream;
+
+    stream.open(path_);
+
+    TDO::FSWalker fsw(stream,callbacks);
+    fsw.walk();
+  }
+
+  static
+  void
+  list_packed_file(const std::string          &filepath_,
+                   const TDO::DirectoryRecord &record_)
+  {
+    char dir_char      = (record_.is_directory() ? 'd' : '-');
+    char readonly_char = (record_.is_readonly() ? 'r' : '-');
+    char for_fs_char   = (record_.is_for_fs() ? 'f' : '-');
+
+    fmt::print("{}{}{} {:11L} {:#010x} {:4s} {}\n",
+               dir_char,
+               readonly_char,
+               for_fs_char,
+               record_.byte_count,
+               record_.unique_identifier,
+               record_.type_str(),
+               filepath_);
+  }
+
+  class PackListCallbacks final : public TDO::FSWalker::Callbacks
+  {
+  public:
+    void
+    begin()
+    {
+      fmt::print("Flags      Size         ID Type Filename\n");
+    }
+
+    void
+    operator()(const std::filesystem::path &,
+               const TDO::DirectoryHeader &,
+               TDO::DevStream &)
+    {
+    }
+
+    void
+    operator()(const std::filesystem::path &filepath_,
+               const TDO::DirectoryRecord  &record_,
+               const uint32_t,
+               TDO::DevStream &)
+    {
+      list_packed_file(filepath_.generic_string(),record_);
+    }
+
+    Error
+    invalid_filename(const std::filesystem::path &parent_,
+                     const std::string           &filename_,
+                     const TDO::DirectoryRecord  &record_,
+                     const uint32_t,
+                     const Error                 &,
+                     TDO::DevStream &)
+    {
+      std::string filepath = display_path(parent_);
+      if(!filepath.empty() && filepath != "/")
+        filepath += "/";
+      filepath += filename_;
+      list_packed_file(filepath,record_);
+      return Error();
+    }
+  };
+
+  static
+  void
+  list_packed_image(const fs::path &path_)
+  {
+    TDO::FileStream stream;
+
+    stream.open(path_);
+
+    PackListCallbacks callbacks;
+    TDO::FSWalker fsw(stream,callbacks);
+
+    fmt::print("{}:\n  - Contents:\n",path_);
+    fsw.walk();
+  }
+
+  static
+  TDO::DiscManifest
+  create_manifest(const Options::Pack &options_)
+  {
+    LayoutMap layout;
+    TDO::DiscManifest manifest{};
+    fs::path layout_path;
+    u32 next_id;
+
+    validate_output_location(options_.input,options_.output);
+    reject_symlink_path(options_.input);
+
+    manifest.output = options_.output;
+    manifest.disc_label = {};
+    manifest.disc_label.record_type = RECORD_STD_VOLUME;
+    manifest.disc_label.volume_sync_bytes.fill(VOLUME_SYNC_BYTE);
+    manifest.disc_label.volume_structure_version = VOLUME_STRUCTURE_OPERA_READONLY;
+    manifest.disc_label.volume_flags = 0;
+    if(options_.volume_commentary.size() >= VOLUME_COM_LEN)
+      throw Error("volume commentary is too long for OperaFS");
+    memcpy(&manifest.disc_label.volume_commentary[0],
+           options_.volume_commentary.c_str(),
+           options_.volume_commentary.size());
+    if(options_.volume_label.size() >= VOLUME_ID_LEN)
+      throw Error("volume label is too long for OperaFS");
+    memcpy(&manifest.disc_label.volume_identifier[0],
+           options_.volume_label.c_str(),
+           options_.volume_label.size());
+    manifest.disc_label.volume_block_size = TDO::BLOCK_SIZE;
+    manifest.disc_label.root_directory_block_size = TDO::BLOCK_SIZE;
+    manifest.total_blocks = 0;
+    manifest.replay_layout = false;
+    manifest.root.name = "";
+    manifest.root.kind = EntryKind::Normal;
+    manifest.root.directory = true;
+    apply_pack_unique_identifiers(options_,manifest);
+    manifest.root.type = DR_TYPE_DIRECTORY;
+    manifest.root.flags = (DR_FLAG_IS_DIRECTORY |
+                           DR_FLAG_IS_READONLY |
+                           DR_FLAG_IS_FOR_FILESYSTEM);
+    manifest.root.block_size = TDO::BLOCK_SIZE;
+    manifest.root.byte_count = 0;
+    manifest.root.block_count = 0;
+    manifest.root.burst = 0;
+    manifest.root.gap = 0;
+    manifest.root.start_block = 0;
+    manifest.root.record_file_offset = 0;
+    manifest.root.record_size = 0;
+
+    layout_path = layout_path_for(options_);
+    if(!layout_path.empty())
+      layout = read_layout(layout_path,manifest);
+
+    read_directory(options_.input,manifest.root);
+    add_or_replace_synthetic_entries(manifest.root,true);
+
+    next_id = 2;
+    assign_unique_identifiers(manifest.root,next_id);
+
+    if(!layout_path.empty())
+      {
+        apply_layout(manifest.root,fs::path(),layout);
+        apply_pack_unique_identifiers(options_,manifest,true);
+        ensure_replay_signatures_entry(manifest.root,
+                                       next_id,
+                                       manifest.total_blocks);
+      }
+
+    if(manifest.replay_layout)
+      {
+        {
+          u32 total_blocks;
+
+          do
+            {
+              total_blocks = manifest.total_blocks;
+              reserve_signatures_file(manifest.root,manifest.total_blocks);
+              manifest.total_blocks = std::max(manifest.total_blocks,
+                                               max_allocated_block(manifest.root));
+            }
+          while(manifest.total_blocks != total_blocks);
+        }
+        validate_replay_file_sizes(manifest.root,fs::path());
+        validate_layout_allocations(manifest.root);
+      }
+    else
+      {
+        compute_directory_sizes(manifest.root);
+        reserve_signatures_file(manifest.root);
+        manifest.total_blocks = allocate_blocks(manifest.root);
+      }
+
+    return manifest;
+  }
+}
 
 namespace Subcommand
 {
   void
   pack(const Options::Pack &options_)
   {
+    fs::path output_path;
+    fs::path temp_output_path;
+    TDO::DiscManifest manifest;
 
+    try
+      {
+        manifest = create_manifest(options_);
+        preflight_input_files(manifest.root);
+      }
+    catch(const std::exception &e)
+      {
+        throw Error(e.what());
+      }
+
+    if(options_.dry_run)
+      {
+        fmt::print("{}:\n"
+                   "  - dry run: true\n"
+                   "  - total blocks: {}\n"
+                   "  - total bytes: {}\n",
+                   options_.output,
+                   manifest.total_blocks,
+                   static_cast<u64>(manifest.total_blocks) * TDO::BLOCK_SIZE);
+        return;
+      }
+
+    output_path = manifest.output;
+    try
+      {
+        temp_output_path = temp_path_for(output_path);
+        manifest.output = temp_output_path;
+      }
+    catch(const std::exception &e)
+      {
+        throw Error(e.what());
+      }
+
+    try
+      {
+        TDO::pack_disc_image(manifest);
+        list_packed_image(temp_output_path);
+
+        const bool recreate_layout_specials = (manifest.replay_layout &&
+                                               options_.sign);
+        const auto digest_check_count =
+          static_cast<std::uint8_t>(options_.signature_digest_check_count);
+
+        if(options_.mark)
+          {
+            TDO::mark_disc_image(temp_output_path,
+                                 (options_.sign ?
+                                  "packed and signed" :
+                                  "packed"));
+          }
+
+        if(recreate_layout_specials)
+          {
+            TDO::recreate_layout_special_files(temp_output_path,
+                                               options_.sign,
+                                               false,
+                                               options_.banner_romtag,
+                                               options_.billstuff_romtag,
+                                               digest_check_count);
+          }
+
+        if(options_.sign && !recreate_layout_specials)
+          {
+            TDO::sign_disc_image(temp_output_path,
+                                 false,
+                                 true,
+                                 options_.banner_romtag,
+                                 options_.billstuff_romtag,
+                                 digest_check_count);
+          }
+
+        if(options_.sign)
+          {
+            Options::Verify verify_opts{};
+
+            fmt::print("{}:\n  - Verifying signed image\n",temp_output_path);
+            verify_opts.filepaths.emplace_back(temp_output_path);
+            Subcommand::verify(verify_opts);
+          }
+        else
+          {
+            fmt::print("{}:\n  - Verifying OperaFS structure\n",temp_output_path);
+            verify_operafs_structure_file(temp_output_path);
+          }
+
+        fs::rename(temp_output_path,output_path);
+      }
+    catch(const std::exception &e)
+      {
+        std::error_code ec;
+
+        fs::remove(temp_output_path,ec);
+        throw;
+      }
   }
 }

--- a/src/subcommand_rename.cpp
+++ b/src/subcommand_rename.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -53,30 +53,28 @@ namespace l
   }
 
   static
-  Error
+  void
   rename(const fs::path &filepath_,
          const bool      take_first_,
-         std::istream   &is_)
+         std::iostream  &ios_)
   {
-    Error err;
     TDO::DiscIdentifier identifier;
 
-    err = identifier.identify(is_);
-    if(err)
-      return err;
+    identifier.identify(ios_);
 
     if(identifier.full_matches.empty())
-      return {"no match found"};
+      throw Error("no match found");
 
     if((identifier.full_matches.size() == 1) || (take_first_ == true))
-      return l::rename(filepath_,identifier.full_matches[0],identifier.disc_image_ext);
+      {
+        l::rename(filepath_,identifier.full_matches[0],identifier.disc_image_ext);
+        return;
+      }
 
     fmt::print("{}: skipping due to multiple matches - ",filepath_);
     for(auto match : identifier.full_matches)
       fmt::print("{}",match->name);
     fmt::print("\n");
-
-    return {};
   }
 
   static
@@ -84,21 +82,18 @@ namespace l
   rename(const fs::path &filepath_,
          const bool      take_first_)
   {
-    Error err;
-    std::ifstream ifs;
+    std::fstream fs;
 
-    ifs.open(filepath_,std::ios::binary);
-    if(!ifs.good())
+    fs.open(filepath_,std::ios::binary|std::ios::in);
+    if(!fs.good())
       {
         Log::error_stream_open(filepath_);
-        return;
+        throw Error("failed to open");
       }
 
-    err = l::rename(filepath_,take_first_,ifs);
-    if(err)
-      Log::error(err);
+    l::rename(filepath_,take_first_,fs);
 
-    ifs.close();
+    fs.close();
   }
 }
 
@@ -107,7 +102,23 @@ namespace Subcommand
   void
   rename(const Options::Rename &options_)
   {
+    bool failed;
+
+    failed = false;
     for(auto &filepath : options_.filepaths)
-      l::rename(filepath,options_.take_first);
+      {
+        try
+          {
+            l::rename(filepath,options_.take_first);
+          }
+        catch(const std::exception &e)
+          {
+            fmt::print(stderr,"3dt: {} - {}\n",e.what(),filepath);
+            failed = true;
+          }
+      }
+
+    if(failed)
+      throw Error("rename failed");
   }
 }

--- a/src/subcommand_repack.cpp
+++ b/src/subcommand_repack.cpp
@@ -1,0 +1,174 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "subcommand.hpp"
+#include "temp_path.hpp"
+#include "tdo_disc_unpacker.hpp"
+#include "tdo_file_stream.hpp"
+
+#include "fmt.hpp"
+#include "options.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+  static
+  std::string
+  label_string(const std::array<char,32> &arr_)
+  {
+    return std::string(arr_.data());
+  }
+
+  static
+  fs::path
+  create_temp_dir(const fs::path &base_)
+  {
+    std::random_device rd;
+    const std::string stem = base_.stem().string();
+    for(std::uint32_t attempt = 0; attempt < 1000; attempt++)
+      {
+        fs::path tmp = fs::temp_directory_path() /
+          fmt::format("3dt-repack-{:08x}-{:08x}-{}",rd(),rd(),stem);
+        std::error_code ec;
+        if(fs::create_directory(tmp,ec))
+          return tmp;
+        if(ec && !fs::exists(tmp))
+          throw Error("failed to create temporary directory: " +
+                      tmp.string() + ": " + ec.message());
+      }
+    throw Error("failed to find a unique temporary directory name");
+  }
+
+  // FileExtractor used to override before()/after() to write each
+  // file body to _dstpath. That duplicated TDO::DiscUnpacker::Impl's
+  // own extraction (Impl reopens the same path with std::ios::trunc
+  // and rewrites the same bytes the callback just wrote), giving
+  // every repack a 2x I/O cost and silently undoing any
+  // transformation a callback might apply. The unpacker now
+  // provides no-op defaults for before()/after(), so repack just
+  // needs a default Callback to drive the walk; Impl handles the
+  // actual extraction.
+
+  static
+  void
+  repack_one(const fs::path        &input_,
+             const fs::path        &target_,
+             const Options::Repack &opts_)
+  {
+    TDO::DiscLabel disc_label;
+
+    {
+      TDO::FileStream stream;
+      stream.open(input_);
+      disc_label = stream.disc_label();
+      stream.close();
+    }
+
+    fs::path temp_dir;
+    fs::path temp_output;
+
+    try
+      {
+        temp_dir = create_temp_dir(input_);
+
+        {
+          std::fstream ifs;
+          ifs.open(input_,std::ios::binary|std::ios::in);
+          // Default Callback (all hooks are no-op virtuals); Impl
+          // handles the directory-tree creation and file extraction.
+          TDO::DiscUnpacker::Callback cb;
+          TDO::DiscUnpacker unpacker(ifs,cb);
+          unpacker.unpack(temp_dir);
+        }
+
+        Options::Pack pack_opts{};
+        pack_opts.input = temp_dir;
+        pack_opts.output = target_;
+        pack_opts.banner_romtag = opts_.banner_romtag;
+        pack_opts.billstuff_romtag = opts_.billstuff_romtag;
+        pack_opts.mark = opts_.mark;
+        pack_opts.sign = opts_.sign;
+        pack_opts.signature_digest_check_count = opts_.signature_digest_check_count;
+
+        pack_opts.volume_commentary = label_string(disc_label.volume_commentary);
+        pack_opts.volume_label = label_string(disc_label.volume_identifier);
+        pack_opts.volume_unique_identifier = disc_label.volume_unique_identifier;
+        pack_opts.volume_unique_identifier_set = true;
+        pack_opts.root_unique_identifier = disc_label.root_unique_identifier;
+        pack_opts.root_unique_identifier_set = true;
+
+        Subcommand::pack(pack_opts);
+      }
+    catch(...)
+      {
+        std::error_code ec;
+        fs::remove_all(temp_dir,ec);
+        throw;
+      }
+
+    {
+      std::error_code ec;
+      fs::remove_all(temp_dir,ec);
+      if(ec)
+        fmt::print(stderr,
+                   "3dt: warning: failed to clean up temp dir {}: {}\n",
+                   temp_dir.string(),ec.message());
+    }
+  }
+}
+
+namespace Subcommand
+{
+  void
+  repack(const Options::Repack &opts_)
+  {
+    bool failed;
+
+    failed = false;
+    if(!opts_.output.empty() && (opts_.filepaths.size() != 1))
+      throw Error("--output requires exactly one input image");
+
+    for(const auto &filepath : opts_.filepaths)
+      {
+        fs::path target;
+
+        target = opts_.output.empty() ? filepath : opts_.output;
+        try
+          {
+            repack_one(filepath,target,opts_);
+          }
+        catch(const std::exception &e)
+          {
+            fmt::print(stderr,"3dt: {} - {}\n",e.what(),filepath);
+            failed = true;
+          }
+      }
+
+    if(failed)
+      throw Error("repack failed");
+  }
+}

--- a/src/subcommand_romtags.cpp
+++ b/src/subcommand_romtags.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -49,61 +49,9 @@ print_romtags_csv_header(void)
 }
 
 static
-std::string
-rsanode_type(const uint8_t type_)
-{
-  switch(type_)
-    {
-    case RSA_MUST_RSA:
-      return "MUST_RSA";
-    case RSA_NEWKNEWNEWGNUBOOT:
-      return "NEWKNEWNEWGNUBOOT";
-    case RSA_OS:
-      return "OS";
-    case RSA_BILLSTUFF:
-      return "BILLSTUFF";
-    case RSA_BLOCKS_ALWAYS:
-      return "BLOCKS_ALWAYS";
-    case RSA_MISCCODE:
-      return "MISCCODE";
-    case RSA_SIGNATURE_BLOCK:
-      return "SIGNATURE_BLOCK";
-    case RSA_APPSPLASH:
-      return "APPSPLASH";
-    case RSA_DEPOTCONFIG:
-      return "DEPOTCONFIG";
-    case RSA_DEVICE_INFO:
-      return "DEVICE_INFO";
-    case RSA_DEV_PERMS:
-      return "DEV_PERMS";
-    case RSA_BOOT_OVERLAY:
-      return "BOOT_OVERLAY";
-
-    case RSA_M2_OS:
-      return "M2_OS";
-    case RSA_M2_MISCCODE:
-      return "M2_MISCCODE";
-    case RSA_M2_DRIVER:
-      return "M2_DRIVER";
-    case RSA_M2_DEVDIPIR:
-      return "M2_DEVDIPIR";
-    case RSA_M2_APPBANNER:
-      return "M2_APPBANNER";
-    case RSA_M2_APP_KEYS:
-      return "M2_APP_KEYS";
-    case RSA_OPERA_CD_IMAGE:
-      return "OPERA_CD_IMAGE";
-    case RSA_M2_ICON:
-      return "M2_ICON";
-    }
-
-  return fmt::format("{:#04x}",type_);
-}
-
-static
 void
-romtags_human(const std::filesystem::path &filepath_,
-              TDO::DevStream              &stream_)
+romtags_csv(const std::filesystem::path &filepath_,
+            TDO::DevStream              &stream_)
 {
   TDO::ROMTagVec tags;
   CSVWriter csv(",");
@@ -115,7 +63,7 @@ romtags_human(const std::filesystem::path &filepath_,
       csv << filepath_.string()
           << fmt::format("{:#04x}",tag.sub_systype)
           << fmt::format("{:#04x}",tag.type)
-          << fmt::format("{}",rsanode_type(tag.type))
+          << fmt::format("{}",tag.type_str())
           << fmt::format("{}",tag.version)
           << fmt::format("{}",tag.revision)
           << fmt::format("{:x}",tag.flags)
@@ -127,42 +75,80 @@ romtags_human(const std::filesystem::path &filepath_,
   fmt::print("{}\n",csv.toString());
 }
 
+static
+void
+romtags_human(const std::filesystem::path &filepath_,
+               TDO::DevStream              &stream_)
+{
+  TDO::ROMTagVec tags;
+
+  tags = stream_.romtags();
+  fmt::print("{}:\n", filepath_.filename());
+  for(const auto &tag : tags)
+    {
+       fmt::print("  - Offset:      {}\n"
+                  "    SubSysType:  {:#04x}\n"
+                  "    Type:        {:#04x} ({})\n"
+                  "    Version:     {}\n"
+                  "    Revision:    {}\n"
+                  "    Flags:       {:#x}\n"
+                  "    TypeSpec:    {}\n"
+                  "    Size:        {}\n",
+                  tag.offset,
+                  tag.sub_systype,
+                  tag.type,
+                  tag.type_str(),
+                  tag.version,
+                  tag.revision,
+                  tag.flags,
+                  tag.type_specific,
+                 tag.size);
+    }
+}
+
 void
 Subcommand::romtags(const Options::ROMTags &opts_)
 {
+  bool failed;
   bool printed_header = false;
 
+  failed = false;
   for(const auto &filepath : opts_.filepaths)
     {
       try
         {
-          Error err;
           TDO::FileStream stream;
 
-          err = stream.open(filepath);
-          if(err)
-            {
-              fmt::print(stderr,"3dt: {} - {}\n",err.str,filepath);
-              continue;
-            }
+          stream.open(filepath);
 
           if(!stream.has_romtags())
             {
               fmt::print(stderr,"3dt: {} does not contain ROMTags\n",filepath);
+              failed = true;
               continue;
             }
 
-          if(printed_header == false)
+          if(opts_.format == "csv")
             {
-              print_romtags_csv_header();
-              printed_header = true;
+              if(printed_header == false)
+                {
+                  print_romtags_csv_header();
+                  printed_header = true;
+                }
+              romtags_csv(filepath,stream);
             }
-
-          ::romtags_human(filepath,stream);
+          else
+            {
+              romtags_human(filepath,stream);
+            }
         }
-      catch(const Error &err)
+      catch(const std::exception &e)
         {
-          fmt::print(stderr,"3dt: {} - {}\n",err.str,filepath);
+          fmt::print(stderr,"3dt: {} - {}\n",e.what(),filepath);
+          failed = true;
         }
     }
+
+  if(failed)
+    throw Error("romtags failed");
 }

--- a/src/subcommand_sign.cpp
+++ b/src/subcommand_sign.cpp
@@ -1,0 +1,118 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "subcommand.hpp"
+#include "tdo_disc_signer.hpp"
+
+#include "fmt.hpp"
+#include "options.hpp"
+#include "temp_path.hpp"
+#include "types_ints.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+  static
+  void
+  verify_signed_image(const fs::path &path_)
+  {
+    Options::Verify verify_opts{};
+
+    verify_opts.filepaths.emplace_back(path_);
+    Subcommand::verify(verify_opts);
+  }
+
+
+
+  static
+  void
+  sign_one(const fs::path     &input_,
+           const fs::path     &target_,
+           const Options::Sign &opts_)
+  {
+    fs::path temp_path;
+
+    if(!opts_.output.empty() && fs::exists(target_))
+      throw Error("output already exists: " + target_.string());
+
+    temp_path = temp_path_for(target_);
+    try
+      {
+        const auto digest_check_count =
+          static_cast<std::uint8_t>(opts_.signature_digest_check_count);
+
+        fs::copy_file(input_,temp_path,fs::copy_options::none);
+
+        TDO::sign_disc_image(temp_path,
+                             opts_.mark,
+                             !opts_.force,
+                             opts_.banner_romtag,
+                             opts_.billstuff_romtag,
+                             digest_check_count);
+
+        verify_signed_image(temp_path);
+
+        fs::rename(temp_path,target_);
+      }
+    catch(...)
+      {
+        std::error_code ec;
+
+        fs::remove(temp_path,ec);
+        throw;
+      }
+  }
+}
+
+namespace Subcommand
+{
+  void
+  sign(const Options::Sign &opts_)
+  {
+    bool failed;
+
+    failed = false;
+    if(!opts_.output.empty() && (opts_.filepaths.size() != 1))
+      throw Error("--output requires exactly one input image");
+
+    for(const auto &filepath : opts_.filepaths)
+      {
+        fs::path target;
+
+        target = opts_.output.empty() ? filepath : opts_.output;
+        try
+          {
+            sign_one(filepath,target,opts_);
+          }
+        catch(const std::exception &e)
+          {
+            fmt::print(stderr,"3dt: {} - {}\n",e.what(),filepath);
+            failed = true;
+          }
+      }
+
+    if(failed)
+      throw Error("signing failed");
+  }
+}

--- a/src/subcommand_sign_file.cpp
+++ b/src/subcommand_sign_file.cpp
@@ -1,0 +1,195 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "md5.h"
+#include "tdo_rsa.h"
+
+#include "error.hpp"
+#include "subcommand.hpp"
+
+#include "options.hpp"
+
+#include "fmt.hpp"
+#include "fmt_rsa512_sig.hpp"
+#include "fmt_md5_digest.hpp"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+  static
+  std::vector<char>
+  read_file_prefix(const fs::path &filepath_,
+                   const u64       size_)
+  {
+    std::ifstream is;
+    std::vector<char> data;
+
+    data.resize(size_);
+    is.open(filepath_,std::ios::binary);
+    if(!is)
+      throw Error("error opening " + filepath_.string());
+    if(size_ > 0)
+      is.read(data.data(),data.size());
+    if(!is)
+      throw Error("error reading " + filepath_.string());
+
+    return data;
+  }
+
+  static
+  void
+  read_signature_trailer(const fs::path &filepath_,
+                         rsa512_sig_t   sig_)
+  {
+    std::ifstream is;
+
+    is.open(filepath_,std::ios::binary);
+    if(!is)
+      throw Error("error opening " + filepath_.string());
+    is.seekg(-static_cast<std::streamoff>(sizeof(rsa512_sig_t)),std::ios::end);
+    is.read((char*)sig_,sizeof(rsa512_sig_t));
+    if(!is)
+      throw Error("error reading signature trailer from " + filepath_.string());
+  }
+
+  static
+  void
+  write_signature(const fs::path   &filepath_,
+                  const u64         offset_,
+                  const rsa512_sig_t sig_)
+  {
+    std::fstream fs;
+
+    fs.open(filepath_,std::ios::binary|std::ios::in|std::ios::out);
+    if(!fs)
+      throw Error("error opening " + filepath_.string());
+    fs.seekp(offset_,std::ios::beg);
+    fs.write((const char*)sig_,sizeof(rsa512_sig_t));
+    if(!fs)
+      throw Error("error writing signature to " + filepath_.string());
+  }
+
+  static
+  void
+  write_signature_output(const fs::path   &filepath_,
+                         const rsa512_sig_t sig_)
+  {
+    std::ofstream os;
+
+    os.open(filepath_,std::ios::binary|std::ios::trunc);
+    if(!os)
+      throw Error("error opening signature output " + filepath_.string());
+    os.write((const char*)sig_,sizeof(rsa512_sig_t));
+    if(!os)
+      throw Error("error writing signature output " + filepath_.string());
+  }
+
+  static
+  u64
+  signed_data_size(const u64  filesize_,
+                   const bool replace_,
+                   const bool verify_)
+  {
+    if(!replace_ && !verify_)
+      return filesize_;
+    if(filesize_ < sizeof(rsa512_sig_t))
+      throw Error("file is too small to contain a signature trailer");
+
+    return (filesize_ - sizeof(rsa512_sig_t));
+  }
+
+  static
+  void
+  sign_file_one(const fs::path          &filepath_,
+                const Options::SignFile &opts_)
+  {
+    md5_digest_t digest;
+    rsa512_sig_t original_sig;
+    rsa512_sig_t sig;
+    std::vector<char> data;
+
+    const u64 filesize = fs::file_size(filepath_);
+    const u64 data_size = signed_data_size(filesize,opts_.replace,opts_.verify);
+    data = read_file_prefix(filepath_,data_size);
+
+    md5_calc(data.data(),data.size(),digest);
+    tdo_rsa_sign(opts_.key_name.c_str(),digest,sig);
+
+    fmt::print("{}:\n"
+               " - key: {}\n"
+               " - md5 digest: {}\n"
+               " - rsa sig: {}\n",
+               filepath_,
+               opts_.key_name,
+               digest,
+               sig);
+
+    if(opts_.verify)
+      {
+        read_signature_trailer(filepath_,original_sig);
+        const bool matched = (memcmp(original_sig,sig,sizeof(rsa512_sig_t)) == 0);
+
+        fmt::print(" - original sig: {}\n"
+                   " - match: {}\n",
+                   original_sig,
+                   matched);
+        if(!matched)
+          throw Error("signature mismatch");
+      }
+
+    if(!opts_.signature_output.empty())
+      write_signature_output(opts_.signature_output,sig);
+
+    if(opts_.write)
+      write_signature(filepath_,(opts_.append ? filesize : data_size),sig);
+  }
+}
+
+void
+Subcommand::sign_file(const Options::SignFile &opts_)
+{
+  bool failed;
+
+  failed = false;
+  if(opts_.write && (opts_.append == opts_.replace))
+    throw Error("--write requires exactly one of --append or --replace");
+  if(!opts_.signature_output.empty() && (opts_.filepaths.size() != 1))
+    throw Error("--signature-output requires exactly one input file");
+
+  for(const auto &filepath : opts_.filepaths)
+    {
+      try
+        {
+          sign_file_one(filepath,opts_);
+        }
+      catch(const std::exception &e)
+        {
+          fmt::print(stderr,"3dt: {} - {}\n",e.what(),filepath);
+          failed = true;
+        }
+    }
+
+  if(failed)
+    throw Error("sign-file failed");
+}

--- a/src/subcommand_to-iso.cpp
+++ b/src/subcommand_to-iso.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -50,7 +50,6 @@ namespace Subcommand
   void
   to_iso(const Options::ToISO &options_)
   {
-    Error err;
     std::uint64_t blocks;
     std::ofstream ofs;
     fs::path output_path;
@@ -59,20 +58,25 @@ namespace Subcommand
 
     output_path = get_output_path(options_);
     if(output_path == options_.input)
-      return Log::error({"input == output"});
+      {
+        Log::error({"input == output"});
+        throw Error("to-iso failed");
+      }
 
-    err = stream.open(options_.input);
-    if(err)
-      return Log::error(err);
+    stream.open(options_.input);
 
     if(!stream.good())
-      return  Log::error_stream_open(options_.input);
+      {
+        Log::error_stream_open(options_.input);
+        throw Error("to-iso failed");
+      }
 
     ofs.open(output_path,std::ios::binary|std::ios::trunc);
     if(!ofs.good())
       {
         stream.close();
-        return Log::error_stream_open(output_path);
+        Log::error_stream_open(output_path);
+        throw Error("to-iso failed");
       }
 
     const std::uint64_t leading_blocks =
@@ -92,7 +96,10 @@ namespace Subcommand
 
             ofs.write(buf.data(),buf.size());
             if(ofs.bad())
-              return Log::error({"write failed"});
+              {
+                Log::error({"write failed"});
+                throw Error("to-iso failed");
+              }
 
             fmt::print("\r{}: block {} of {} written",
                        output_path,
@@ -102,7 +109,8 @@ namespace Subcommand
       }
     catch(const Error &err)
       {
-        return Log::error(err);
+        Log::error(err);
+        throw Error("to-iso failed");
       }
 
     fmt::print("\n");

--- a/src/subcommand_unpack.cpp
+++ b/src/subcommand_unpack.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -17,18 +17,163 @@
 */
 
 #include "fmt.hpp"
+#include "json.hpp"
 #include "log.hpp"
 #include "options.hpp"
 #include "tdo_disc_unpacker.hpp"
 
 #include "CSVWriter.h"
 
+#include <array>
+#include <cstring>
 #include <fstream>
+#include <limits>
+#include <sstream>
+#include <utility>
+#include <vector>
 
 namespace fs = std::filesystem;
 
 namespace
 {
+  using json = nlohmann::json;
+
+  static constexpr const char *DEFAULT_LAYOUT_FILENAME = "layout.json";
+
+  static
+  std::string
+  array_string(const std::array<char,32> &arr_)
+  {
+    const char *begin;
+    const char *end;
+
+    begin = &arr_[0];
+    end = static_cast<const char*>(memchr(begin,'\0',arr_.size()));
+    if(end == nullptr)
+      end = begin + arr_.size();
+
+    return std::string(begin,end);
+  }
+
+  static
+  std::string
+  bytes_hex(const char *data_,
+            const u64   size_)
+  {
+    std::string rv;
+
+    rv.reserve(size_ * 2);
+    for(u64 i = 0; i < size_; i++)
+      rv += fmt::format("{:02X}",static_cast<unsigned char>(data_[i]));
+
+    return rv;
+  }
+
+  static
+  std::string
+  fixed_string(const char *data_,
+               const u64   size_)
+  {
+    const char *end;
+
+    end = static_cast<const char*>(memchr(data_,'\0',size_));
+    if(end == nullptr)
+      end = data_ + size_;
+
+    return std::string(data_,end);
+  }
+
+  static
+  json
+  avatar_list_json(const std::vector<u32> &avatar_list_)
+  {
+    json avatars = json::array();
+
+    for(auto avatar : avatar_list_)
+      avatars.emplace_back(avatar);
+
+    return avatars;
+  }
+
+  static
+  json
+  disc_label_json(const TDO::DiscLabel &label_)
+  {
+    json sync = json::array();
+    json root_avatars = json::array();
+
+    for(auto c : label_.volume_sync_bytes)
+      sync.emplace_back(static_cast<u8>(c));
+    // Cap the loop by the avatar_list's fixed capacity rather than
+    // trusting root_directory_last_avatar_index. A malformed/odd label
+    // can have last_avatar_index >= 8 (OOB read on the on-disc array)
+    // or UINT32_MAX (the original `i <= last_idx` form looped forever
+    // once unsigned i wrapped past UINT_MAX, with each iteration
+    // emplace_back'ing an OOB value into the JSON manifest until
+    // allocation failed). Mirrors the protective shape applied to
+    // subcommand_info.cpp's equivalent loop. Cast through u64 so the
+    // `+ 1` cannot itself wrap when last_idx is UINT32_MAX.
+    const auto avatar_capacity = label_.root_directory_avatar_list.size();
+    const u32  last_idx        = label_.root_directory_last_avatar_index;
+    const bool last_idx_oob =
+      (static_cast<u64>(last_idx) + 1 > avatar_capacity);
+    const u32 emit_count =
+      last_idx_oob
+      ? static_cast<u32>(avatar_capacity)
+      : (last_idx + 1);
+    for(u32 i = 0; i < emit_count; i++)
+      root_avatars.emplace_back(label_.root_directory_avatar_list[i]);
+    if(last_idx_oob)
+      fmt::print(stderr,
+                 "3dt: warning: root_directory_last_avatar_index={} exceeds "
+                 "avatar_list capacity {} -- truncating in manifest\n",
+                 last_idx,avatar_capacity);
+
+    return {
+      {"record_type",label_.record_type},
+      {"volume_sync_bytes",sync},
+      {"volume_structure_version",label_.volume_structure_version},
+      {"volume_flags",label_.volume_flags},
+      {"volume_commentary",array_string(label_.volume_commentary)},
+      {"volume_identifier",array_string(label_.volume_identifier)},
+      {"volume_unique_identifier",label_.volume_unique_identifier},
+      {"volume_block_size",label_.volume_block_size},
+      {"volume_block_count",label_.volume_block_count},
+      {"root_unique_identifier",label_.root_unique_identifier},
+      {"root_directory_block_count",label_.root_directory_block_count},
+      {"root_directory_block_size",label_.root_directory_block_size},
+      {"root_directory_last_avatar_index",label_.root_directory_last_avatar_index},
+      {"root_directory_avatar_list",root_avatars}
+    };
+  }
+
+  static
+  json
+  romtags_json(TDO::DevStream &stream_)
+  {
+    json tags = json::array();
+
+    for(const auto &tag : stream_.romtags())
+      {
+        tags.push_back({
+          {"sub_systype",tag.sub_systype},
+          {"type",tag.type},
+          {"type_name",tag.type_str()},
+          {"version",tag.version},
+          {"revision",tag.revision},
+          {"flags",tag.flags},
+          {"type_specific",tag.type_specific},
+          {"reserved1",tag.reserved1},
+          {"reserved2",tag.reserved2},
+          {"offset",tag.offset},
+          {"size",tag.size},
+          {"reserved3",{tag.reserved3[0],tag.reserved3[1],tag.reserved3[2],tag.reserved3[3]}}
+        });
+      }
+
+    return tags;
+  }
+
   struct CSVPrinter final : public TDO::DiscUnpacker::Callback
   {
     void
@@ -79,7 +224,24 @@ namespace
       dir_char      = (record_.is_directory() ? 'd' : '-');
       readonly_char = (record_.is_readonly() ? 'r' : '-');
       for_fs_char   = (record_.is_for_fs() ? 'f' : '-');
-      avatar = (stream_.data_offset() + (record_.avatar_list[0] * stream_.device_block_size()));
+      if(record_.avatar_list.empty())
+        {
+          avatar = 0u;
+        }
+      else
+        {
+          // OperaFS targets a 32-bit platform; the avatar's file offset
+          // must fit in u32. Compute in s64 so we can detect overflow,
+          // then narrow. Throwing here surfaces the malformed image
+          // rather than silently truncating the displayed offset.
+          const s64 file_offset =
+            stream_.data_block_to_file_offset(record_.avatar_list[0]);
+          if((file_offset < 0) ||
+             (file_offset > static_cast<s64>(std::numeric_limits<std::uint32_t>::max())))
+            throw Error("avatar file offset out of 32-bit range: " +
+                        filepath_.string());
+          avatar = static_cast<std::uint32_t>(file_offset);
+        }
       fmt::print("{}{}{} {:11L} {:#010x} {:4s} {:#010x} {:#010x} {}\n",
                  dir_char,
                  readonly_char,
@@ -101,6 +263,118 @@ namespace
     }
   };
 
+  struct LayoutWriter final : public TDO::DiscUnpacker::Callback
+  {
+    LayoutWriter(TDO::DiscUnpacker::Callback::Ptr printer_)
+      : _printer(std::move(printer_)),
+        _initialized(false)
+    {
+    }
+
+    void
+    init(TDO::DevStream &stream_)
+    {
+      if(_initialized)
+        return;
+
+      _initialized = true;
+      _manifest = {
+        {"format","3dt-operafs-layout"},
+        {"version",1},
+        {"image",{
+          {"container",stream_.device_block_header() == 0 ? "iso2048" : "mode1_2352"},
+          {"file_size",stream_.size_in_bytes()},
+          {"data_start_offset",stream_.data_start_offset()},
+          {"device_block_size",stream_.device_block_size()},
+          {"device_block_header",stream_.device_block_header()},
+          {"device_block_data_size",stream_.device_block_data_size()},
+          {"device_block_footer",stream_.device_block_footer()},
+          {"disc_label_block",stream_.disc_label_block()},
+          {"romtags_block",stream_.romtags_block()}
+        }},
+        {"disc_label",disc_label_json(stream_.disc_label())},
+        {"rom_tags",romtags_json(stream_)},
+        {"entries",json::array()}
+      };
+    }
+
+    void
+    directory(const fs::path              &path_,
+              const TDO::DirectoryHeader &header_,
+              const uint32_t              header_pos_,
+              TDO::DevStream             &stream_)
+    {
+      (void)path_;
+      (void)header_;
+      (void)header_pos_;
+      init(stream_);
+    }
+
+    void
+    before(const fs::path             &path_,
+           const TDO::DirectoryRecord &record_,
+           const uint32_t              record_pos_,
+           TDO::DevStream             &stream_)
+    {
+      init(stream_);
+      _printer->before(path_,record_,record_pos_,stream_);
+      _manifest["entries"].push_back({
+        {"path",path_.generic_string()},
+        {"kind",record_.is_directory() ? "directory" : "file"},
+        {"record_file_offset",record_pos_},
+        {"record_data_offset",stream_.data_byte_tell(record_pos_)},
+        {"record_size",68 + (record_.avatar_list.size() * sizeof(u32))},
+        {"flags",record_.flags},
+        {"unique_identifier",record_.unique_identifier},
+        {"type",record_.type},
+        {"block_size",record_.block_size},
+        {"byte_count",record_.byte_count},
+        {"block_count",record_.block_count},
+        {"burst",record_.burst},
+        {"gap",record_.gap},
+        {"filename",fixed_string(record_.filename,sizeof(record_.filename))},
+        {"filename_raw_hex",bytes_hex(record_.filename,sizeof(record_.filename))},
+        {"last_avatar_index",record_.last_avatar_index},
+        {"avatar_list",avatar_list_json(record_.avatar_list)},
+        {"start_block",record_.avatar_list.empty() ? 0 : record_.avatar_list[0]}
+      });
+    }
+
+    void
+    after(const fs::path             &path_,
+          const TDO::DirectoryRecord &record_,
+          const int                   err_)
+    {
+      _printer->after(path_,record_,err_);
+    }
+
+    void
+    end()
+    {
+      _printer->end();
+    }
+
+    void
+    write(const fs::path &layout_path_)
+    {
+      std::ofstream os;
+
+      os.open(layout_path_,std::ios::trunc);
+      if(!os)
+        {
+          Log::error({"failed to open layout output file: " + layout_path_.string()});
+          return;
+        }
+
+      os << _manifest.dump(2) << '\n';
+    }
+
+  private:
+    TDO::DiscUnpacker::Callback::Ptr _printer;
+    json                             _manifest;
+    bool                             _initialized;
+  };
+
   TDO::DiscUnpacker::Callback::Ptr
   get_printer(const std::string &format_)
   {
@@ -109,6 +383,17 @@ namespace
 
     return std::make_unique<HumanPrinter>();
   }
+
+  static
+  fs::path
+  layout_path_for(const Options::Unpack &options_,
+                  const fs::path        &dstpath_)
+  {
+    if(!options_.layout.empty())
+      return options_.layout;
+
+    return (dstpath_ / DEFAULT_LAYOUT_FILENAME);
+  }
 }
 
 namespace Subcommand
@@ -116,31 +401,60 @@ namespace Subcommand
   void
   unpack(const Options::Unpack &options_)
   {
-    Error err;
+    bool failed;
     fs::path dstpath;
-    std::ifstream ifs;
-    TDO::DiscUnpacker::Ptr unpacker;
-    TDO::DiscUnpacker::Callback::Ptr printer;
 
-    printer  = get_printer(options_.format);
-    unpacker = std::make_unique<TDO::DiscUnpacker>(ifs,*printer);
+    if(!options_.layout.empty() && (options_.filepaths.size() != 1))
+      {
+        Log::error({"--layout requires exactly one input image"});
+        throw Error("unpack failed");
+      }
 
+    failed = false;
     for(auto &srcpath : options_.filepaths)
       {
-        ifs.open(srcpath,std::ios::binary);
-        if(ifs.bad())
+        fs::path layout_path;
+        TDO::DiscUnpacker::Ptr unpacker;
+        TDO::DiscUnpacker::Callback::Ptr printer;
+        LayoutWriter *layout_writer;
+        std::fstream fs;
+
+        fs.open(srcpath,fs.binary|fs.in);
+        if(!fs.is_open())
           {
             Log::error_stream_open(srcpath);
+            failed = true;
             continue;
           }
 
         dstpath = options_.output / (srcpath.filename().concat(".unpacked"));
+        fs::create_directories(dstpath);
 
-        err = unpacker->unpack(dstpath);
-        if(err)
-          Log::error(err);
+        layout_path = layout_path_for(options_,dstpath);
 
-        ifs.close();
+        printer = get_printer(options_.format);
+        {
+          auto lw = std::make_unique<LayoutWriter>(std::move(printer));
+          layout_writer = lw.get();
+          printer = std::move(lw);
+        }
+        unpacker = std::make_unique<TDO::DiscUnpacker>(fs,*printer);
+
+        try
+          {
+            unpacker->unpack(dstpath);
+            layout_writer->write(layout_path);
+          }
+        catch(const std::exception &e)
+          {
+            Log::error({e.what()});
+            failed = true;
+          }
+
+        fs.close();
       }
+
+    if(failed)
+      throw Error("unpack failed");
   }
 }

--- a/src/subcommand_verify.cpp
+++ b/src/subcommand_verify.cpp
@@ -1,0 +1,1145 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "md5.h"
+#include "subcommand.hpp"
+
+#include "options.hpp"
+#include "tdo_dev_stream.hpp"
+#include "tdo_disc_format.hpp"
+#include "tdo_disc_label.hpp"
+#include "tdo_romtag.hpp"
+#include "tdo_boot_code_crypto.hpp"
+#include "tdo_file_stream.hpp"
+#include "tdo_fs_walker.hpp"
+#include "tdo_rsa.h"
+
+#include "discdata.h"
+
+#include "fmt.hpp"
+#include "fmt_md5_digest.hpp"
+#include "fmt_rsa512_sig.hpp"
+#include "json.hpp"
+
+#include "types_ints.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+static constexpr int VERIFY_EXIT_UNSIGNED = 2;
+static constexpr int VERIFY_EXIT_UNSUPPORTED = 3;
+static constexpr int VERIFY_EXIT_INVALID = 4;
+
+static bool g_check_digest_table = true;
+static bool g_quiet = false;
+
+enum class VerifyStatus
+{
+  Valid,
+  Unsigned,
+  Unsupported,
+  Invalid
+};
+
+struct VerifyResult
+{
+  std::string  path;
+  VerifyStatus status;
+};
+
+static
+const char*
+verify_status_str(const VerifyStatus status_)
+{
+  switch(status_)
+    {
+    case VerifyStatus::Valid:
+      return "valid";
+    case VerifyStatus::Unsigned:
+      return "unsigned";
+    case VerifyStatus::Unsupported:
+      return "unsupported";
+    case VerifyStatus::Invalid:
+      return "invalid";
+    }
+
+  return "invalid";
+}
+
+template<typename... Args>
+static
+void
+_vprint(const char *fmt_,
+        Args&&...   args_)
+{
+  if(!g_quiet)
+    fmt::print(fmt_,std::forward<Args>(args_)...);
+}
+
+static
+bool
+_range_in_image(TDO::DevStream &s_,
+                const s64       image_size_,
+                const u64       start_block_,
+                const u64       byte_count_)
+{
+  s64 file_offset;
+
+  if(byte_count_ == 0)
+    return true;
+
+  file_offset = s_.data_block_to_file_offset(start_block_);
+  if((file_offset < 0) || (image_size_ < 0))
+    return false;
+  if(file_offset > image_size_)
+    return false;
+
+  return (byte_count_ <= static_cast<u64>(image_size_ - file_offset));
+}
+
+class VerifyFSCallbacks final : public TDO::FSWalker::Callbacks
+{
+public:
+  Error
+  invalid_filename(const std::filesystem::path &parent_,
+                   const std::string           &filename_,
+                   const TDO::DirectoryRecord&,
+                   const uint32_t,
+                   const Error                 &err_,
+                   TDO::DevStream&)
+  {
+    fmt::print(stderr,
+               "3dt: warning: {} - {}\n",
+               err_.str,
+                TDO::display_path(parent_,filename_));
+
+    return {};
+  }
+};
+
+static
+void
+_get_cross_app_sig(TDO::DevStream &s_,
+                   rsa512_sig_t    sig_)
+{
+  s_.data_block_seek(s_.romtags_block());
+  s_.data_byte_skip(s_.romtags_size_in_bytes());
+  s_.read((char*)sig_,sizeof(rsa512_sig_t));
+}
+
+static
+void
+_get_sig_from_end(std::vector<char> &data_,
+                  rsa512_sig_t       sig_)
+{
+  std::memcpy(sig_,
+              &data_[data_.size() - sizeof(rsa512_sig_t)],
+              sizeof(rsa512_sig_t));
+}
+
+static
+bool
+_is_zero_sig(const rsa512_sig_t sig_)
+{
+  static const std::array<unsigned char, RSA512_SIG_SIZE> ZERO{};
+  return (std::memcmp(sig_, ZERO.data(), RSA512_SIG_SIZE) == 0);
+}
+
+// Unsigned prerelease discs can use recognizable placeholders instead of real
+// RSA signatures. Casper beta uses "iamaduck" for the cross-app signature.
+static
+bool
+_is_iamaduck_sig(const rsa512_sig_t sig_)
+{
+  static constexpr char PATTERN[] = "iamaduck";
+
+  for(u64 i = 0; i < sizeof(rsa512_sig_t); i++)
+    if(sig_[i] != PATTERN[i % (sizeof(PATTERN) - 1)])
+      return false;
+
+  return true;
+}
+
+static
+const char*
+_sig_status(const rsa512_sig_t sig_,
+            const bool         matched_,
+            bool              &saw_unsigned_,
+            bool              &saw_invalid_)
+{
+  if(matched_)
+    return "valid";
+  if(_is_zero_sig(sig_))
+    {
+      saw_unsigned_ = true;
+      return "unsigned placeholder: zero";
+    }
+  if(_is_iamaduck_sig(sig_))
+    {
+      saw_unsigned_ = true;
+      return "unsigned placeholder: iamaduck";
+    }
+
+  saw_invalid_ = true;
+  return "invalid";
+}
+
+
+// See details in `portfolio_os/src/dipir/cdipir.c:1178` from the original Portfolio OS tree.
+static
+bool
+_verify_disclabel_romtags_bootcode(TDO::DevStream &s_,
+                                   bool           &saw_unsigned_,
+                                   bool           &saw_invalid_)
+{
+  md5_digest_t digest;  
+  rsa512_sig_t original_sig;
+  rsa512_sig_t computed_sig;
+  std::vector<char> data;
+  std::optional<TDO::ROMTag> romtag;
+
+  _vprint(" - Verifying DiscLabel + ROMTags + BootCode with APP Key\n");
+  
+  s_.read_data_bytes_from_block(data,
+                                 s_.disc_label_block(),
+                                 s_.disc_label_size_in_bytes());
+  s_.read_data_bytes_from_block(data,
+                                 s_.romtags_block(),
+                                 s_.romtags_size_in_bytes());
+
+  romtag = s_.romtag(RSA_NEWKNEWNEWGNUBOOT);
+  if(!romtag)
+    {
+      _vprint(" - No NEWKNEWNEWGNUBOOT romtag found.\n");
+      return true;
+    }
+  const u64 newgnuboot_first_block = TDO::safe_romtag_first_data_block(s_,*romtag,"NEWKNEWNEWGNUBOOT");
+  if(!_range_in_image(s_,s_.size_in_bytes(),newgnuboot_first_block,romtag->size))
+    {
+      _vprint("   - error: NEWKNEWNEWGNUBOOT is outside image bounds\n");
+      return false;
+    }
+
+  s_.read_data_bytes_from_block(data,
+                                 newgnuboot_first_block,
+                                 romtag->size);
+
+  _vprint("   - disc label block: {}\n"
+          "   - disc label size: {}b\n"
+          "   - romtags block: {}\n"
+          "   - romtags size: {}b\n"
+          "   - newknewnewgnuboot block: {}\n"
+          "   - newknewnewgnuboot size: {}b\n",
+          s_.disc_label_block(),
+          s_.disc_label_size_in_bytes(),
+          s_.romtags_block(),
+          s_.romtags_size_in_bytes(),
+          newgnuboot_first_block,
+          romtag->size);
+
+  ::_get_cross_app_sig(s_,original_sig);
+  _vprint("   - original sig: {}\n",original_sig);
+  
+  md5_calc(data.data(),
+           data.size(),
+           digest);
+
+  tdo_rsa_sign(TDO_KEY_APP,digest,computed_sig);
+  _vprint("   - computed sig: {}\n",computed_sig);
+
+  const bool matched = (memcmp(original_sig,computed_sig,sizeof(rsa512_sig_t)) == 0);
+  _vprint("   - match: {}\n",matched);
+  _vprint("   - status: {}\n",_sig_status(original_sig,matched,saw_unsigned_,saw_invalid_));
+
+  return matched;
+}
+
+static
+u64
+_portfolio_digest_start32(TDO::DevStream &s_,
+                          const u64       num_digests_)
+{
+  std::optional<TDO::ROMTag> app_romtag;
+
+  app_romtag = s_.romtag(RSA_APP);
+  if(app_romtag)
+    return ((app_romtag->offset + s_.romtags_block()) / TDO::LOG_BLOCKS_PER_DIGEST);
+  if(num_digests_ <= (256 / TDO::LOG_BLOCKS_PER_DIGEST))
+    return 0;
+
+  return (256 / TDO::LOG_BLOCKS_PER_DIGEST);
+}
+
+static
+bool
+_portfolio_digest_is_ignored(const u64 digest_)
+{
+  return ((digest_ == 0x080F) ||
+          (digest_ == 0x0306));
+}
+
+static
+bool
+_digest_overlaps_extent(const u64 digest_,
+                        const u64 start_byte_,
+                        const u64 byte_count_)
+{
+  const u64 extent_end_byte = (start_byte_ + byte_count_);
+  const u64 digest_start_byte = (digest_ * TDO::LOG_BLOCK_SIZE);
+  const u64 digest_end_byte = (digest_start_byte + TDO::LOG_BLOCK_SIZE);
+
+  if(byte_count_ == 0)
+    return false;
+
+  return ((digest_start_byte < extent_end_byte) &&
+          (digest_end_byte > start_byte_));
+}
+
+static
+void
+_mark_valid_digest_extent(std::vector<bool> &valid_digests_,
+                          const u64          avatar_,
+                          const u64          byte_count_)
+{
+  const u64 start_byte = (avatar_ * TDO::BLOCK_SIZE);
+  const u64 first_digest = (start_byte / TDO::LOG_BLOCK_SIZE);
+  const u64 last_digest = ((start_byte + byte_count_ - 1) / TDO::LOG_BLOCK_SIZE);
+
+  if(byte_count_ == 0)
+    return;
+
+  for(u64 digest = first_digest;
+      (digest <= last_digest) && (digest < valid_digests_.size());
+      digest++)
+    if(_digest_overlaps_extent(digest,start_byte,byte_count_))
+      valid_digests_[digest] = true;
+}
+
+static
+void
+_mark_valid_record_digests(std::vector<bool>              &valid_digests_,
+                           const TDO::DirectoryRecord     &record_)
+{
+  for(const auto avatar : record_.avatar_list)
+    _mark_valid_digest_extent(valid_digests_,avatar,record_.byte_count);
+}
+
+class ValidDigestCollector final : public TDO::FSWalker::Callbacks
+{
+public:
+  ValidDigestCollector(std::vector<bool> &valid_digests_)
+    : _valid_digests(valid_digests_)
+  {
+  }
+
+public:
+  void
+  operator()(const std::filesystem::path&,
+             const TDO::DirectoryRecord  &record_,
+             const uint32_t,
+             TDO::DevStream&)
+  {
+    _mark_valid_record_digests(_valid_digests,record_);
+  }
+
+  Error
+  invalid_filename(const std::filesystem::path&,
+                   const std::string&,
+                   const TDO::DirectoryRecord &record_,
+                   const uint32_t,
+                   const Error&,
+                   TDO::DevStream&)
+  {
+    _mark_valid_record_digests(_valid_digests,record_);
+
+    return {};
+  }
+
+private:
+  std::vector<bool> &_valid_digests;
+};
+
+static
+void
+_collect_valid_digests(TDO::DevStream    &s_,
+                        const u64          num_digests_,
+                        std::vector<bool> &valid_digests_)
+{
+  ValidDigestCollector callbacks(valid_digests_);
+  TDO::FSWalker fsw(s_,callbacks);
+
+  valid_digests_.assign(num_digests_,false);
+
+  fsw.walk();
+}
+
+
+// --- Digest-to-file mapping for mismatch reporting ---
+
+static
+void
+_mark_digest_file_overlap(std::vector<std::vector<std::string>> &digest_to_files_,
+                            const u64                             digest_,
+                            const std::string                   &filepath_)
+{
+  if(digest_ < digest_to_files_.size())
+    digest_to_files_[digest_].push_back(filepath_);
+}
+
+static
+void
+_mark_digest_extent_files(std::vector<std::vector<std::string>> &digest_to_files_,
+                            const u64                              avatar_,
+                            const u64                              byte_count_,
+                            const std::string                    &filepath_)
+{
+  if(byte_count_ == 0)
+    return;
+
+  const u64 start_byte = (avatar_ * TDO::BLOCK_SIZE);
+  const u64 first_digest = (start_byte / TDO::LOG_BLOCK_SIZE);
+  const u64 last_digest = ((start_byte + byte_count_ - 1) / TDO::LOG_BLOCK_SIZE);
+
+  for(u64 digest = first_digest;
+      (digest <= last_digest) && (digest < digest_to_files_.size());
+      digest++)
+    {
+      if(_digest_overlaps_extent(digest,start_byte,byte_count_))
+        _mark_digest_file_overlap(digest_to_files_,digest,filepath_);
+    }
+}
+
+static
+void
+_mark_record_digest_files(std::vector<std::vector<std::string>> &digest_to_files_,
+                            const TDO::DirectoryRecord          &record_,
+                            const std::filesystem::path           &path_)
+{
+  for(const auto avatar : record_.avatar_list)
+    _mark_digest_extent_files(digest_to_files_,avatar,record_.byte_count,
+                              path_.generic_string());
+}
+
+class FileDigestCollector final : public TDO::FSWalker::Callbacks
+{
+public:
+  FileDigestCollector(std::vector<std::vector<std::string>> &digest_to_files_)
+    : _digest_to_files(digest_to_files_)
+  {
+  }
+
+public:
+  void
+  operator()(const std::filesystem::path    &path_,
+             const TDO::DirectoryRecord     &record_,
+             const uint32_t,
+             TDO::DevStream&)
+  {
+    _mark_record_digest_files(_digest_to_files,record_,path_);
+  }
+
+  Error
+  invalid_filename(const std::filesystem::path    &parent_,
+                   const std::string             &filename_,
+                   const TDO::DirectoryRecord     &record_,
+                   const uint32_t,
+                   const Error&,
+                   TDO::DevStream&)
+  {
+    const std::filesystem::path path = TDO::display_path(parent_,filename_);
+    _mark_record_digest_files(_digest_to_files,record_,path);
+
+    return {};
+  }
+
+private:
+  std::vector<std::vector<std::string>> &_digest_to_files;
+};
+
+static
+void
+_collect_digest_files(TDO::DevStream                       &s_,
+                        const u64                             num_digests_,
+                        std::vector<std::vector<std::string>> &digest_to_files_)
+{
+  FileDigestCollector callbacks(digest_to_files_);
+  TDO::FSWalker fsw(s_,callbacks);
+
+  digest_to_files_.assign(num_digests_,{});
+
+  fsw.walk();
+}
+
+static
+bool
+_signature_digest_is_mutable(const u64 digest_,
+                             const u64 signature_block_,
+                             const u64 signature_size_)
+{
+  const u64 signature_start_byte = (signature_block_ * TDO::BLOCK_SIZE);
+  const u64 signature_end_byte = (signature_start_byte + signature_size_);
+  const u64 digest_start_byte = (digest_ * TDO::LOG_BLOCK_SIZE);
+  const u64 digest_end_byte = (digest_start_byte + TDO::LOG_BLOCK_SIZE);
+
+  return ((digest_start_byte < signature_end_byte) &&
+          (digest_end_byte > signature_start_byte));
+}
+
+static
+void
+_print_affected_files(const u64                                        digest_,
+                      const u64                                        block_pos_,
+                      const std::vector<std::vector<std::string>>     &digest_to_files_)
+{
+  const u64 end_block = block_pos_ + TDO::LOG_BLOCKS_PER_DIGEST - 1;
+
+  _vprint("   - digest mismatch covers blocks: {}-{} ({:#010x}-{:#010x})\n",
+          block_pos_,end_block,
+          block_pos_,end_block);
+  _vprint("   - affected files/data:\n");
+
+  if(digest_ < digest_to_files_.size() && !digest_to_files_[digest_].empty())
+    {
+      std::vector<std::string> seen;
+      for(const auto &path : digest_to_files_[digest_])
+        {
+          if(std::find(seen.begin(),seen.end(),path) == seen.end())
+            {
+              seen.push_back(path);
+              _vprint("     - {}\n",path);
+            }
+        }
+    }
+  else
+    {
+      _vprint("     - (unallocated space)\n");
+    }
+}
+
+static
+bool
+_verify_signature_digests(TDO::DevStream                       &s_,
+                          const std::vector<char>              &signatures_,
+                          const u64                             num_digests_,
+                          const u64                             signature_block_,
+                          const u64                             signature_size_,
+                          const std::vector<std::vector<std::string>> &digest_to_files_)
+{
+  u64 checked_count;
+  u64 digest_start32;
+  u64 skipped_ignored_count;
+  u64 skipped_mutable_count;
+  u64 skipped_prefix_count;
+  u64 skipped_unallocated_count;
+  md5_digest_t digest;
+  std::vector<char> data;
+  std::vector<bool> valid_digests;
+
+  if(signatures_.size() < (num_digests_ * sizeof(md5_digest_t)))
+    {
+      _vprint("   - digest table comparison: false\n"
+              "   - digest table error: too small\n");
+      return false;
+    }
+
+  _collect_valid_digests(s_,num_digests_,valid_digests);
+
+  digest_start32 = _portfolio_digest_start32(s_,num_digests_);
+  checked_count = 0;
+  skipped_ignored_count = 0;
+  skipped_prefix_count = 0;
+  skipped_mutable_count = 0;
+  skipped_unallocated_count = 0;
+  for(u64 i = 0; i < num_digests_; i++)
+    {
+      const u64 expected_offset = (i * sizeof(md5_digest_t));
+      const u64 block_pos = (i * TDO::LOG_BLOCKS_PER_DIGEST);
+
+      if(i < digest_start32)
+        {
+          skipped_prefix_count++;
+          continue;
+        }
+
+      if(!valid_digests[i])
+        {
+          skipped_unallocated_count++;
+          continue;
+        }
+
+      if(_portfolio_digest_is_ignored(i))
+        {
+          skipped_ignored_count++;
+          continue;
+        }
+
+      if(_signature_digest_is_mutable(i,signature_block_,signature_size_))
+        {
+          skipped_mutable_count++;
+          continue;
+        }
+
+      data.clear();
+      s_.read_data_blocks(data,block_pos,TDO::LOG_BLOCKS_PER_DIGEST);
+      md5_calc(data.data(),data.size(),digest);
+
+      if(memcmp(&signatures_[expected_offset],digest,sizeof(md5_digest_t)) != 0)
+        {
+          _vprint("   - digest table comparison: false\n"
+                  "   - digest mismatch index: {}\n"
+                  "   - digest mismatch block: {}\n",
+                  i,
+                  block_pos);
+          _print_affected_files(i,block_pos,digest_to_files_);
+          return false;
+        }
+
+      checked_count++;
+    }
+
+  _vprint("   - digest table comparison: true\n"
+          "   - digest table policy: Portfolio max-check exhaustive\n"
+          "   - digest table start index: {}\n"
+          "   - digest table checked: {}\n"
+          "   - digest table skipped prefix: {}\n"
+          "   - digest table skipped ignored: {}\n"
+          "   - digest table skipped unallocated: {}\n"
+          "   - digest table skipped mutable: {}\n",
+          digest_start32,
+          checked_count,
+          skipped_prefix_count,
+          skipped_ignored_count,
+          skipped_unallocated_count,
+          skipped_mutable_count);
+
+  return true;
+}
+
+static
+bool
+_verify_signature_file(TDO::DevStream    &s_,
+                       const TDO::ROMTag &rom_tag_,
+                       bool              &saw_unsigned_,
+                       bool              &saw_invalid_)
+{
+  u64 sigfile_size = 0;
+  u64 num_digests = 0;
+  u64 sigfile_block_start = 0;
+  u64 sigfile_block_end = 0;
+  u64 sigfile_block_count = 0;
+  u64 volume_block_count = 0;
+  bool digests_matched;
+  md5_digest_t digest;
+  rsa512_sig_t original_sig;
+  rsa512_sig_t computed_sig;
+  std::vector<char> signatures;
+  std::vector<std::vector<std::string>> digest_to_files;
+  TDO::DiscLabel disc_label;
+
+  disc_label = s_.disc_label();
+  const s64 image_size = s_.size_in_bytes();
+
+  // This setup comes from Portfolio OS dipir/appdigest.c. When the digest
+  // count is divisible by 512, appdigest reads an extra 8192-byte trailer;
+  // the RSA_SIGNATURE_BLOCK ROMTag may still report only digest bytes.
+  volume_block_count = disc_label.volume_block_count;
+  sigfile_block_start = TDO::safe_romtag_first_data_block(s_,rom_tag_,"signatures");
+  sigfile_size = rom_tag_.size;
+  // volume_block_count is attacker-influenced disc-label data and
+  // feeds an unbounded multiplication and downstream allocation
+  // (valid_digests.assign(num_digests, ...)). Retail images sometimes
+  // had odd-but-valid layouts so we do not bail out, but we must keep
+  // the math finite. Detect overflow and out-of-image counts, warn,
+  // and clamp num_digests to what the image can physically describe.
+  {
+    const u64 max_vbc = (std::numeric_limits<u64>::max() / TDO::BLOCK_SIZE);
+    u64 effective_vbc = volume_block_count;
+    if(effective_vbc > max_vbc)
+      {
+        _vprint("   - warning: volume_block_count overflows digest math; clamping\n");
+        effective_vbc = max_vbc;
+      }
+    const u64 device_blocks = s_.device_block_count();
+    if((device_blocks > 0) && (effective_vbc > device_blocks))
+      {
+        _vprint("   - warning: volume_block_count exceeds image size; clamping to image\n");
+        effective_vbc = device_blocks;
+      }
+    num_digests = (effective_vbc * TDO::BLOCK_SIZE) / TDO::LOG_BLOCK_SIZE;
+  }
+  const u64 digest_table_size = num_digests * sizeof(md5_digest_t);
+  if(((num_digests & 511) == 0) && (sigfile_size == digest_table_size))
+    sigfile_size += 8192;
+  sigfile_block_count = TDO::div_round_up(sigfile_size,TDO::BLOCK_SIZE);
+  sigfile_block_end = sigfile_block_start + sigfile_block_count;
+
+  if(sigfile_size < RSA512_SIG_SIZE)
+    {
+      _vprint("   - error: signature file is too small\n");
+      return false;
+    }
+  if(!_range_in_image(s_,image_size,sigfile_block_start,sigfile_size))
+    {
+      _vprint("   - error: signature file is outside image bounds\n");
+      return false;
+    }
+
+  s_.read_data_bytes_from_block(signatures,
+                                sigfile_block_start,
+                                sigfile_size);
+
+  if(signatures.size() < RSA512_SIG_SIZE)
+    {
+      _vprint("   - error: signature file is too small\n");
+      return false;
+    }
+
+  _vprint("   - start block: {}\n"
+          "   - start byte: {}\n"
+          "   - end block: {}\n"
+          "   - end byte: {}\n"
+          "   - block count: {}\n"
+          "   - file size: {}b\n"
+          "   - num digests: {}\n"
+          "   - volume block count: {}\n"
+          "   - digest table mode: {}\n",
+          sigfile_block_start,
+          sigfile_block_start * s_.device_block_data_size(),
+          sigfile_block_end,
+          sigfile_block_end * s_.device_block_data_size(),
+          sigfile_block_count,
+          sigfile_size,
+          num_digests,
+          volume_block_count,
+          (g_check_digest_table ? "Portfolio" : "skipped"));
+
+  _get_sig_from_end(signatures,original_sig);
+  _vprint("   - original sig: {}\n",original_sig);
+
+  md5_calc(signatures.data(),
+           signatures.size() - RSA512_SIG_SIZE,
+           digest);
+  tdo_rsa_sign(TDO_KEY_APP,
+               digest,
+               computed_sig);
+
+  _vprint("   - computed sig: {}\n",computed_sig);
+
+  const bool matched = (memcmp(original_sig,computed_sig,sizeof(rsa512_sig_t)) == 0);
+  _vprint("   - match: {}\n",matched);
+  _vprint("   - status: {}\n",_sig_status(original_sig,matched,saw_unsigned_,saw_invalid_));
+
+  if(!g_check_digest_table)
+    {
+      _vprint("   - digest table comparison: skipped\n");
+      return matched;
+    }
+
+  _collect_digest_files(s_,num_digests,digest_to_files);
+
+  digests_matched = _verify_signature_digests(s_,
+                                              signatures,
+                                              num_digests,
+                                              sigfile_block_start,
+                                              rom_tag_.size,
+                                              digest_to_files);
+  return (matched && digests_matched);
+}
+
+static
+bool
+_verify_file(TDO::DevStream &s_,
+             const u64       start_offset_in_blocks_,
+             const u64       size_in_bytes_,
+             const char     *key_,
+             bool           &saw_unsigned_,
+             bool           &saw_invalid_)
+{
+  md5_digest_t digest;
+  rsa512_sig_t original_sig;
+  rsa512_sig_t computed_sig;
+  std::vector<char> data;
+
+  _vprint("   - start block: {}\n"
+          "   - file size: {}b\n",
+          start_offset_in_blocks_,
+          size_in_bytes_);
+  if(size_in_bytes_ < RSA512_SIG_SIZE)
+    {
+      _vprint("   - error: file is too small to contain a signature\n");
+      return false;
+    }
+  if(!_range_in_image(s_,s_.size_in_bytes(),start_offset_in_blocks_,size_in_bytes_))
+    {
+      _vprint("   - error: file is outside image bounds\n");
+      return false;
+    }
+  s_.read_data_bytes_from_block(data,
+                                start_offset_in_blocks_,
+                                size_in_bytes_);
+
+  _get_sig_from_end(data,original_sig);
+  _vprint("   - original sig: {}\n",original_sig);
+
+  md5_calc(data.data(),
+           data.size() - RSA512_SIG_SIZE,
+           digest);
+  tdo_rsa_sign(key_,
+               digest,
+               computed_sig);
+
+  _vprint("   - computed sig: {}\n",computed_sig);
+
+  const bool matched = (memcmp(original_sig,computed_sig,sizeof(rsa512_sig_t)) == 0);
+  _vprint("   - match: {}\n",matched);
+  _vprint("   - status: {}\n",_sig_status(original_sig,matched,saw_unsigned_,saw_invalid_));
+
+  return matched;
+}
+
+static
+bool
+_verify_boot_code_post_cheeze(TDO::DevStream    &s_,
+                              const TDO::ROMTag &rom_tag_,
+                              bool              &saw_unsigned_,
+                              bool              &saw_invalid_)
+{
+  md5_digest_t digest;
+  rsa512_sig_t original_sig;
+  rsa512_sig_t computed_sig;
+  std::vector<char> data;
+  const u64 start_offset_in_blocks = TDO::safe_romtag_first_data_block(s_,rom_tag_,"boot_code");
+  const u64 size_in_bytes = rom_tag_.size;
+
+  _vprint(" - Verifying NEWKNEWNEWGNUBOOT post-cheeze with 3DO Key:\n");
+  if(size_in_bytes < (RSA512_SIG_SIZE * 2))
+    {
+      _vprint("   - error: boot_code is too small to contain both signatures\n");
+      return false;
+    }
+  if(!_range_in_image(s_,s_.size_in_bytes(),start_offset_in_blocks,size_in_bytes))
+    {
+      _vprint("   - error: boot_code is outside image bounds\n");
+      return false;
+    }
+
+  s_.read_data_bytes_from_block(data,
+                                start_offset_in_blocks,
+                                size_in_bytes - RSA512_SIG_SIZE);
+  TDO::decrypt_boot_code_range(data.data(),data.size());
+
+  _vprint("   - decrypted data size: {}b\n",
+          data.size() - RSA512_SIG_SIZE);
+
+  _get_sig_from_end(data,original_sig);
+  _vprint("   - original sig: {}\n",original_sig);
+
+  md5_calc(data.data(),
+           data.size() - RSA512_SIG_SIZE,
+           digest);
+  tdo_rsa_sign(TDO_KEY_3DO,
+               digest,
+               computed_sig);
+
+  _vprint("   - computed sig: {}\n",computed_sig);
+
+  const bool matched = (memcmp(original_sig,computed_sig,sizeof(rsa512_sig_t)) == 0);
+  _vprint("   - match: {}\n",matched);
+  _vprint("   - status: {}\n",_sig_status(original_sig,matched,saw_unsigned_,saw_invalid_));
+
+  return matched;
+}
+
+static
+bool
+_has_checkable_rsa_sig(TDO::DevStream &s_)
+{
+  TDO::ROMTagVec rom_tags;
+
+  rom_tags = s_.romtags();
+  for(const auto &rom_tag : rom_tags)
+    {
+      switch(rom_tag.type)
+        {
+        case RSA_OS:
+        case RSA_MISCCODE:
+        case RSA_NEWKNEWNEWGNUBOOT:
+        case RSA_APPSPLASH:
+        case RSA_SIGNATURE_BLOCK:
+          return true;
+        }
+    }
+
+  return false;
+}
+
+static
+bool
+_verify_romtag_assets(TDO::DevStream &s_,
+                      bool           &saw_unsigned_,
+                      bool           &saw_invalid_)
+{
+  bool matched;
+  u64 size_in_bytes;  
+  u64 offset_in_blocks;
+  TDO::ROMTagVec rom_tags;
+
+  matched = true;
+  rom_tags = s_.romtags();
+  for(const auto &rom_tag : rom_tags)
+    {
+      // Filter to types we actually verify before computing first_block,
+      // so unrelated tags don't trip the wrap check unnecessarily.
+      switch(rom_tag.type)
+        {
+        case RSA_OS:
+        case RSA_MISCCODE:
+        case RSA_NEWKNEWNEWGNUBOOT:
+        case RSA_APPSPLASH:
+        case RSA_SIGNATURE_BLOCK:
+          break;
+        default:
+          continue;
+        }
+
+      try
+        {
+          offset_in_blocks = TDO::safe_romtag_first_data_block(s_,rom_tag,rom_tag.type_str().c_str());
+          size_in_bytes    = rom_tag.size;
+
+          switch(rom_tag.type)
+            {
+            case RSA_OS:
+            case RSA_MISCCODE:
+            case RSA_NEWKNEWNEWGNUBOOT:
+              _vprint(" - Verifying {} with 3DO Key:\n",
+                      rom_tag.type_str());
+              matched &= ::_verify_file(s_,offset_in_blocks,size_in_bytes,TDO_KEY_3DO,
+                                        saw_unsigned_,saw_invalid_);
+              if(rom_tag.type == RSA_NEWKNEWNEWGNUBOOT)
+                matched &= ::_verify_boot_code_post_cheeze(s_,rom_tag,
+                                                           saw_unsigned_,saw_invalid_);
+              break;
+            case RSA_APPSPLASH:
+              _vprint(" - Verifying {} with APP Key:\n",
+                      rom_tag.type_str());
+              matched &= ::_verify_file(s_,offset_in_blocks,size_in_bytes,TDO_KEY_APP,
+                                        saw_unsigned_,saw_invalid_);
+              break;
+            case RSA_SIGNATURE_BLOCK:
+              _vprint(" - Verifying {} with APP Key:\n",
+                      rom_tag.type_str());
+              matched &= ::_verify_signature_file(s_,rom_tag,
+                                                  saw_unsigned_,saw_invalid_);
+              break;
+            }
+        }
+      catch(const std::exception &e)
+        {
+          // A malformed tag (e.g. out-of-range offset caught by
+          // safe_romtag_first_data_block) used to be reported via
+          // _range_in_image's bool return, which let the loop
+          // continue past it. Preserve that behavior so one bad tag
+          // does not hide the verification result of every subsequent
+          // tag in the same image.
+          _vprint("   - error verifying {}: {}\n",
+                  rom_tag.type_str(),
+                  e.what());
+          matched = false;
+          saw_invalid_ = true;
+        }
+    }
+
+  return matched;
+}
+
+static
+void
+_verify_operafs_structure(TDO::DevStream &s_)
+{
+  VerifyFSCallbacks callbacks;
+  TDO::FSWalker fsw(s_,callbacks);
+
+  _vprint(" - Verifying OperaFS structure\n");
+
+  fsw.walk();
+}
+
+static
+VerifyStatus
+_verify_rsa_sigs(TDO::DevStream &s_)
+{
+  bool matched;
+  bool saw_unsigned;
+  bool saw_invalid;
+
+  saw_unsigned = false;
+  saw_invalid = false;
+
+  if(!_has_checkable_rsa_sig(s_))
+    {
+      _vprint(" - No RSA signatures found\n");
+      return VerifyStatus::Unsigned;
+    }
+
+  matched = true;
+  try
+    {
+      matched = _verify_disclabel_romtags_bootcode(s_,saw_unsigned,saw_invalid);
+    }
+  catch(const std::exception &e)
+    {
+      // Match the per-tag isolation _verify_romtag_assets uses: a
+      // malformed NEWKNEWNEWGNUBOOT (e.g. offset out of range caught
+      // by safe_romtag_first_data_block) or a failed read should
+      // record an invalid signature outcome and let the per-tag asset
+      // verification still run, rather than escaping to the outer
+      // _verify catch and skipping every later tag in the image.
+      _vprint(" - error verifying DiscLabel + ROMTags + BootCode: {}\n",e.what());
+      matched = false;
+      saw_invalid = true;
+    }
+  matched &= _verify_romtag_assets(s_,saw_unsigned,saw_invalid);
+
+  if(matched)
+    return VerifyStatus::Valid;
+  if(saw_invalid)
+    return VerifyStatus::Invalid;
+  if(saw_unsigned)
+    return VerifyStatus::Unsigned;
+
+  return VerifyStatus::Invalid;
+}
+
+static
+void
+_verify(const Options::Verify &opts_);
+
+static
+void
+_print_summary(const std::string                              &format_,
+               const bool                                      quiet_,
+               const std::vector<VerifyResult>                &results_)
+{
+  if(format_ == "csv")
+    {
+      fmt::print("status,path\n");
+      for(const auto &result : results_)
+        fmt::print("{},{}\n",verify_status_str(result.status),result.path);
+      return;
+    }
+
+  if(format_ == "json")
+    {
+      nlohmann::json arr = nlohmann::json::array();
+      for(const auto &result : results_)
+        arr.push_back({{"path", result.path}, {"status", verify_status_str(result.status)}});
+      fmt::print("{}\n", arr.dump());
+      return;
+    }
+
+  if(quiet_)
+    for(const auto &result : results_)
+      fmt::print("{}: {}\n",result.path,verify_status_str(result.status));
+}
+
+void
+Subcommand::verify(const Options::Verify &opts_)
+{
+  ::_verify(opts_);
+}
+
+static
+void
+_verify(const Options::Verify &opts_)
+{
+  bool failed;
+  int exit_code;
+  std::string format;
+  std::vector<VerifyResult> results;
+
+  format = opts_.format.empty() ? "human" : opts_.format;
+
+  g_check_digest_table = opts_.digest_table;
+  g_quiet = (opts_.quiet || (format != "human"));
+  failed = false;
+  exit_code = 0;
+  for(const auto &filepath : opts_.filepaths)
+    {
+      bool file_failed;
+      VerifyStatus status;
+      TDO::FileStream stream;
+
+      file_failed = false;
+      status = VerifyStatus::Valid;
+      try
+        {
+          stream.open(filepath);
+
+          if(!stream.has_romtags())
+            {
+              fmt::print(stderr,"3dt: {} does not contain ROMTags\n",filepath);
+              status = VerifyStatus::Unsupported;
+              file_failed = true;
+              throw Error("image does not contain ROMTags");
+            }
+
+          _vprint("{}:\n",filepath);
+          ::_verify_operafs_structure(stream);
+          status = ::_verify_rsa_sigs(stream);
+          if(status != VerifyStatus::Valid)
+            file_failed = true;
+        }
+      catch(const std::exception &e)
+        {
+          if(!file_failed)
+            fmt::print(stderr,"3dt: {} - {}\n",e.what(),filepath);
+          if(status == VerifyStatus::Valid)
+            status = VerifyStatus::Invalid;
+          file_failed = true;
+        }
+
+      if(file_failed)
+        {
+          failed = true;
+          if(status == VerifyStatus::Invalid)
+            exit_code = VERIFY_EXIT_INVALID;
+          else if((status == VerifyStatus::Unsupported) &&
+                  (exit_code != VERIFY_EXIT_INVALID))
+            exit_code = VERIFY_EXIT_UNSUPPORTED;
+          else if((status == VerifyStatus::Unsigned) &&
+                  (exit_code == 0))
+            exit_code = VERIFY_EXIT_UNSIGNED;
+        }
+      results.push_back({filepath.string(),status});
+    }
+
+  _print_summary(format,opts_.quiet,results);
+  if(failed)
+    {
+      if(exit_code == VERIFY_EXIT_UNSIGNED)
+        throw Error("image is unsigned",exit_code);
+      if(exit_code == VERIFY_EXIT_UNSUPPORTED)
+        throw Error("unsupported image",exit_code);
+      throw Error("verification failed",exit_code);
+    }
+}

--- a/src/subcommand_version.cpp
+++ b/src/subcommand_version.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -16,11 +16,9 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#include "fmt.hpp"
+#include "version.hpp"
 
-#define MAJOR 1
-#define MINOR 1
-#define PATCH 1
+#include "fmt.hpp"
 
 namespace Subcommand
 {
@@ -28,13 +26,16 @@ namespace Subcommand
   version()
   {
     fmt::print("3dt v{}.{}.{}\n\n"
-               "https://github.com/trapexit/3dt\n\n"
-               "ISC License (ISC)\n\n"
+               "https://github.com/trapexit/3dt\n"
+               "\n"
+               "ISC License (ISC)\n"
+               "\n"
                "Copyright 2022, Antonio SJ Musumeci <trapexit@spawn.link>\n\n"
                "Permission to use, copy, modify, and/or distribute this software for\n"
                "any purpose with or without fee is hereby granted, provided that the\n"
                "above copyright notice and this permission notice appear in all\n"
-               "copies.\n\n"
+               "copies.\n"
+               "\n"
                "THE SOFTWARE IS PROVIDED \"AS IS\" AND THE AUTHOR DISCLAIMS ALL\n"
                "WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED\n"
                "WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE\n"
@@ -44,8 +45,8 @@ namespace Subcommand
                "TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR\n"
                "PERFORMANCE OF THIS SOFTWARE.\n\n"
                ,
-               MAJOR,
-               MINOR,
-               PATCH);
+               VERSION_MAJOR,
+               VERSION_MINOR,
+               VERSION_PATCH);
   }
 }

--- a/src/tdo_boot_code_crypto.cpp
+++ b/src/tdo_boot_code_crypto.cpp
@@ -1,0 +1,99 @@
+#include "tdo_boot_code_crypto.hpp"
+
+#include "error.hpp"
+
+#include <cstring>
+
+namespace
+{
+  static constexpr u32 DECRYPT_MASK_1 = 0xf0f0f0f0;
+  static constexpr u32 DECRYPT_MASK_2 = 0x0f0f0f0f;
+
+  // From Portfolio OS source `src/dipir/cdipir.c`: DecryptBlock().  The original
+  // initializes q from PUBLIC_SIGNATURES_ARRAY, but that value is overwritten
+  // before the first dereference and every 16 words after.  In practice
+  // PUBLIC_SIGNATURES_ARRAY has no effect; the active key is PUBLIC_THDOKEY_MOD.
+  static constexpr u8 BOOT_CODE_CRYPT_KEY[] =
+    {
+      0x00, 0xB1, 0x94, 0x62, 0xB0, 0x0D, 0x8D, 0x6E,
+      0x1E, 0xC9, 0x09, 0xAB, 0x38, 0x5E, 0x06, 0xFE,
+      0x03, 0x4B, 0xFD, 0x28, 0x2E, 0x9F, 0xFD, 0xC5,
+      0x84, 0x83, 0x8C, 0x15, 0xF1, 0x25, 0x93, 0xDD,
+      0x1E, 0x3A, 0x8B, 0x56, 0x26, 0xF1, 0xB9, 0xD0,
+      0xED, 0x0C, 0x38, 0x4E, 0xF6, 0xC5, 0xD1, 0x45,
+      0x12, 0xBD, 0x72, 0xDD, 0xB8, 0x5B, 0x44, 0x08,
+      0x0E, 0x04, 0x72, 0xC0, 0x3D, 0x0A, 0xFC, 0x4C,
+    };
+
+  static
+  u32
+  key_word(const u64 word_offset_)
+  {
+    u32 key;
+    const u64 key_offset = (word_offset_ % 16) * sizeof(u32);
+
+    memcpy(&key,&BOOT_CODE_CRYPT_KEY[key_offset],sizeof(key));
+
+    return key;
+  }
+
+  static
+  u32
+  decrypt_word(const u32 word_,
+               const u64 word_offset_)
+  {
+    const u32 xored = word_ ^ key_word(word_offset_);
+
+    return (((xored & DECRYPT_MASK_1) >> 4) |
+            ((xored & DECRYPT_MASK_2) << 4));
+  }
+
+  static
+  u32
+  encrypt_word(const u32 word_,
+               const u64 word_offset_)
+  {
+    const u32 swapped = (((word_ & DECRYPT_MASK_1) >> 4) |
+                         ((word_ & DECRYPT_MASK_2) << 4));
+
+    return (swapped ^ key_word(word_offset_));
+  }
+
+  static
+  void
+  crypt_range(void *data_,
+              const u64 size_,
+              const u64 key_offset_,
+              u32 (*crypt_word_)(u32,u64))
+  {
+    if(((size_ % 4) != 0) || ((key_offset_ % 4) != 0))
+      throw Error("boot_code encrypted range is not 4-byte aligned");
+
+    u32 *words = static_cast<u32*>(data_);
+    for(u64 i = 0; i < size_ / sizeof(u32); i++)
+      words[i] = crypt_word_(words[i], (key_offset_ / sizeof(u32)) + i);
+
+  }
+}
+
+u64
+TDO::boot_code_crypto_aligned_size(const u64 size_)
+{
+  return (size_ - (size_ % 4));
+}
+
+void
+TDO::decrypt_boot_code_range(void *data_,
+                             const u64 size_,
+                             const u64 key_offset_)
+{
+  crypt_range(data_,size_,key_offset_,decrypt_word);
+}
+
+void
+TDO::encrypt_boot_code_range(void *data_,
+                             const u64 size_,
+                             const u64 key_offset_)
+{
+  crypt_range(data_,size_,key_offset_,encrypt_word);
+}

--- a/src/tdo_boot_code_crypto.hpp
+++ b/src/tdo_boot_code_crypto.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "types_ints.h"
+
+namespace TDO
+{
+  u64 boot_code_crypto_aligned_size(u64 size_);
+
+  void decrypt_boot_code_range(void *data_,
+                               u64   size_,
+                               u64   key_offset_ = 0);
+  void encrypt_boot_code_range(void *data_,
+                               u64   size_,
+                               u64   key_offset_ = 0);
+}

--- a/src/tdo_dev_stream.cpp
+++ b/src/tdo_dev_stream.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -16,37 +16,150 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#include "error_unknown_image_format.hpp"
-#include "fmt.hpp"
 #include "tdo_dev_stream.hpp"
+
+#include "tdo_disc_label.hpp"
 #include "tdo_linked_mem_file_entry.hpp"
+#include "tdo_safe_narrow.hpp"
 
+#include <algorithm>
 #include <array>
-
-#include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <ios>
-#include <cassert>
+#include <limits>
+#include <stdexcept>
 
-
-static constexpr int TDO_SECTOR_SIZE   = 2048;
+static constexpr int TDO_SECTOR_SIZE = 2048;
 static constexpr int CDROM_SECTOR_SIZE = 2352;
 static constexpr int SYNC_PATTERN_SIZE = 12;
-static constexpr std::uint32_t MAX_DIRECTORY_AVATAR_INDEX = ROOT_HIGHEST_AVATAR;
-static constexpr std::uint32_t DIRECTORY_HEADER_SIZE = sizeof(TDO::DirectoryHeader);
-typedef std::array<uint8_t,CDROM_SECTOR_SIZE> CDROMSectorBuf;
-typedef std::array<uint8_t,SYNC_PATTERN_SIZE> CDROMSyncPatternBuf;
-typedef std::array<uint8_t,VOLUME_SYNC_BYTE_LEN> VolumeSyncByteBuf;
+static constexpr u64 MAX_RECOGNITION_SCAN_BYTES = 1024 * 1024;
+static constexpr u32 MAX_DIRECTORY_AVATAR_INDEX = ROOT_HIGHEST_AVATAR;
+static constexpr u32 DIRECTORY_HEADER_SIZE = sizeof(TDO::DirectoryHeader);
+static constexpr u32 M1_MAX_ROMTAG_BLOCK_SIZE = 2048;
+static constexpr u32 M1_RSA_SIGNATURE_SIZE = 64;
+static constexpr u32 M2_MAX_ROMTAG_BLOCK_SIZE = 8192;
+typedef std::array<u8,CDROM_SECTOR_SIZE> CDROMSectorBuf;
+typedef std::array<u8,SYNC_PATTERN_SIZE> CDROMSyncPatternBuf;
+typedef std::array<u8,VOLUME_SYNC_BYTE_LEN> VolumeSyncByteBuf;
 static constexpr CDROMSyncPatternBuf MODE1_SYNC_PATTERN = {0x00,0xFF,0xFF,0xFF,
                                                            0xFF,0xFF,0xFF,0xFF,
                                                            0xFF,0xFF,0xFF,0x00};
 static constexpr VolumeSyncByteBuf VOLUME_SYNC_BYTES = {0x5A,0x5A,0x5A,0x5A,0x5A};
-static constexpr std::array<uint8_t,4> ARM_NOOP = {0xE1,0xA0,0x10,01};
+
+static
+inline
+s64
+_round_up(s64 number_,
+          s64 multiple_)
+{
+  return (((number_ + multiple_ - 1) / multiple_) * multiple_);
+}
+
+static
+inline
+u64
+_div_round_up(u64 number_,
+              u64 multiple_)
+{
+  return ((number_ + multiple_ - 1) / multiple_);
+}
+
+static
+inline
+u64
+_checked_s64_add(u64        lhs_,
+                 u64        rhs_,
+                 const char *msg_)
+{
+  static constexpr u64 S64_MAX_AS_U64 = static_cast<u64>(S64_MAX);
+
+  if((lhs_ > S64_MAX_AS_U64) ||
+     (rhs_ > S64_MAX_AS_U64) ||
+     (lhs_ > (S64_MAX_AS_U64 - rhs_)))
+    throw Error(msg_);
+
+  return (lhs_ + rhs_);
+}
+
+static
+inline
+u64
+_checked_s64_mul(u64        lhs_,
+                 u64        rhs_,
+                 const char *msg_)
+{
+  static constexpr u64 S64_MAX_AS_U64 = static_cast<u64>(S64_MAX);
+
+  if((rhs_ != 0) && (lhs_ > (S64_MAX_AS_U64 / rhs_)))
+    throw Error(msg_);
+
+  return (lhs_ * rhs_);
+}
+
+static
+inline
+s64
+_data_byte_to_file_offset(s64 data_byte_,
+                          u64 data_start_offset_,
+                          u64 device_block_header_,
+                          u64 device_block_data_size_,
+                          u64 device_block_size_)
+{
+  static constexpr const char *MSG = "data offset is too large";
+  u64 block;
+  u64 extra;
+  u64 file_offset;
+  u64 pos;
+
+  if(data_byte_ < 0)
+    throw Error("data offset must be non-negative");
+  if(device_block_data_size_ == 0)
+    throw Error("device block data size must be non-zero");
+
+  pos   = _checked_s64_add(data_byte_,data_start_offset_,MSG);
+  block = (pos / device_block_data_size_);
+  extra = (pos % device_block_data_size_);
+
+  file_offset  = _checked_s64_mul(block,device_block_size_,MSG);
+  file_offset  = _checked_s64_add(file_offset,device_block_header_,MSG);
+  file_offset  = _checked_s64_add(file_offset,extra,MSG);
+
+  return static_cast<s64>(file_offset);
+}
+
+static
+inline
+bool
+_is_m2_volume(const TDO::DiscLabel &dl_)
+{
+  return ((dl_.volume_flags & VOLUME_FLAG_M2) != 0);
+}
+
+static
+inline
+u64
+_disc_label_size_in_bytes(const TDO::DiscLabel &dl_)
+{
+  if(_is_m2_volume(dl_))
+    return sizeof(TDO::ExtDiscLabel);
+
+  return sizeof(TDO::DiscLabel);
+}
 
 static
 inline
 void
-_swap(uint32_t &u32_)
+_validate_m2_romtag_count(u32 count_)
+{
+  if(count_ > (M2_MAX_ROMTAG_BLOCK_SIZE / sizeof(TDO::ROMTag)))
+    throw Error(fmt::format("invalid M2 ROMTag count: {}",count_));
+}
+
+static
+inline
+void
+_swap(u32 &u32_)
 {
   u32_ = __builtin_bswap32(u32_);
 }
@@ -54,79 +167,64 @@ _swap(uint32_t &u32_)
 static
 inline
 void
-_swap(int32_t &i32_)
+_swap(s32 &s32_)
 {
-  i32_ = __builtin_bswap32(i32_);
+  s32_ = __builtin_bswap32(s32_);
 }
 
-static
-inline
-void
-_swap(uint16_t &u16_)
-{
-  u16_ = __builtin_bswap16(u16_);
-}
-
-static
-inline
-void
-_swap(int16_t &i16_)
-{
-  i16_ = __builtin_bswap16(i16_);
-}
-
-static
-inline
-void
-_swap(uint64_t &u64_)
-{
-  u64_ = __builtin_bswap64(u64_);
-}
-
-static
-inline
-void
-_swap(int64_t &i64_)
-{
-  i64_ = __builtin_bswap64(i64_);
-}
-
-TDO::DevStream::DevStream(std::istream &is_)
-  : _device_block_data_size(0),
-    _device_block_header(0),
+TDO::DevStream::DevStream(std::iostream &ios_)
+  : _device_block_header(0),
+    _device_block_data_size(0),
     _device_block_footer(0),
-    _data_offset(0),
-    _is(is_),
-    _initialized(false)
+    _data_start_offset(0),
+    _disc_label_size_in_bytes(0),
+    _disc_label_block(0),
+    _romtags_block(0),
+    _romtags_entry_count(0),
+    _romtags_entry_count_is_explicit(false),
+    _ios(ios_)
 {
-
 }
 
 void
 TDO::DevStream::find_label()
 {
-  int i;
-  char v;
+  static constexpr std::array<char, 6> PATTERN =
+    {RECORD_STD_VOLUME, VOLUME_SYNC_BYTE, VOLUME_SYNC_BYTE,
+     VOLUME_SYNC_BYTE, VOLUME_SYNC_BYTE, VOLUME_SYNC_BYTE};
+  static constexpr u64 CHUNK_SIZE = 65536;
+  static constexpr u64 OVERLAP = PATTERN.size() - 1;
+  std::vector<char> buf(CHUNK_SIZE + OVERLAP);
+  u64 bytes_scanned = 0;
 
-  _is.seekg(0);
-  while(_is && !_is.eof())
+  _ios.seekg(0);
+  while(_ios && !_ios.eof() && (bytes_scanned < MAX_RECOGNITION_SCAN_BYTES))
     {
-      _is.read(&v,1);
-      if(v != RECORD_STD_VOLUME)
-        continue;
+      const u64 seek_pos = (bytes_scanned > OVERLAP) ? bytes_scanned - OVERLAP : 0;
+      _ios.seekg(seek_pos);
 
-      for(i = 0; i < VOLUME_SYNC_BYTE_LEN; i++)
+      const u64 remaining = MAX_RECOGNITION_SCAN_BYTES - bytes_scanned;
+      const u64 to_read = std::min<u64>(CHUNK_SIZE + OVERLAP, remaining + OVERLAP);
+      _ios.read(buf.data(), to_read);
+      const std::streamsize n = _ios.gcount();
+      if(n <= 0)
+        break;
+
+      const u64 scan_limit = n - OVERLAP;
+      for(u64 i = 0; i < scan_limit; i++)
         {
-          _is.read(&v,1);
-          if(v == VOLUME_SYNC_BYTE)
-            continue;
-          break;
+          if(std::memcmp(&buf[i], PATTERN.data(), PATTERN.size()) == 0)
+            {
+              _ios.clear(_ios.rdstate() & std::ios::badbit);
+              _ios.seekg(seek_pos + i);
+              return;
+            }
         }
 
-      _is.seekg(-(i + 1),_is.cur);
-      if(i == 5)
-        break;
+      bytes_scanned += scan_limit;
     }
+
+  throw Error("no OperaFS label was found");
 }
 
 bool
@@ -134,8 +232,8 @@ TDO::DevStream::is_mode1_2352()
 {
   CDROMSectorBuf buf;
 
-  _is.seekg(0);
-  _is.read((char*)&buf[0],buf.size());
+  _ios.seekg(0);
+  _ios.read((char*)&buf[0],buf.size());
 
   const bool has_mode1_sync_pattern =
     (memcmp(&buf[0],&MODE1_SYNC_PATTERN[0],MODE1_SYNC_PATTERN.size()) == 0);
@@ -144,51 +242,47 @@ TDO::DevStream::is_mode1_2352()
   return (has_mode1_sync_pattern && has_mode1_sector_marker);
 }
 
-std::uint32_t
-TDO::DevStream::count_m1_romtags(const std::int64_t pos_)
-{
-  uint32_t count;
-  TDO::ROMTag tag;
-  TDO::PosGuard guard(*this);
-
-  data_block_seek(pos_);
-
-  count = 0;
-  while(true)
-    {
-      read(tag);
-      if((tag.sub_systype == 0) || (tag.type == 0))
-        break;
-      count++;
-    }
-
-  return count;
-}
-
 void
 TDO::DevStream::setup()
 {
-  TDO::DiscLabel label;
+  TDO::DiscLabel dl;
 
   if(is_mode1_2352())
     {
       _device_block_header = 16;
       _device_block_footer = 288;
     }
+  else
+    {
+      _device_block_header = 0;
+      _device_block_footer = 0;
+    }
 
   find_label();
-  if(eof())
-    _throw("unable to find OperaFS in image");
 
   {
-    PosGuard guard(*this);
-    read(label);
-    _device_block_data_size = label.volume_block_size;
+    TDO::PosGuard guard(*this);
+
+    read(dl);
+    _device_block_data_size = dl.volume_block_size;
+    _disc_label_size_in_bytes = ::_disc_label_size_in_bytes(dl);
+    _romtags_entry_count = 0;
+    _romtags_entry_count_is_explicit = false;
+    if(::_is_m2_volume(dl))
+      {
+        read(_romtags_entry_count);
+        ::_validate_m2_romtag_count(_romtags_entry_count);
+        _romtags_entry_count_is_explicit = true;
+      }
   }
 
-  _initialized = true;
+  _data_start_offset = data_byte_tell();
+  _disc_label_block = data_block_tell();
+  _romtags_block = (_disc_label_block +
+                    ::_div_round_up(_disc_label_size_in_bytes,
+                                     _device_block_data_size));
 
-  _data_offset = data_byte_tell();
+  _ios.seekg(0);
 }
 
 static
@@ -200,94 +294,186 @@ is_romfs(TDO::DevStream &stream_)
           (stream_.device_block_footer()    == 0));
 }
 
-static
-bool
-is_konami_m2(TDO::DevStream &stream_)
-{
-  TDO::DiscLabel dl;
-
-  stream_.find_label();
-  const bool found_label = !stream_.eof();
-
-  if(!found_label)
-    return found_label;
-  stream_.read(dl);
-
-  const bool has_expected_volume_flags =
-    (dl.volume_flags == (VOLUME_FLAG_M2 | VOLUME_FLAG_BLESSED));
-  const bool has_expected_volume_identifier =
-    (strcmp(&dl.volume_identifier[0],"cd-rom") == 0);
-  const bool has_expected_rom_tag_count = (dl.num_rom_tags == 9);
-
-  return (has_expected_volume_flags &&
-          has_expected_volume_identifier &&
-          has_expected_rom_tag_count);
-}
-
 bool
 TDO::DevStream::has_romtags()
 {
   TDO::PosGuard pos_guard(*this);
 
-  const bool uses_romfs_layout = ::is_romfs(*this);
-  const bool uses_konami_m2_layout = ::is_konami_m2(*this);
+  if(::is_romfs(*this))
+    return false;
+  if(_romtags_entry_count_is_explicit)
+    return (_romtags_entry_count != 0);
 
-  return (!uses_romfs_layout && !uses_konami_m2_layout);
+  return true;
+}
+
+TDO::DiscLabel
+TDO::DevStream::disc_label()
+{
+  TDO::DiscLabel dl;
+  TDO::PosGuard pos_guard(*this);
+
+  data_block_seek(disc_label_block());
+  read(dl);
+
+  return dl;
+}
+
+u64
+TDO::DevStream::disc_label_size_in_bytes() const
+{
+  return _disc_label_size_in_bytes;
+}
+
+u64
+TDO::DevStream::disc_label_block() const
+{
+  return _disc_label_block;
+}
+
+u64
+TDO::DevStream::_romtags_count_impl()
+{
+  TDO::PosGuard guard(*this);
+
+  if(!has_romtags())
+    return 0;
+
+  data_block_seek(romtags_block());
+  if(_romtags_entry_count_is_explicit)
+    return _romtags_entry_count;
+
+  u64 count = 0;
+  u64 rttlen = 0;
+  while(true)
+    {
+      TDO::ROMTag romtag;
+
+      read(romtag);
+      count++;
+      if(romtag.sub_systype == 0)
+        break;
+
+      rttlen += sizeof(TDO::ROMTag);
+      if(rttlen > (M1_MAX_ROMTAG_BLOCK_SIZE -
+                   M1_RSA_SIGNATURE_SIZE -
+                   sizeof(TDO::ROMTag)))
+        throw Error("invalid OperaFS ROMTag table: missing terminator");
+    }
+
+  return count;
 }
 
 TDO::ROMTagVec
 TDO::DevStream::romtags()
 {
-  std::int64_t pos;
-  TDO::DiscLabel dl;
-  TDO::ROMTagVec tags;
+  TDO::ROMTagVec romtags;
+  TDO::PosGuard guard(*this);
 
   if(!has_romtags())
-    return tags;
+    return romtags;
 
-  find_label();
-  pos = data_block_tell();
-  read(dl);
-
-  if(dl.num_rom_tags == 0)
-    dl.num_rom_tags = count_m1_romtags(pos+1);
-
-  data_block_seek(pos+1);
-  for(uint32_t i = 0; i < dl.num_rom_tags; i++)
+  data_block_seek(romtags_block());
+  if(_romtags_entry_count_is_explicit)
     {
-      TDO::ROMTag tag;
-      read(tag);
-      tags.push_back(tag);
+      for(u32 i = 0; i < _romtags_entry_count; i++)
+        {
+          TDO::ROMTag romtag;
+
+          read(romtag);
+          romtags.emplace_back(romtag);
+        }
+    }
+  else
+    {
+      u64 rttlen;
+
+      rttlen = 0;
+      while(true)
+        {
+          TDO::ROMTag romtag;
+
+          read(romtag);
+          if(romtag.sub_systype == 0)
+            break;
+
+          rttlen += sizeof(TDO::ROMTag);
+          if(rttlen > (M1_MAX_ROMTAG_BLOCK_SIZE -
+                       M1_RSA_SIGNATURE_SIZE -
+                       sizeof(TDO::ROMTag)))
+            throw Error("invalid OperaFS ROMTag table: missing terminator");
+
+          romtags.emplace_back(romtag);
+        }
     }
 
-  return tags;
+  return romtags;
 }
 
-std::uint32_t
+std::optional<TDO::ROMTag>
+TDO::DevStream::romtag(const int type_)
+{
+  TDO::PosGuard guard(*this);
+
+  if(!has_romtags())
+    return {};
+
+  for(const auto &romtag : romtags())
+    if(romtag.type == type_)
+      return romtag;
+
+  return {};
+}
+
+u64
+TDO::DevStream::romtags_block() const
+{
+  return _romtags_block;
+}
+
+u64
+TDO::DevStream::romtags_count()
+{
+  return _romtags_count_impl();
+}
+
+u64
+TDO::DevStream::romtags_size_in_bytes()
+{
+  return (romtags_count() * sizeof(TDO::ROMTag));
+}
+
+u64
 TDO::DevStream::data_offset() const
 {
-  return _data_offset;
+  return _data_start_offset;
 }
 
-std::uint32_t
+u64
+TDO::DevStream::data_start_offset() const
+{
+  return _data_start_offset;
+}
+
+u64
 TDO::DevStream::device_block_header() const
 {
   return _device_block_header;
 }
 
-std::uint32_t
+u64
 TDO::DevStream::device_block_data_size() const
 {
   return _device_block_data_size;
 }
 
-std::uint32_t
+u64
 TDO::DevStream::device_block_footer() const
 {
   return _device_block_footer;
 }
 
-std::uint32_t
+u64
 TDO::DevStream::device_block_size() const
 {
   return (_device_block_header +
@@ -295,133 +481,144 @@ TDO::DevStream::device_block_size() const
           _device_block_footer);
 }
 
-std::uint32_t
+u64
 TDO::DevStream::device_block_count()
 {
-  assert(_initialized == true);
+  TDO::PosGuard guard(*this);
 
-  PosGuard guard(*this);
-  std::uint64_t pos;
+  // Check failbit on the seek and use file_tell() (which throws on
+  // tellg == -1) rather than letting a failed seek leave tellg at -1.
+  // streamoff(-1) / u64(blocksize) undergoes the usual arithmetic
+  // conversion (signed -> unsigned) producing 0xFFFF... / blocksize,
+  // a huge u64 that silently bypasses downstream end-bound checks
+  // such as safe_romtag_first_data_block's offset+1 >= file_blocks
+  // guard.
+  _ios.seekg(0,_ios.end);
+  if(!_ios.good())
+    throw Error("stream seek to end failed in device_block_count");
 
-  _is.seekg(0,_is.end);
-  pos = _is.tellg();
-  pos /= device_block_size();
-
-  return pos;
+  const s64 pos = file_tell();
+  return (static_cast<u64>(pos) / device_block_size());
 }
 
-std::int64_t
-TDO::DevStream::data_block_to_file_offset(std::int64_t data_block_) const
+s64
+TDO::DevStream::data_block_to_file_offset(s64 data_block_) const
 {
-  assert(_initialized == true);
+  s64 data_byte;
 
-  std::int64_t file_offset;
+  if(data_block_ < 0)
+    throw Error("data block must be non-negative");
 
-  file_offset = _data_offset;
-  file_offset += (data_block_ * device_block_size());
-  file_offset += _device_block_header;
+  data_byte = _checked_s64_mul(data_block_,
+                               _device_block_data_size,
+                               "data block offset is too large");
 
-  return file_offset;
+  return _data_byte_to_file_offset(data_byte,
+                                   _data_start_offset,
+                                   _device_block_header,
+                                   _device_block_data_size,
+                                   device_block_size());
 }
 
-std::int64_t
-TDO::DevStream::file_offset_to_data_block(const std::int64_t file_offset_) const
-{
-  assert(_initialized == true);
-
-  std::int64_t block;
-  std::int64_t extra;
-  std::int64_t file_offset;
-
-  file_offset = file_offset_;
-  block       = (file_offset / device_block_size());
-  extra       = (file_offset % device_block_size());
-
-  file_offset  = (block * _device_block_data_size);
-  file_offset += (extra - _device_block_header);
-  file_offset -= _data_offset;
-
-  return (file_offset / _device_block_data_size);
-}
-
-std::int64_t
+s64
 TDO::DevStream::file_tell() const
 {
-  return _is.tellg();
+  s64 rv;
+
+  rv = _ios.tellg();
+  if(rv == -1)
+    throw Error("stream position error");
+
+  return rv;
 }
 
-std::int64_t
-TDO::DevStream::data_byte_tell(const std::int64_t pos_) const
+s64
+TDO::DevStream::_file_pos_to_data_byte_pos(const s64 pos_) const
 {
-  assert(_initialized == true);
+  static constexpr const char *MSG = "file position is out of range";
+  u64 pos;
+  u64 block;
+  u64 extra;
+  u64 result;
 
-  std::int64_t pos;
-  std::int64_t block;
-  std::int64_t extra;
+  // Mirror the structure of _data_byte_to_file_offset above: enforce
+  // pos_ >= 0 explicitly and do all arithmetic in u64. The previous
+  // implementation mixed an s64 destination variable with u64 member
+  // operands, which produced two wrap hazards:
+  //  - (extra - _device_block_header) wraps to ~U64_MAX when pos_
+  //    lands inside the 16-byte block header of a mode-1/2352 image.
+  //  - (pos -= _data_start_offset) wraps when pos_ falls before the
+  //    start of the data region.
+  // Both used to silently produce a huge positive s64 result.
+  if(pos_ < 0)
+    throw Error("file position must be non-negative");
+  if(device_block_size() == 0)
+    throw Error("device block size must be non-zero");
 
-  pos   = pos_;
+  pos   = static_cast<u64>(pos_);
   block = (pos / device_block_size());
   extra = (pos % device_block_size());
 
-  pos  = (block * _device_block_data_size);
-  pos += (extra - _device_block_header);
-  pos -= _data_offset;
+  if(extra < _device_block_header)
+    throw Error("file position points inside device block header");
 
-  return pos;
+  result  = _checked_s64_mul(block,_device_block_data_size,MSG);
+  result  = _checked_s64_add(result,extra - _device_block_header,MSG);
+  if(result < _data_start_offset)
+    throw Error("file position is before start of data region");
+  result -= _data_start_offset;
+
+  return TDO::checked_narrow_u64_to_s64(result,"data byte position");
 }
 
-std::int64_t
+s64
+TDO::DevStream::data_byte_tell(const s64 pos_) const
+{
+  return _file_pos_to_data_byte_pos(pos_);
+}
+
+s64
 TDO::DevStream::data_byte_tell() const
 {
-  std::int64_t pos;
-
-  pos = file_tell();
-
-  return data_byte_tell(pos);
+  return data_byte_tell(file_tell());
 }
 
-std::int64_t
-TDO::DevStream::data_block_tell(const std::int64_t pos_) const
+s64
+TDO::DevStream::data_block_tell(const s64 pos_) const
 {
-  assert(_initialized == true);
-
-  std::int64_t pos;
-  std::int64_t block;
-  std::int64_t extra;
-
-  pos   = pos_;
-  block = (pos / device_block_size());
-  extra = (pos % device_block_size());
-
-  pos  = (block * _device_block_data_size);
-  pos += (extra - _device_block_header);
-  pos -= _data_offset;
-
-  return (pos / _device_block_data_size);
+  return (_file_pos_to_data_byte_pos(pos_) / _device_block_data_size);
 }
 
-std::int64_t
+s64
 TDO::DevStream::data_block_tell() const
 {
-  std::int64_t pos;
+  s64 pos;
 
   pos = file_tell();
 
   return data_block_tell(pos);
 }
 
-std::int64_t
-TDO::DevStream::device_block_tell(const std::int64_t pos_) const
+s64
+TDO::DevStream::device_block_tell(const s64 pos_) const
 {
-  assert(_initialized == true);
+  // Match the protective shape of _file_pos_to_data_byte_pos: reject
+  // a negative pos_ rather than letting s64/u64 mixed division
+  // reinterpret it as a huge u64 quotient that the caller silently
+  // accepts. The block-count quotient itself is bounded by pos_ so a
+  // direct cast back to s64 is safe once non-negative.
+  if(pos_ < 0)
+    throw Error("file position must be non-negative");
+  if(device_block_size() == 0)
+    throw Error("device block size must be non-zero");
 
-  return (pos_ / device_block_size());
+  return static_cast<s64>(static_cast<u64>(pos_) / device_block_size());
 }
 
-std::int64_t
+s64
 TDO::DevStream::device_block_tell() const
 {
-  std::int64_t pos;
+  s64 pos;
 
   pos = file_tell();
 
@@ -429,35 +626,30 @@ TDO::DevStream::device_block_tell() const
 }
 
 void
-TDO::DevStream::file_seek(const std::int64_t pos_)
+TDO::DevStream::file_seek(const s64 pos_)
 {
-  _is.seekg(pos_);
+  _ios.seekg(pos_);
+  _ios.seekp(pos_);
 }
 
 void
-TDO::DevStream::data_byte_seek(const std::int64_t pos_)
+TDO::DevStream::data_byte_seek(const s64 pos_)
 {
-  assert(_initialized == true);
+  s64 pos;
 
-  std::int64_t pos;
-  std::int64_t block;
-  std::int64_t extra;
-
-  pos   = (pos_ + _data_offset);
-  block = (pos / _device_block_data_size);
-  extra = (pos % _device_block_data_size);
-
-  pos  = (block * device_block_size());
-  pos += _device_block_header;
-  pos += extra;
+  pos = _data_byte_to_file_offset(pos_,
+                                  _data_start_offset,
+                                  _device_block_header,
+                                  _device_block_data_size,
+                                  device_block_size());
 
   file_seek(pos);
 }
 
 void
-TDO::DevStream::data_byte_skip(const std::int64_t count_)
+TDO::DevStream::data_byte_skip(const s64 count_)
 {
-  std::int64_t pos;
+  s64 pos;
 
   pos  = data_byte_tell();
   pos += count_;
@@ -466,9 +658,9 @@ TDO::DevStream::data_byte_skip(const std::int64_t count_)
 }
 
 void
-TDO::DevStream::data_block_seek(const std::int64_t block_)
+TDO::DevStream::data_block_seek(const s64 block_)
 {
-  std::int64_t file_offset;
+  s64 file_offset;
 
   file_offset = data_block_to_file_offset(block_);
 
@@ -476,9 +668,9 @@ TDO::DevStream::data_block_seek(const std::int64_t block_)
 }
 
 void
-TDO::DevStream::data_block_skip(const std::int64_t count_)
+TDO::DevStream::data_block_skip(const s64 count_)
 {
-  std::int64_t pos;
+  s64 pos;
 
   pos  = data_block_tell();
   pos += count_;
@@ -487,19 +679,29 @@ TDO::DevStream::data_block_skip(const std::int64_t count_)
 }
 
 void
-TDO::DevStream::device_block_seek(const std::int64_t pos_)
+TDO::DevStream::device_block_seek(const s64 pos_)
 {
-  std::int64_t pos;
+  static constexpr const char *MSG = "device block offset is too large";
+  u64 pos;
 
-  pos = (pos_ * device_block_size());
+  // Mirror _data_byte_to_file_offset / fix to _file_pos_to_data_byte_pos:
+  // reject negative pos_ explicitly so the s64*u64 multiplication does
+  // not silently reinterpret a sign-bit value as a huge u64. Route the
+  // multiply through _checked_s64_mul so an overlarge image-block
+  // index produces an Error rather than a wrapped file offset, and
+  // narrow the u64 back through checked_narrow_u64_to_s64 for symmetry.
+  if(pos_ < 0)
+    throw Error("device block must be non-negative");
 
-  file_seek(pos);
+  pos = _checked_s64_mul(static_cast<u64>(pos_),device_block_size(),MSG);
+
+  file_seek(TDO::checked_narrow_u64_to_s64(pos,"device block file offset"));
 }
 
 void
-TDO::DevStream::device_block_skip(const std::int64_t count_)
+TDO::DevStream::device_block_skip(const s64 count_)
 {
-  std::int64_t pos;
+  s64 pos;
 
   pos  = device_block_tell();
   pos += count_;
@@ -508,18 +710,103 @@ TDO::DevStream::device_block_skip(const std::int64_t count_)
 }
 
 void
-TDO::DevStream::read(char     *buf_,
-                     uint32_t  size_)
+TDO::DevStream::read(char      *buf_,
+                     const u64  size_)
 {
-  const std::streampos pos = _is.tellg();
-
-  if(!_is.good())
+  if(!_ios.good())
     _throw("bad stream state before read");
 
-  _is.read(buf_,size_);
+  _ios.read(buf_,size_);
 
-  if(!_is.good())
+  if(!_ios.good())
     _throw("bad stream state after read");
+}
+
+void
+TDO::DevStream::write(const char *buf_,
+                      const u64   size_)
+{
+  _ios.write(buf_,size_);
+  if(!_ios.good())
+    _throw("bad stream state after write");
+}
+
+void
+TDO::DevStream::read_data_blocks(std::vector<char> &v_,
+                                 const s64          pos_,
+                                 const s64          blocks_)
+{
+  size_t end;
+
+  end = v_.size();
+  v_.resize(end + (device_block_data_size() * blocks_));
+  for(s64 i = 0; i < blocks_; i++)
+    {
+      data_block_seek(pos_ + i);
+      read(&v_[end],device_block_data_size());
+      end += device_block_data_size();
+    }
+}
+
+void
+TDO::DevStream::read_data_bytes_from_block(char     *buf_,
+                                             const s64 block_pos_,
+                                             const s64 bytes_)
+{
+  read_data_bytes(buf_,
+                  (block_pos_ * device_block_data_size()),
+                  bytes_);
+}
+
+void
+TDO::DevStream::read_data_bytes(char     *buf_,
+                               const s64 pos_,
+                               const s64 bytes_)
+{
+  s64 pos;
+  s64 bytes_read;
+  s64 bytes_to_read;
+  s64 block_size;
+
+  bytes_read = 0;
+  block_size = device_block_data_size();
+
+  pos = pos_;
+  for(s64 bytes_left = bytes_; bytes_left > 0;)
+    {
+      data_byte_seek(pos);
+
+      bytes_to_read = (block_size - (pos % block_size));
+      bytes_to_read = std::min(bytes_to_read,bytes_left);
+
+      read(&buf_[bytes_read],bytes_to_read);
+
+      pos        += bytes_to_read;
+      bytes_left -= bytes_to_read;
+      bytes_read += bytes_to_read;
+    }
+}
+
+void
+TDO::DevStream::read_data_bytes_from_block(std::vector<char> &v_,
+                                           const s64          block_pos_,
+                                           const s64          bytes_)
+{
+  s64 vec_end = v_.size();
+  v_.resize(v_.size() + bytes_);
+  read_data_bytes(&v_[vec_end],
+                  (block_pos_ * device_block_data_size()),
+                  bytes_);
+}
+
+void
+TDO::DevStream::read_data_bytes(std::vector<char> &v_,
+                                const s64          pos_,
+                                const s64          bytes_)
+{
+  s64 vec_end = v_.size();
+  v_.resize(v_.size() + bytes_);
+  read_data_bytes(&v_[vec_end],pos_,bytes_);
 }
 
 void
@@ -529,23 +816,49 @@ TDO::DevStream::read(char &c_)
 }
 
 void
-TDO::DevStream::read(uint8_t &u8_)
+TDO::DevStream::write(const char c_)
+{
+  write(&c_,1);
+}
+
+void
+TDO::DevStream::read(u8 &u8_)
 {
   read((char*)&u8_,1);
 }
 
 void
-TDO::DevStream::read(uint32_t &u32_)
+TDO::DevStream::write(u8 u8_)
 {
-  read((char*)&u32_,sizeof(uint32_t));
+  write((const char*)&u8_,1);
+}
+
+void
+TDO::DevStream::read(u32 &u32_)
+{
+  read((char*)&u32_,sizeof(u32));
   _swap(u32_);
 }
 
 void
-TDO::DevStream::read(int32_t &i32_)
+TDO::DevStream::write(u32 u32_)
 {
-  read((char*)&i32_,sizeof(int32_t));
-  _swap(i32_);
+  _swap(u32_);
+  write((const char*)&u32_,sizeof(u32));
+}
+
+void
+TDO::DevStream::read(s32 &s32_)
+{
+  read((char*)&s32_,sizeof(s32));
+  _swap(s32_);
+}
+
+void
+TDO::DevStream::write(s32 s32_)
+{
+  _swap(s32_);
+  write((const char*)&s32_,sizeof(s32));
 }
 
 void
@@ -553,12 +866,12 @@ TDO::DevStream::read(TDO::DiscLabel &dl_)
 {
   TDO::DiscLabel tmp;
 
-  read(&tmp.record_type,sizeof(tmp.record_type));
-  read(&tmp.volume_sync_bytes[0],sizeof(tmp.volume_sync_bytes));
-  read(&tmp.volume_structure_version,sizeof(tmp.volume_structure_version));
-  read(&tmp.volume_flags,sizeof(tmp.volume_flags));
-  read(&tmp.volume_commentary[0],sizeof(tmp.volume_commentary));
-  read(&tmp.volume_identifier[0],sizeof(tmp.volume_identifier));
+  read(tmp.record_type);
+  read(tmp.volume_sync_bytes);
+  read(tmp.volume_structure_version);
+  read(tmp.volume_flags);
+  read(tmp.volume_commentary);
+  read(tmp.volume_identifier);
   read(tmp.volume_unique_identifier);
   read(tmp.volume_block_size);
   read(tmp.volume_block_count);
@@ -566,21 +879,7 @@ TDO::DevStream::read(TDO::DiscLabel &dl_)
   read(tmp.root_directory_block_count);
   read(tmp.root_directory_block_size);
   read(tmp.root_directory_last_avatar_index);
-
-  for(std::size_t i = 0; i < tmp.root_directory_avatar_list.size(); i++)
-    read(tmp.root_directory_avatar_list[i]);
-
-  if(tmp.volume_flags & VOLUME_FLAG_M2)
-    {
-      read(tmp.num_rom_tags);
-      read(tmp.application_id);
-      memset(tmp.reserved,0,sizeof(tmp.reserved));
-    }
-  else
-    {
-      tmp.num_rom_tags = 0;
-      tmp.application_id = 0;
-    }
+  read(tmp.root_directory_avatar_list);
 
   if(tmp.record_type != RECORD_STD_VOLUME)
     _throw("invalid OperaFS disc label: incorrect record type");
@@ -599,7 +898,54 @@ TDO::DevStream::read(TDO::DiscLabel &dl_)
   if(tmp.root_directory_last_avatar_index > ROOT_HIGHEST_AVATAR)
     _throw("invalid OperaFS disc label: root directory avatar index exceeds maximum");
 
+  // Bound volume_block_count against the raw file size. Consumers
+  // (signer, verifier) multiply this by BLOCK_SIZE / LOG_BLOCK_SIZE
+  // to derive digest counts and signature-file sizes, so an
+  // unbounded value produces astronomical work and out-of-image
+  // reads. We compare against raw size_in_bytes() rather than the
+  // device block count because geometry may not yet be initialized
+  // when this runs during setup(); the resulting bound is loose
+  // but correct (data bytes are always <= raw bytes).
+  //
+  // size_in_bytes() returns s64 and may be -1 when tellg() fails
+  // (or when the stream geometry is not yet known); casting -1 to
+  // u64 yields 0xFFFF... and silently disables the bound. Inspect
+  // the signed value first and skip the check only when size is
+  // genuinely unavailable.
+  {
+    const u64 vbc = tmp.volume_block_count;
+    const u64 vbs = tmp.volume_block_size;
+    if((vbs > 0) && (vbc > (std::numeric_limits<u64>::max() / vbs)))
+      _throw("invalid OperaFS disc label: volume_block_count overflows volume_block_size math");
+    const s64 raw_bytes_signed = size_in_bytes();
+    if((raw_bytes_signed > 0) && (vbs > 0))
+      {
+        const u64 raw_bytes = static_cast<u64>(raw_bytes_signed);
+        if((vbc * vbs) > raw_bytes)
+          _throw("invalid OperaFS disc label: volume_block_count exceeds image size");
+      }
+  }
+
   dl_ = tmp;
+}
+
+void
+TDO::DevStream::write(const TDO::DiscLabel &dl_)
+{
+  write(dl_.record_type);
+  write(dl_.volume_sync_bytes);
+  write(dl_.volume_structure_version);
+  write(dl_.volume_flags);
+  write(dl_.volume_commentary);
+  write(dl_.volume_identifier);
+  write(dl_.volume_unique_identifier);
+  write(dl_.volume_block_size);
+  write(dl_.volume_block_count);
+  write(dl_.root_unique_identifier);
+  write(dl_.root_directory_block_count);
+  write(dl_.root_directory_block_size);
+  write(dl_.root_directory_last_avatar_index);
+  write(dl_.root_directory_avatar_list);
 }
 
 void
@@ -613,17 +959,17 @@ TDO::DevStream::read(TDO::DirectoryHeader &dh_)
   read(tmp.first_free_byte);
   read(tmp.first_entry_offset);
 
-  const std::uint32_t dev_block_count = device_block_count();
+  const u64 dev_block_count = device_block_count();
 
   if(tmp.next_block < -1)
     _throw("unsafe OperaFS directory metadata: invalid next_block");
   if(tmp.prev_block < -1)
     _throw("unsafe OperaFS directory metadata: invalid prev_block");
   if((tmp.next_block != -1) &&
-     (static_cast<std::uint32_t>(tmp.next_block) >= dev_block_count))
+     (static_cast<u64>(tmp.next_block) >= dev_block_count))
     _throw("unsafe OperaFS directory metadata: next_block exceeds device bounds");
   if((tmp.prev_block != -1) &&
-     (static_cast<std::uint32_t>(tmp.prev_block) >= dev_block_count))
+     (static_cast<u64>(tmp.prev_block) >= dev_block_count))
     _throw("unsafe OperaFS directory metadata: prev_block exceeds device bounds");
   if(tmp.first_free_byte < DIRECTORY_HEADER_SIZE)
     _throw("unsafe OperaFS directory metadata: first_free_byte overlaps header");
@@ -639,7 +985,7 @@ void
 TDO::DevStream::read(TDO::DirectoryRecord &dr_)
 {
   TDO::DirectoryRecord tmp;
-  std::array<std::uint32_t, MAX_DIRECTORY_AVATAR_INDEX + 1> avatar_list;
+  std::array<u32,MAX_DIRECTORY_AVATAR_INDEX + 1> avatar_list;
 
   read(tmp.flags);
   read(tmp.unique_identifier);
@@ -649,25 +995,22 @@ TDO::DevStream::read(TDO::DirectoryRecord &dr_)
   read(tmp.block_count);
   read(tmp.burst);
   read(tmp.gap);
-  read(tmp.filename,sizeof(tmp.filename));
+  read(tmp.filename,32);
   read(tmp.last_avatar_index);
 
   if(tmp.last_avatar_index > MAX_DIRECTORY_AVATAR_INDEX)
-    _throw("impossible OperaFS directory record last_avatar_index: %d > %d",
-           tmp.last_avatar_index, MAX_DIRECTORY_AVATAR_INDEX);
+    _throw("impossible OperaFS directory record last_avatar_index: {} > {}",
+           tmp.last_avatar_index,MAX_DIRECTORY_AVATAR_INDEX);
 
-  for(std::uint32_t i = 0; i <= tmp.last_avatar_index; i++)
+  for(u32 i = 0; i <= tmp.last_avatar_index; i++)
     read(avatar_list[i]);
 
   tmp.avatar_list.assign(avatar_list.begin(),
                          avatar_list.begin() + (tmp.last_avatar_index + 1));
 
-  const std::uint32_t avatar_count = tmp.last_avatar_index + 1;
-  const std::uint32_t data_block_size = device_block_data_size();
+  const u32 avatar_count = tmp.last_avatar_index + 1;
+  const u32 data_block_size = device_block_data_size();
 
-  if(tmp.last_avatar_index > MAX_DIRECTORY_AVATAR_INDEX)
-    _throw("impossible OperaFS directory record last_avatar_index: {} > {}",
-           tmp.last_avatar_index,MAX_DIRECTORY_AVATAR_INDEX);
   if(tmp.avatar_list.size() != avatar_count)
     _throw("impossible OperaFS directory record avatar count: avatar_list.size()={} last_avatar_index+1={}",
            tmp.avatar_list.size(),avatar_count);
@@ -676,9 +1019,12 @@ TDO::DevStream::read(TDO::DirectoryRecord &dr_)
   if((data_block_size == 0) || ((tmp.block_size % data_block_size) != 0))
     _throw("unsafe OperaFS directory record metadata: invalid block_size alignment");
 
-  const std::uint32_t dev_block_count = device_block_count();
-  const std::uint64_t max_byte_count =
-    static_cast<std::uint64_t>(tmp.block_size) * static_cast<std::uint64_t>(tmp.block_count);
+  const u64 dev_block_count = device_block_count();
+  const u64 record_dev_block_count =
+    (static_cast<u64>(tmp.block_count) *
+     (static_cast<u64>(tmp.block_size) / data_block_size));
+  const u64 max_byte_count =
+    static_cast<u64>(tmp.block_size) * static_cast<u64>(tmp.block_count);
 
   if((tmp.block_count == 0) && (avatar_count > 1))
     _throw("unsafe OperaFS directory record metadata: avatars without blocks");
@@ -688,11 +1034,19 @@ TDO::DevStream::read(TDO::DirectoryRecord &dr_)
     _throw("unsafe OperaFS directory record metadata: byte_count exceeds block capacity");
 
   if(tmp.block_count != 0)
-    for(std::uint32_t avatar : tmp.avatar_list)
-      {
-        if(avatar >= dev_block_count)
-          _throw("unsafe OperaFS directory record metadata: avatar exceeds device bounds");
-      }
+    {
+      if(record_dev_block_count > dev_block_count)
+        _throw("unsafe OperaFS directory record metadata: block_count exceeds device bounds");
+
+      for(u32 avatar : tmp.avatar_list)
+        {
+          if(avatar >= dev_block_count)
+            _throw("unsafe OperaFS directory record metadata: avatar exceeds device bounds");
+          if(static_cast<u64>(avatar) >
+             (dev_block_count - record_dev_block_count))
+            _throw("unsafe OperaFS directory record metadata: avatar extent exceeds device bounds");
+        }
+    }
 
   dr_ = tmp;
 }
@@ -717,6 +1071,25 @@ TDO::DevStream::read(TDO::ROMTag &tag_)
 }
 
 void
+TDO::DevStream::write(const TDO::ROMTag &tag_)
+{
+  write(tag_.sub_systype);
+  write(tag_.type);
+  write(tag_.version);
+  write(tag_.revision);
+  write(tag_.flags);
+  write(tag_.type_specific);
+  write(tag_.reserved1);
+  write(tag_.reserved2);
+  write(tag_.offset);
+  write(tag_.size);
+  write(tag_.reserved3[0]);
+  write(tag_.reserved3[1]);
+  write(tag_.reserved3[2]);
+  write(tag_.reserved3[3]);
+}
+
+void
 TDO::DevStream::read(TDO::LinkedMemFileEntry &lmfe_)
 {
   TDO::LinkedMemFileEntry tmp;
@@ -729,7 +1102,7 @@ TDO::DevStream::read(TDO::LinkedMemFileEntry &lmfe_)
   read(tmp.byte_count);
   read(tmp.unique_identifier);
   read(tmp.type);
-  read(tmp.filename, sizeof(tmp.filename));
+  read(tmp.filename,sizeof(tmp.filename));
 
   if((tmp.fingerprint != FINGERPRINT_FILEBLOCK) &&
      (tmp.fingerprint != FINGERPRINT_FREEBLOCK) &&
@@ -749,4 +1122,51 @@ TDO::DevStream::read(TDO::LinkedMemFileEntry &lmfe_)
            "block count without byte count");
 
   lmfe_ = tmp;
+}
+
+s64
+TDO::DevStream::size_in_bytes()
+{
+  s64 size;
+  TDO::PosGuard guard(this);
+
+  _ios.seekg(0,_ios.end);
+  size = _ios.tellg();
+
+  return size;
+}
+
+s64
+TDO::DevStream::size_in_device_blocks()
+{
+  const s64 bytes = size_in_bytes();
+  // size_in_bytes() returns -1 when tellg() fails. Letting the s64
+  // value mix with the u64 device_block_size() in division promotes
+  // -1 to 0xFFFF... via usual arithmetic conversion and yields a
+  // huge positive count (~9e15) that silently feeds downstream
+  // u32-narrowed sinks (e.g. signer dl.volume_block_count). Propagate
+  // the failure sentinel instead.
+  if(bytes < 0)
+    return bytes;
+  return (bytes / static_cast<s64>(device_block_size()));
+}
+
+void
+TDO::DevStream::resize_multiple(s64 multiple_)
+{
+  s64 size;
+  s64 rounded_size;
+  TDO::PosGuard guard(this);
+
+  _ios.seekg(0,_ios.end);
+  size = _ios.tellg();
+
+  rounded_size = _round_up(size,multiple_);
+  if(rounded_size == size)
+    return;
+
+  _ios.seekp(rounded_size - 1);
+  _ios.put(0);
+  if(!_ios)
+    throw Error("failed to resize stream");
 }

--- a/src/tdo_dev_stream.hpp
+++ b/src/tdo_dev_stream.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -19,106 +19,186 @@
 #pragma once
 
 #include "error.hpp"
+#include "fmt.hpp"
 #include "tdo_directory_header.hpp"
 #include "tdo_directory_record.hpp"
 #include "tdo_disc_label.hpp"
 #include "tdo_linked_mem_file_entry.hpp"
 #include "tdo_romtag.hpp"
+#include "types_ints.h"
 
+#include <array>
 #include <iostream>
-#include <stack>
+#include <optional>
+#include <utility>
 
 namespace TDO
 {
   class DevStream
   {
+  private:
+    u64 _device_block_header;
+    u64 _device_block_data_size;
+    u64 _device_block_footer;
+    u64 _data_start_offset;
+    u64 _disc_label_size_in_bytes;
+
+  private:
+    s64 _file_pos_to_data_byte_pos(const s64 pos_) const;
+
+  private:
+    u64  _disc_label_block;
+    u64  _romtags_block;
+    u32  _romtags_entry_count;
+    bool _romtags_entry_count_is_explicit;
+    std::iostream &_ios;
+
   public:
-    DevStream(std::istream &is);
+    DevStream(std::iostream &ios);
 
   public:
     void find_label();
     void setup();
 
   public:
-    bool good() const { return _is.good(); }
-    bool bad() const { return _is.bad(); }
-    bool eof() const { return _is.eof(); }
-    std::istream &istream() { return _is; }
+    bool good() const { return _ios.good(); }
+    bool bad() const { return _ios.bad(); }
+    bool eof() const { return _ios.eof(); }
+    std::iostream &iostream() { return _ios; }
 
   public:
-    std::uint32_t data_offset() const;
-    std::uint32_t device_block_size() const;
-    std::uint32_t device_block_header() const;
-    std::uint32_t device_block_data_size() const;
-    std::uint32_t device_block_footer() const;
-
-    std::uint32_t device_block_count();
-    std::uint32_t data_block_size() const;
+    s64 size_in_bytes();
+    s64 size_in_device_blocks();
+    void resize_multiple(s64 multiple);
 
   public:
-    void file_seek(const std::int64_t pos);
-    void data_byte_seek(const std::int64_t pos);
-    void data_byte_skip(const std::int64_t pos);
-    void data_block_seek(const std::int64_t pos);
-    void data_block_skip(const std::int64_t pos);
-    void device_block_seek(const std::int64_t pos);
-    void device_block_skip(const std::int64_t pos);
+    u64 data_offset() const;
+    u64 data_start_offset() const;
 
   public:
-    std::int64_t file_tell() const;
-    std::int64_t data_byte_tell(std::int64_t) const;
-    std::int64_t data_byte_tell() const;
-    std::int64_t data_block_tell(std::int64_t) const;
-    std::int64_t data_block_tell() const;
-    std::int64_t device_block_tell(std::int64_t) const;
-    std::int64_t device_block_tell() const;
+    u64 device_block_size() const;
+    u64 device_block_header() const;
+    u64 device_block_data_size() const;
+    u64 device_block_footer() const;
+    u64 device_block_count();
 
   public:
-    std::int64_t file_offset_to_data_block(const std::int64_t) const;
-    std::int64_t data_block_to_file_offset(const std::int64_t) const;
+    void file_seek(const s64 pos);
+    void data_byte_seek(const s64 pos);
+    void data_byte_skip(const s64 pos);
+    void data_block_seek(const s64 pos);
+    void data_block_skip(const s64 pos);
+    void device_block_seek(const s64 pos);
+    void device_block_skip(const s64 pos);
+
+  public:
+    s64 file_tell() const;
+    s64 data_byte_tell(s64) const;
+    s64 data_byte_tell() const;
+    s64 data_block_tell(s64) const;
+    s64 data_block_tell() const;
+    s64 device_block_tell(s64) const;
+    s64 device_block_tell() const;
+
+  public:
+    s64 data_block_to_file_offset(const s64) const;
+
+  public:
+    TDO::DiscLabel disc_label();
+    u64 disc_label_size_in_bytes() const;
+    u64 disc_label_block() const;
 
   public:
     bool has_romtags();
     TDO::ROMTagVec romtags();
+    std::optional<TDO::ROMTag> romtag(const int type);
+    u64 romtags_block() const;
+    u64 romtags_count();
+    u64 romtags_size_in_bytes();
 
   public:
-    void read(char *buf, uint32_t size);
+    void read(char *buf, const u64 size);
     void read(char &);
-    void read(uint8_t &);
-    void read(uint32_t &);
-    void read(int32_t &);
+    void read(u8 &);
+    void read(u32 &);
+    void read(s32 &);
     void read(TDO::DiscLabel &);
     void read(TDO::DirectoryHeader &);
     void read(TDO::DirectoryRecord &);
     void read(TDO::ROMTag &);
     void read(TDO::LinkedMemFileEntry &);
+    void read_data_blocks(std::vector<char> &v,
+                          const s64          block_pos,
+                          const s64          blocks);
+    void read_data_bytes_from_block(std::vector<char> &v,
+                                    const s64          block_pos,
+                                    const s64          bytes);
+    void read_data_bytes(std::vector<char> &v,
+                         const s64          byte_pos,
+                         const s64          bytes);
+    void read_data_bytes_from_block(char     *buf_,
+                                    const s64 block_pos_,
+                                    const s64 bytes_);
+    void read_data_bytes(char     *buf_,
+                         const s64 pos_,
+                         const s64 bytes_);
 
-    template<std::size_t N>
+    template<u64 N>
     void
     read(std::array<char,N> &arr_)
     {
       read(&arr_[0],arr_.size());
     }
 
-    template<typename T, std::size_t N>
+    template<u64 N>
     void
-    read(std::array<T,N> &arr_)
+    read(std::array<u32,N> &arr_)
     {
-      for(std::size_t i = 0; i < arr_.size(); i++)
+      for(u64 i = 0; i < arr_.size(); i++)
         read(arr_[i]);
     }
 
+  public:
+    void write(const char *buf, const u64 size);
+    void write(char);
+    void write(u8);
+    void write(u32);
+    void write(s32);
+    void write(const TDO::DiscLabel &);
+    void write(const TDO::DirectoryHeader &);
+    void write(const TDO::DirectoryRecord &);
+    void write(const TDO::ROMTag &);
+    void write(const TDO::LinkedMemFileEntry &);
+    void write_data_blocks(const std::vector<char> &v,
+                           const s64                block_pos,
+                           const s64                blocks);
+    void write_data_bytes_from_block(const std::vector<char> &v,
+                                     const s64                block_pos,
+                                     const s64                bytes);
+    void write_data_bytes(const std::vector<char> &v,
+                          const s64                byte_pos,
+                          const s64                bytes);
+
+    template<u64 N>
+    void
+    write(const std::array<char,N> &arr_)
+    {
+      write(&arr_[0],arr_.size());
+    }
+
+    template<u64 N>
+    void
+    write(const std::array<u32,N> &arr_)
+    {
+      for(u64 i = 0; i < arr_.size(); i++)
+        write(arr_[i]);
+    }
+
   private:
-    std::uint32_t  _device_block_data_size;
-    std::uint32_t  _device_block_header;
-    std::uint32_t  _device_block_footer;
-    std::uint32_t  _data_offset;
-    std::istream  &_is;
-    bool           _initialized;
+    u64 _romtags_count_impl();
 
   private:
     bool is_mode1_2352();
-    std::uint32_t count_m1_romtags(const std::int64_t pos_);
 
   private:
     template<typename... Args>
@@ -128,21 +208,25 @@ namespace TDO
       std::string msg;
 
       msg = fmt::format(fmt_,std::forward<Args>(args_)...);
-
-      msg += fmt::format(" at offset {}",_is.tellg());
+      msg += fmt::format(" at offset {}",_ios.tellg());
 
       throw Error(msg);
     }
-
   };
 
   class PosGuard
   {
   public:
     PosGuard(DevStream &stream_)
-      : _stream(stream_)
+      : _stream(stream_),
+        _pos(_stream.file_tell())
     {
-      _pos = _stream.file_tell();
+    }
+
+    PosGuard(DevStream *stream_)
+      : _stream(*stream_),
+        _pos(_stream.file_tell())
+    {
     }
 
     ~PosGuard()
@@ -151,7 +235,7 @@ namespace TDO
     }
 
   private:
-    DevStream      &_stream;
-    std::streampos  _pos;
+    DevStream            &_stream;
+    const std::streampos  _pos;
   };
 }

--- a/src/tdo_directory_header.hpp
+++ b/src/tdo_directory_header.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/tdo_directory_record.hpp
+++ b/src/tdo_directory_record.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -18,10 +18,12 @@
 
 #pragma once
 
+#include "error.hpp"
 #include "fmt.hpp"
 
 #include <cctype>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -66,7 +68,21 @@ namespace TDO
     bool last_in_dir() const { return !!(flags & DR_FLAG_LAST_IN_DIR); }
 
   public:
-    uint32_t disc_avatar_offset(const uint32_t i) const { return (avatar_list[i] * block_size); }
+    // OperaFS targets a 32-bit platform; both the avatar block index
+    // and the byte offset must fit in u32. Compute the multiply in
+    // u64 so we can detect a malformed image whose record drives the
+    // product past UINT32_MAX, then narrow. Throwing here surfaces
+    // the bad record to the calling listing/unpack path's per-image
+    // try/catch rather than silently displaying a wrapped offset.
+    uint32_t disc_avatar_offset(const uint32_t i) const
+    {
+      const uint64_t offset =
+        static_cast<uint64_t>(avatar_list[i]) * block_size;
+      if(offset > std::numeric_limits<uint32_t>::max())
+        throw Error("avatar disc offset out of 32-bit range: " +
+                    std::to_string(offset));
+      return static_cast<uint32_t>(offset);
+    }
     uint32_t disc_avatar_offset() const { return disc_avatar_offset(0); }
 
   public:

--- a/src/tdo_disc_format.hpp
+++ b/src/tdo_disc_format.hpp
@@ -1,0 +1,91 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include "md5.h"
+#include "tdo_rsa.h"
+#include "types_ints.h"
+
+#include <cstddef>
+#include <filesystem>
+#include <string>
+
+namespace TDO
+{
+  constexpr u64 BLOCK_SIZE = 2048;
+  constexpr u64 LOG_BLOCK_SIZE = 32768;
+  constexpr u64 LOG_BLOCKS_PER_DIGEST = (LOG_BLOCK_SIZE / BLOCK_SIZE);
+
+  static inline
+  u64
+  round_up(const u64 number_,
+           const u64 multiple_)
+  {
+    return (((number_ + multiple_ - 1) / multiple_) * multiple_);
+  }
+
+  static inline
+  u64
+  div_round_up(const u64 number_,
+               const u64 multiple_)
+  {
+    return ((number_ + multiple_ - 1) / multiple_);
+  }
+
+  static inline
+  u64
+  signature_file_size_for_digest_count(const u64 num_digests_)
+  {
+    const u64 digest_size = num_digests_ * sizeof(md5_digest_t);
+    // Portfolio OS dipir/appdigest.c adds an 8192-byte trailer whenever
+    // the digest count is divisible by 512.
+    if((num_digests_ & 511) == 0)
+      return (digest_size + 8192);
+
+    return round_up(digest_size + RSA512_SIG_SIZE, BLOCK_SIZE);
+  }
+
+  static inline
+  u64
+  signature_record_size_for_digest_count(const u64 num_digests_)
+  {
+    // For the appdigest.c 512-digest boundary case, the OperaFS record and
+    // RSA_SIGNATURE_BLOCK ROMTag advertise only digest bytes; the allocated
+    // file still includes the 8192-byte trailer used to store the signature.
+    if((num_digests_ & 511) == 0)
+      return (num_digests_ * sizeof(md5_digest_t));
+
+    return signature_file_size_for_digest_count(num_digests_);
+  }
+
+  static inline
+  std::string
+  display_path(const std::filesystem::path &parent_,
+               const std::string           &filename_)
+  {
+    std::string path = parent_.generic_string();
+    if(!path.empty() && !filename_.empty() && (filename_[0] != '/'))
+      path += "/";
+    if(filename_.empty())
+      path += "<invalid empty filename>";
+    else
+      path += filename_;
+    return path;
+  }
+}

--- a/src/tdo_disc_identifier.cpp
+++ b/src/tdo_disc_identifier.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -61,30 +61,18 @@ TDO::DiscIdentifier::DiscIdentifier()
 {
 }
 
-Error
-TDO::DiscIdentifier::identify(std::istream &is_)
+void
+TDO::DiscIdentifier::identify(std::iostream &ios_)
 {
-  try
-    {
-      Error err;
-      TDO::DevStream stream(is_);
+  TDO::DevStream stream(ios_);
 
-      stream.setup();
+  stream.setup();
 
-      stream.data_byte_seek(0);
-      stream.read(label);
+  stream.data_byte_seek(0);
+  stream.read(label);
 
-      err = fsstats.collect(stream);
-      if(err)
-        return err;
+  fsstats.collect(stream);
 
-      ::find_matches(label,fsstats,full_matches,partial_matches);
-      disc_image_ext = ::get_ext_based_on_type(stream);
-
-      return {};
-    }
-  catch(const Error &err)
-    {
-      return err;
-    }
+  ::find_matches(label,fsstats,full_matches,partial_matches);
+  disc_image_ext = ::get_ext_based_on_type(stream);
 }

--- a/src/tdo_disc_identifier.hpp
+++ b/src/tdo_disc_identifier.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -33,7 +33,7 @@ namespace TDO
     DiscIdentifier();
 
   public:
-    Error identify(std::istream &is_);
+    void identify(std::iostream &ios_);
 
   public:
     std::string disc_image_ext;

--- a/src/tdo_disc_ids.c
+++ b/src/tdo_disc_ids.c
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/tdo_disc_ids.cpp
+++ b/src/tdo_disc_ids.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/tdo_disc_ids.h
+++ b/src/tdo_disc_ids.h
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -22,6 +22,8 @@
 #include "extern_c.h"
 
 #include <stdint.h>
+
+// TODO: Add hash of signatures file?
 
 EXTERN_C_BEGIN
 

--- a/src/tdo_disc_ids.hpp
+++ b/src/tdo_disc_ids.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above

--- a/src/tdo_disc_ids_list.c
+++ b/src/tdo_disc_ids_list.c
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -487,8 +487,8 @@ TDOID_LIST[] =
    {"Starblade (Japan)","CD-ROM",0x249C7B52,281600,0x04A9273A,258,481596532},
    {"Stellar 7 - Draxon's Revenge (Japan)","CD-ROM",0x33334588,153600,0x34E8AB94,224,264184852},
    {"Stellar 7 - Draxon's Revenge (USA)","CD-ROM",0x1CB7640F,148480,0x31CB70CE,230,259035034},
-   {"Step Aerobics (USA)","CD-ROM",0x20E944D9,286720,0x1D0D4C17,165,551046554},
-   {"Storage Manager - Memory Kanri (Japan)","CD-ROM",0x12CA2BE4,1536,0x33C4471C,199,1593381},
+    {"Step Aerobics (USA)","CD-ROM",0x20E944D9,286720,0x1D0D4C17,165,551046554},
+    {"Storage Manager - Memory Kanri (Japan)","CD-ROM",0x12CA2BE4,1536,0x33C4471C,199,1265701},
    {"Strahl (Japan)","CD-ROM",0x373AC22B,275968,0x257A414B,603,535761213},
    {"Strahl (USA)","CD-ROM",0x087289AC,322560,0x1653DE65,629,626694731},
    {"Striker - World Cup Special (Europe)","CD-ROM",0x23E71C78,204800,0x3A11BCB9,931,289305025},

--- a/src/tdo_disc_label.hpp
+++ b/src/tdo_disc_label.hpp
@@ -61,10 +61,10 @@ namespace TDO
 
   struct DiscLabel
   {
-    char     record_type;                      /* Should equal 0x01 */
+    uint8_t  record_type;                      /* Should equal 0x01 */
     VSBArray volume_sync_bytes;                /* Synchronization bytes: 0x5A5A5A5A5A */
-    char     volume_structure_version;         /* Should equal 0x01 */
-    char     volume_flags;                     /* Should equal 0x00 */
+    uint8_t  volume_structure_version;         /* Should equal 0x01 */
+    uint8_t  volume_flags;                     /* Should equal 0x00 */
     VCIArray volume_commentary;                /* volume/disc description */
     VCIArray volume_identifier;                /* volume/disc name */
     uint32_t volume_unique_identifier;         /* Roll a billion-sided die */
@@ -75,7 +75,25 @@ namespace TDO
     uint32_t root_directory_block_size;        /* usually same as vol blk size */
     uint32_t root_directory_last_avatar_index; /* should contain 7 */
     RDAArray root_directory_avatar_list;
+  };
 
+  struct ExtDiscLabel
+  {
+    uint8_t  record_type;                      /* Should equal 0x01 */
+    VSBArray volume_sync_bytes;                /* Synchronization bytes: 0x5A5A5A5A5A */
+    uint8_t  volume_structure_version;         /* Should equal 0x01 */
+    uint8_t  volume_flags;                     /* See values above */
+    VCIArray volume_commentary;                /* volume/disc description */
+    VCIArray volume_identifier;                /* volume/disc name */
+    uint32_t volume_unique_identifier;         /* Roll a billion-sided die */
+    uint32_t volume_block_size;                /* Usually contains 2048 */
+    uint32_t volume_block_count;               /* # of blocks on disc */
+    uint32_t root_unique_identifier;           /* Roll a billion-sided die */
+    uint32_t root_directory_block_count;       /* # of blocks in root */
+    uint32_t root_directory_block_size;        /* usually same as vol blk size */
+    uint32_t root_directory_last_avatar_index; /* should contain 7 */
+    RDAArray root_directory_avatar_list;
+    
     // Extended Volume Data
     uint32_t num_rom_tags;
     uint32_t application_id;

--- a/src/tdo_disc_packer.cpp
+++ b/src/tdo_disc_packer.cpp
@@ -1,0 +1,394 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "tdo_disc_packer.hpp"
+
+#include "copy_stream.hpp"
+#include "tdo_directory_record.hpp"
+#include "tdo_disc_format.hpp"
+#include "tdo_disc_label.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <fstream>
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+  using Entry = TDO::DiscManifestEntry;
+  using EntryKind = TDO::DiscManifestEntryKind;
+
+  static
+  void
+  write_u8(std::ostream &os_,
+           u8            value_)
+  {
+    os_.put(static_cast<char>(value_));
+  }
+
+  static
+  void
+  write_u32(std::ostream &os_,
+            u32           value_)
+  {
+    u32 be = __builtin_bswap32(value_);
+    os_.write(reinterpret_cast<const char*>(&be), sizeof(be));
+  }
+
+  static
+  void
+  write_s32(std::ostream &os_,
+            s32           value_)
+  {
+    write_u32(os_,static_cast<u32>(value_));
+  }
+
+  static
+  void
+  write_bytes(std::ostream &os_,
+              const char   *data_,
+              u64           size_)
+  {
+    os_.write(data_,size_);
+  }
+
+  static
+  void
+  seek_block(std::ostream &os_,
+             u32           block_)
+  {
+    os_.seekp(static_cast<std::streamoff>(block_) * TDO::BLOCK_SIZE,std::ios::beg);
+  }
+
+  static
+  void
+  write_fixed_string(std::ostream      &os_,
+                     const std::string &str_,
+                     u32                size_)
+  {
+    const u32 len = std::min<u32>(str_.size(), size_ - 1);
+    os_.write(str_.c_str(), len);
+    const u32 padding = size_ - len;
+    if(padding > 0)
+      {
+        std::vector<char> zeros(padding, '\0');
+        os_.write(zeros.data(), padding);
+      }
+  }
+
+  static
+  TDO::DiscLabel
+  make_disc_label(const TDO::DiscManifest &manifest_)
+  {
+    TDO::DiscLabel label;
+
+    label = manifest_.disc_label;
+
+    label.volume_block_count = manifest_.total_blocks;
+    label.root_directory_block_count = manifest_.root.block_count;
+    label.root_directory_block_size = manifest_.root.block_size;
+    label.root_directory_last_avatar_index = manifest_.root.avatar_list.empty() ? 0 : manifest_.root.avatar_list.size() - 1;
+    label.root_directory_avatar_list.fill(0);
+    if(manifest_.root.avatar_list.size() > label.root_directory_avatar_list.size())
+      throw Error("too many root directory avatars");
+    for(std::size_t i = 0; i < manifest_.root.avatar_list.size(); i++)
+      label.root_directory_avatar_list[i] = manifest_.root.avatar_list[i];
+
+    return label;
+  }
+
+  static
+  void
+  write_disc_label(std::ostream         &os_,
+                   const TDO::DiscLabel &label_)
+  {
+    seek_block(os_,0);
+    write_u8(os_,label_.record_type);
+    write_bytes(os_,&label_.volume_sync_bytes[0],label_.volume_sync_bytes.size());
+    write_u8(os_,label_.volume_structure_version);
+    write_u8(os_,label_.volume_flags);
+    write_bytes(os_,&label_.volume_commentary[0],label_.volume_commentary.size());
+    write_bytes(os_,&label_.volume_identifier[0],label_.volume_identifier.size());
+    write_u32(os_,label_.volume_unique_identifier);
+    write_u32(os_,label_.volume_block_size);
+    write_u32(os_,label_.volume_block_count);
+    write_u32(os_,label_.root_unique_identifier);
+    write_u32(os_,label_.root_directory_block_count);
+    write_u32(os_,label_.root_directory_block_size);
+    write_u32(os_,label_.root_directory_last_avatar_index);
+    for(auto block : label_.root_directory_avatar_list)
+      write_u32(os_,block);
+  }
+
+  static
+  void
+  write_directory_header(std::ostream &os_,
+                         s32           next_block_,
+                         s32           prev_block_,
+                         u32           first_free_byte_)
+  {
+    write_s32(os_,next_block_);
+    write_s32(os_,prev_block_);
+    write_u32(os_,0);
+    write_u32(os_,first_free_byte_);
+    write_u32(os_,TDO::DIRECTORY_HEADER_SIZE);
+  }
+
+  static
+  void
+  write_directory_record(std::ostream &os_,
+                         const Entry  &entry_,
+                         u32           extra_flags_)
+  {
+    write_u32(os_,entry_.flags | extra_flags_);
+    write_u32(os_,entry_.unique_identifier);
+    write_u32(os_,entry_.type);
+    write_u32(os_,entry_.block_size);
+    write_u32(os_,entry_.byte_count);
+    write_u32(os_,entry_.block_count);
+    write_u32(os_,entry_.burst);
+    write_u32(os_,entry_.gap);
+    write_fixed_string(os_,entry_.name,FILESYSTEM_MAX_NAME_LEN);
+    if(entry_.avatar_list.empty())
+      {
+        if(entry_.block_count != 0)
+          throw Error(fmt::format("packer: entry '{}' has block_count={} but no avatars",
+                                  entry_.name,entry_.block_count));
+        write_u32(os_,0);
+        write_u32(os_,entry_.start_block);
+      }
+    else
+      {
+        write_u32(os_,entry_.avatar_list.size() - 1);
+        for(auto avatar : entry_.avatar_list)
+          write_u32(os_,avatar);
+      }
+  }
+
+  static
+  std::vector<const Entry*>
+  directory_block_entries(const Entry &dir_,
+                          u32         block_index_,
+                          u32        &first_free_byte_)
+  {
+    std::vector<const Entry*> entries;
+    u32 current_block;
+    u32 used;
+
+    current_block = 0;
+    used          = TDO::DIRECTORY_HEADER_SIZE;
+    for(const auto &child : dir_.children)
+      {
+        u32 size;
+
+        size = TDO::record_size(*child);
+        if((used + size) > TDO::BLOCK_SIZE)
+          {
+            if(current_block == block_index_)
+              break;
+            current_block++;
+            used = TDO::DIRECTORY_HEADER_SIZE;
+          }
+
+        if(current_block == block_index_)
+          entries.push_back(child.get());
+
+        used += size;
+      }
+
+    first_free_byte_ = used;
+
+    return entries;
+  }
+
+  static
+  void
+  write_directory(std::ostream &os_,
+                  const Entry  &dir_)
+  {
+    if(!dir_.directory || (dir_.block_count == 0))
+      return;
+
+    const u32 used_block_count = TDO::directory_block_count(dir_);
+    auto write_avatar = [&](u32 avatar)
+    {
+      for(u32 i = 0; i < dir_.block_count; i++)
+        {
+          s32 next_block;
+          s32 prev_block;
+          u32 first_free_byte;
+          std::vector<const Entry*> entries;
+
+          if(i < used_block_count)
+            entries = directory_block_entries(dir_,i,first_free_byte);
+          else
+            first_free_byte = TDO::DIRECTORY_HEADER_SIZE;
+          next_block = ((i + 1) < dir_.block_count ? i + 1 : -1);
+          prev_block = (i > 0 ? i - 1 : -1);
+
+          seek_block(os_,avatar + i);
+          write_directory_header(os_,next_block,prev_block,first_free_byte);
+          for(std::size_t j = 0; j < entries.size(); j++)
+            {
+              u32 flags;
+
+              flags = 0;
+              if((j + 1) == entries.size())
+                {
+                  flags = DR_FLAG_LAST_IN_BLOCK;
+                  if((i + 1) == used_block_count)
+                    flags |= DR_FLAG_LAST_IN_DIR;
+                }
+              write_directory_record(os_,*entries[j],flags);
+            }
+        }
+    };
+    if(dir_.avatar_list.empty())
+      write_avatar(dir_.start_block);
+    else
+      for(auto avatar : dir_.avatar_list)
+        write_avatar(avatar);
+
+    for(const auto &child : dir_.children)
+      write_directory(os_,*child);
+  }
+
+  static
+  void
+  copy_file_data(std::ostream &os_,
+                 const Entry  &entry_)
+  {
+    std::ifstream is;
+    u64 src_size;
+
+    if(entry_.kind != EntryKind::Normal)
+      return;
+    if(entry_.directory || (entry_.block_count == 0))
+      return;
+
+    {
+      std::error_code ec;
+      src_size = std::filesystem::file_size(entry_.src_path,ec);
+      if(ec)
+        throw Error("failed to stat input file: " + entry_.src_path.string() +
+                    ": " + ec.message());
+    }
+    if(src_size < entry_.data_byte_count)
+      throw Error("input file shrank since manifest was built: " +
+                  entry_.src_path.string());
+
+    is.open(entry_.src_path,std::ios::binary);
+    if(!is)
+      throw Error("failed to open input file: " + entry_.src_path.string());
+
+    auto write_one = [&](u32 block_)
+    {
+      is.clear();
+      is.seekg(0,std::ios::beg);
+      if(!is)
+        throw Error("failed to seek input file: " + entry_.src_path.string());
+
+      seek_block(os_,block_);
+      if(!os_)
+        throw Error("failed to seek output image while writing " +
+                    entry_.src_path.string());
+
+      util::copy_stream(is,os_,entry_.data_byte_count);
+
+      if(os_.fail())
+        throw Error("failed to write file data for " +
+                    entry_.src_path.string());
+      if(is.bad())
+        throw Error("read error on input file: " + entry_.src_path.string());
+    };
+
+    if(entry_.avatar_list.empty())
+      write_one(entry_.start_block);
+    else
+      for(auto avatar : entry_.avatar_list)
+        write_one(avatar);
+  }
+
+  static
+  void
+  write_file_data(std::ostream &os_,
+                  const Entry  &entry_)
+  {
+    if(!entry_.directory)
+      copy_file_data(os_,entry_);
+
+    for(const auto &child : entry_.children)
+      write_file_data(os_,*child);
+  }
+
+  static
+  void
+  resize_output(std::ostream &os_,
+                u32           total_blocks_)
+  {
+    if(total_blocks_ == 0)
+      return;
+
+    os_.seekp((static_cast<std::streamoff>(total_blocks_) * TDO::BLOCK_SIZE) - 1,std::ios::beg);
+    os_.put(0);
+    if(!os_)
+      throw Error("failed to resize output image");
+  }
+
+  static
+  void
+  validate_manifest(const TDO::DiscManifest &manifest_)
+  {
+    if(manifest_.output.empty())
+      throw Error("manifest has no output path");
+    if(!manifest_.root.directory)
+      throw Error("manifest root is not a directory");
+    if(manifest_.root.block_count == 0)
+      throw Error("manifest root directory is empty");
+    if(manifest_.total_blocks == 0)
+      throw Error("manifest has no allocated blocks");
+  }
+}
+
+void
+TDO::pack_disc_image(const TDO::DiscManifest &manifest_)
+{
+  TDO::DiscLabel label;
+  std::ofstream os;
+
+  validate_manifest(manifest_);
+  label = make_disc_label(manifest_);
+
+  os.open(manifest_.output,std::ios::binary|std::ios::trunc);
+  if(!os)
+    throw Error("failed to open output image");
+
+  resize_output(os,manifest_.total_blocks);
+  write_disc_label(os,label);
+  write_directory(os,manifest_.root);
+  write_file_data(os,manifest_.root);
+
+  os.flush();
+  if(!os)
+    throw Error("failed to flush output image: " + manifest_.output.string());
+  os.close();
+  if(os.fail())
+    throw Error("failed to close output image: " + manifest_.output.string());
+}

--- a/src/tdo_disc_packer.hpp
+++ b/src/tdo_disc_packer.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -16,3 +16,97 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
+#pragma once
+
+#include "error.hpp"
+#include "tdo_disc_format.hpp"
+#include "tdo_disc_label.hpp"
+#include "types_ints.h"
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace TDO
+{
+  enum class DiscManifestEntryKind
+  {
+    Normal,
+    DiscLabel,
+    ROMTags,
+    Signatures,
+  };
+
+  struct DiscManifestEntry
+  {
+    typedef std::unique_ptr<DiscManifestEntry> Ptr;
+
+    std::filesystem::path              src_path;
+    std::string                        name;
+    DiscManifestEntryKind              kind;
+    bool                               directory;
+    u32                                unique_identifier;
+    u32                                type;
+    u32                                flags;
+    u32                                block_size;
+    u32                                byte_count;
+    u32                                data_byte_count;
+    u32                                block_count;
+    u32                                burst;
+    u32                                gap;
+    u32                                start_block;
+    u32                                record_file_offset;
+    u32                                record_size;
+    std::vector<u32>                   avatar_list;
+    std::vector<DiscManifestEntry::Ptr> children;
+  };
+
+  struct DiscManifest
+  {
+    std::filesystem::path output;
+    TDO::DiscLabel        disc_label;
+    u32                   total_blocks;
+    bool                  replay_layout;
+    DiscManifestEntry     root;
+  };
+
+  void pack_disc_image(const DiscManifest &manifest);
+
+  constexpr u32 DIRECTORY_HEADER_SIZE = 20;
+  constexpr u32 DIRECTORY_RECORD_BASE_SIZE = 68;
+
+  static inline
+  u32
+  record_size(const DiscManifestEntry &entry_)
+  {
+    return (DIRECTORY_RECORD_BASE_SIZE +
+            (std::max<std::size_t>(1,entry_.avatar_list.size()) * sizeof(u32)));
+  }
+
+  static inline
+  u32
+  directory_block_count(const DiscManifestEntry &dir_)
+  {
+    u32 blocks;
+    u32 used;
+
+    if(dir_.children.empty())
+      return 0;
+
+    blocks = 1;
+    used   = DIRECTORY_HEADER_SIZE;
+    for(const auto &child : dir_.children)
+      {
+        u32 size = record_size(*child);
+        if((used + size) > BLOCK_SIZE)
+          {
+            blocks++;
+            used = DIRECTORY_HEADER_SIZE;
+          }
+        used += size;
+      }
+
+    return blocks;
+  }
+}

--- a/src/tdo_disc_signer.cpp
+++ b/src/tdo_disc_signer.cpp
@@ -1,0 +1,1376 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "tdo_disc_signer.hpp"
+
+#include "md5.h"
+#include "fmt.hpp"
+#include "fmt_md5_digest.hpp"
+#include "fmt_rsa512_sig.hpp"
+#include "nonstd/string.hpp"
+#include "tdo_boot_code_crypto.hpp"
+#include "tdo_disc_format.hpp"
+#include "tdo_file_stream.hpp"
+#include "tdo_fs_walker.hpp"
+#include "tdo_rsa.h"
+#include "tdo_safe_narrow.hpp"
+#include "version.hpp"
+
+#include <limits>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+  static constexpr u32 ARM_NOP = 0xe1a00000;
+  static constexpr u32 AIF_EXIT_INSTRUCTION = 0xef000011;
+  static constexpr u32 AIF_RELOCATION_LIST_END = 0xffffffff;
+  static constexpr u64 AIF_HEADER_RO_SIZE_OFFSET = 0x14;
+  static constexpr u64 AIF_HEADER_RW_SIZE_OFFSET = 0x18;
+  static constexpr u64 AIF_HEADER_DEBUG_SIZE_OFFSET = 0x1c;
+
+  // Compute the digest count for a given volume_block_count, rejecting
+  // values that would overflow the digest math. This is the shared core
+  // of all (volume_block_count * BLOCK_SIZE) / LOG_BLOCK_SIZE sites; it
+  // does not depend on the disc label so it is safe to use during pack
+  // preflight, where the disc label may not yet be authoritative.
+  static
+  u64
+  safe_digest_count_for_volume_blocks(const u64 volume_blocks_)
+  {
+    if(volume_blocks_ > (std::numeric_limits<u64>::max() / TDO::BLOCK_SIZE))
+      throw Error("volume_block_count overflows digest math");
+    return ((volume_blocks_ * TDO::BLOCK_SIZE) / TDO::LOG_BLOCK_SIZE);
+  }
+
+  // Validate volume_block_count against the actual file size and
+  // return the number of digests the signatures table will hold.
+  //
+  // OperaFS volume_block_size is 2 KiB by definition (see TDO::BLOCK_SIZE),
+  // so we use BLOCK_SIZE rather than disc_label().volume_block_size; the
+  // older code in generate_signatures_file_data multiplied by the on-disc
+  // value, which was redundant for any conforming image and would have
+  // produced an unbounded num_digests for a crafted one. Reject mismatches
+  // explicitly.
+  static
+  u64
+  safe_signature_digest_count(TDO::FileStream &stream_)
+  {
+    const u64 volume_blocks = stream_.disc_label().volume_block_count;
+    const u64 volume_block_size = stream_.disc_label().volume_block_size;
+    const u64 file_blocks = stream_.device_block_count();
+    if(volume_block_size != TDO::BLOCK_SIZE)
+      throw Error("disc label volume_block_size is not 2 KiB");
+    if((file_blocks > 0) && (volume_blocks > file_blocks))
+      throw Error("disc label volume_block_count exceeds image size");
+    return safe_digest_count_for_volume_blocks(volume_blocks);
+  }
+
+  static
+  u32
+  read_u32_be(const std::vector<char> &data_,
+              const u64                offset_)
+  {
+    return ((static_cast<u32>(static_cast<u8>(data_[offset_ + 0])) << 24) |
+            (static_cast<u32>(static_cast<u8>(data_[offset_ + 1])) << 16) |
+            (static_cast<u32>(static_cast<u8>(data_[offset_ + 2])) << 8) |
+            (static_cast<u32>(static_cast<u8>(data_[offset_ + 3])) << 0));
+  }
+
+  static
+  std::optional<u64>
+  arm_bl_target(const u32 instruction_,
+                const u64 instruction_offset_)
+  {
+    s32 immediate;
+    s64 target;
+
+    if((instruction_ & 0x0f000000) != 0x0b000000)
+      return {};
+
+    immediate = (instruction_ & 0x00ffffff);
+    if((immediate & 0x00800000) != 0)
+      immediate |= 0xff000000;
+
+    target = static_cast<s64>(instruction_offset_) + 8 +
+             (static_cast<s64>(immediate) << 2);
+    if(target < 0)
+      return {};
+
+    return static_cast<u64>(target);
+  }
+
+  static
+  bool
+  is_zero_range(const std::vector<char> &data_,
+                const u64                begin_,
+                const u64                end_)
+  {
+    for(u64 pos = begin_; pos < end_; pos++)
+      if(data_[pos] != 0)
+        return false;
+
+    return true;
+  }
+
+  static
+  std::optional<u64>
+  aif_executable_size(const std::vector<char> &data_)
+  {
+    u64 image_size;
+    u64 ro_size;
+    u64 rw_size;
+    u64 debug_size;
+    u64 executable_size;
+    u32 decompress_instruction;
+    u32 self_reloc_instruction;
+    u32 zero_init_instruction;
+    u32 entry_instruction;
+    std::optional<u64> self_reloc_target;
+
+    if(data_.size() < 0x40)
+      return {};
+
+    decompress_instruction = read_u32_be(data_,0x00);
+    self_reloc_instruction = read_u32_be(data_,0x04);
+    zero_init_instruction = read_u32_be(data_,0x08);
+    entry_instruction = read_u32_be(data_,0x0c);
+
+    if(read_u32_be(data_,0x10) != AIF_EXIT_INSTRUCTION)
+      return {};
+    if((decompress_instruction != ARM_NOP) &&
+       !arm_bl_target(decompress_instruction,0x00))
+      return {};
+    self_reloc_target = arm_bl_target(self_reloc_instruction,0x04);
+    if((self_reloc_instruction != ARM_NOP) && !self_reloc_target)
+      return {};
+    if((zero_init_instruction != ARM_NOP) &&
+       !arm_bl_target(zero_init_instruction,0x08))
+      return {};
+    if(!arm_bl_target(entry_instruction,0x0c))
+      return {};
+
+    ro_size = read_u32_be(data_,AIF_HEADER_RO_SIZE_OFFSET);
+    rw_size = read_u32_be(data_,AIF_HEADER_RW_SIZE_OFFSET);
+    debug_size = read_u32_be(data_,AIF_HEADER_DEBUG_SIZE_OFFSET);
+
+    image_size = ro_size + rw_size + debug_size;
+    if((image_size < 0x40) ||
+       (image_size < ro_size) ||
+       (image_size < rw_size) ||
+       (image_size > data_.size()))
+      return {};
+
+    executable_size = image_size;
+    if(self_reloc_target &&
+       ((*self_reloc_target % 4) == 0) &&
+       (*self_reloc_target >= executable_size))
+      {
+        for(u64 pos = *self_reloc_target;
+            (pos + sizeof(u32)) <= data_.size();
+            pos += sizeof(u32))
+          {
+            if(read_u32_be(data_,pos) != AIF_RELOCATION_LIST_END)
+              continue;
+
+            executable_size = pos + sizeof(u32);
+            break;
+          }
+      }
+
+    // Some unsigned boot_code files keep one zero word after the AIF
+    // relocation terminator before the signature slots.
+    if(((executable_size + sizeof(u32)) <= data_.size()) &&
+       (read_u32_be(data_,executable_size) == 0) &&
+       is_zero_range(data_,executable_size,data_.size()))
+      executable_size += sizeof(u32);
+
+    return executable_size;
+  }
+
+  static
+  std::optional<u64>
+  boot_code_romtag_size(const std::vector<char> &encrypted_data_)
+  {
+    u64 signed_size;
+    u64 aligned_size;
+    std::vector<char> data;
+    std::optional<u64> executable_size;
+
+    data = encrypted_data_;
+    aligned_size = TDO::boot_code_crypto_aligned_size(data.size());
+    TDO::decrypt_boot_code_range(data.data(),aligned_size);
+
+    executable_size = aif_executable_size(data);
+    if(!executable_size)
+      return {};
+
+    signed_size = TDO::round_up(*executable_size,sizeof(u32)) + (RSA512_SIG_SIZE * 2);
+    if(signed_size > data.size())
+      return {};
+    if((signed_size < data.size()) &&
+       !is_zero_range(data,signed_size,data.size()))
+      return {};
+
+    return signed_size;
+  }
+
+  static
+  void
+  apply_os_romtag_version(TDO::DevStream        &stream_,
+                          TDO::ROMTag          &romtag_,
+                          const TDO::DirectoryRecord &record_)
+  {
+    static constexpr u64 COMPONENT_VERSION_OFFSET = 0xA4;
+    std::array<char, COMPONENT_VERSION_OFFSET + 2> buf{};
+
+    if(record_.byte_count < (COMPONENT_VERSION_OFFSET + 2))
+      return;
+
+    stream_.read_data_bytes_from_block(buf.data(),
+                                       record_.avatar_list[0],
+                                       COMPONENT_VERSION_OFFSET + 2);
+    romtag_.version = static_cast<u8>(buf[COMPONENT_VERSION_OFFSET]);
+    romtag_.revision = static_cast<u8>(buf[COMPONENT_VERSION_OFFSET + 1]);
+  }
+
+  static
+  void
+  apply_boot_romtag_version(TDO::ROMTag &romtag_,
+                            const u64    record_size_)
+  {
+    romtag_.version = ((record_size_ < 8192) ? 1 : 2);
+    romtag_.revision = 0;
+  }
+
+  static
+  void
+  require_iso2048_image(TDO::FileStream &stream_)
+  {
+    if((stream_.device_block_header() != 0) ||
+       (stream_.device_block_footer() != 0) ||
+       (stream_.device_block_data_size() != TDO::BLOCK_SIZE))
+      throw Error("signing is currently supported only for 2048-byte ISO images");
+  }
+
+  static
+  void
+  update_record_sizes(TDO::DevStream &stream_,
+                      const u32       record_pos_,
+                      const u32       byte_count_,
+                      const u32       block_count_)
+  {
+    stream_.file_seek(record_pos_);
+    stream_.data_byte_skip(offsetof(TDO::DirectoryRecord,byte_count));
+    stream_.write(byte_count_);
+    stream_.write(block_count_);
+  }
+
+  class ROMTagsFileUpdater final : public TDO::FSWalker::Callbacks
+  {
+  public:
+    u32 romtags_file_size;
+
+  public:
+    void
+    operator()(const std::filesystem::path &filepath_,
+               const TDO::DirectoryRecord  &record_,
+               const u32                    record_pos_,
+               TDO::DevStream              &stream_)
+    {
+      (void)record_;
+
+      if(nonstd::string::as_lowercase(filepath_.string()) != "rom_tags")
+        return;
+
+      update_record_sizes(stream_,
+                          record_pos_,
+                          romtags_file_size,
+                          TDO::div_round_up(romtags_file_size,TDO::BLOCK_SIZE));
+    }
+  };
+
+  class SignaturesFileUpdater final : public TDO::FSWalker::Callbacks
+  {
+  public:
+    u32 signatures_block_count;
+    u32 signatures_record_size;
+
+  public:
+    void
+    operator()(const std::filesystem::path &filepath_,
+               const TDO::DirectoryRecord  &record_,
+               const u32                    record_pos_,
+               TDO::DevStream              &stream_)
+    {
+      (void)record_;
+
+      if(nonstd::string::as_lowercase(filepath_.string()) != "signatures")
+        return;
+
+      update_record_sizes(stream_,
+                          record_pos_,
+                          signatures_record_size,
+                          std::max<u32>(record_.block_count,
+                                        signatures_block_count));
+    }
+  };
+
+  static
+  u32
+  romtag_type_for_path(const std::string &lc_path_,
+                       const bool         include_banner_)
+  {
+    if(lc_path_ == "signatures")
+      return RSA_SIGNATURE_BLOCK;
+    if(lc_path_ == "system/kernel/boot_code")
+      return RSA_NEWKNEWNEWGNUBOOT;
+    if(lc_path_ == "system/kernel/misc_code")
+      return RSA_MISCCODE;
+    if(lc_path_ == "system/kernel/os_code")
+      return RSA_OS;
+    if(lc_path_ == "launchme")
+      return RSA_BLOCKS_ALWAYS;
+    if(include_banner_ && (lc_path_ == "bannerscreen"))
+      return RSA_APPSPLASH;
+    return 0;
+  }
+
+  class SignaturesFileCapacity final : public TDO::FSWalker::Callbacks
+  {
+  public:
+    bool found;
+    u64  byte_count;
+
+  public:
+    SignaturesFileCapacity()
+      : found(false),
+        byte_count(0)
+    {
+    }
+
+  public:
+    void
+    operator()(const std::filesystem::path &filepath_,
+               const TDO::DirectoryRecord  &record_,
+               const u32                    record_pos_,
+               TDO::DevStream              &stream_)
+    {
+      (void)record_pos_;
+      (void)stream_;
+
+      if(nonstd::string::as_lowercase(filepath_.string()) != "signatures")
+        return;
+
+      found = true;
+      byte_count = static_cast<u64>(record_.block_count) * record_.block_size;
+    }
+  };
+
+  class SpecialFileCapacity final : public TDO::FSWalker::Callbacks
+  {
+  public:
+    bool found_rom_tags;
+    bool found_signatures;
+    u64  rom_tags_capacity;
+    u64  signatures_capacity;
+    u32  signatures_record_pos;
+    u32  signatures_record_size;
+    u32  signatures_block_count;
+
+  public:
+    SpecialFileCapacity()
+      : found_rom_tags(false),
+        found_signatures(false),
+        rom_tags_capacity(0),
+        signatures_capacity(0),
+        signatures_record_pos(0),
+        signatures_record_size(0),
+        signatures_block_count(0)
+    {
+    }
+
+  public:
+    void
+    operator()(const std::filesystem::path &filepath_,
+               const TDO::DirectoryRecord  &record_,
+               const u32                    record_pos_,
+               TDO::DevStream              &stream_)
+    {
+      std::string lc_filepath;
+
+      (void)record_pos_;
+      (void)stream_;
+
+      lc_filepath = nonstd::string::as_lowercase(filepath_.string());
+      if(lc_filepath == "rom_tags")
+        {
+          found_rom_tags = true;
+          rom_tags_capacity = static_cast<u64>(record_.block_count) * record_.block_size;
+        }
+      else if(lc_filepath == "signatures")
+        {
+          found_signatures = true;
+          signatures_capacity = static_cast<u64>(record_.block_count) * record_.block_size;
+          signatures_record_pos = record_pos_;
+          signatures_record_size = record_.byte_count;
+          signatures_block_count = record_.block_count;
+        }
+    }
+  };
+
+  class SigningPreflight final : public TDO::FSWalker::Callbacks
+  {
+  public:
+    bool found_boot_code;
+    bool found_misc_code;
+    bool found_os_code;
+    bool found_rom_tags;
+    bool found_signatures;
+    u32  generated_romtag_count;
+    u64  rom_tags_capacity;
+    u64  signatures_capacity;
+    bool include_banner_romtag;
+
+  public:
+    SigningPreflight(const bool include_banner_romtag_)
+      : found_boot_code(false),
+        found_misc_code(false),
+        found_os_code(false),
+        found_rom_tags(false),
+        found_signatures(false),
+        generated_romtag_count(0),
+        rom_tags_capacity(0),
+        signatures_capacity(0),
+        include_banner_romtag(include_banner_romtag_)
+    {
+    }
+
+  public:
+    void
+    operator()(const std::filesystem::path &filepath_,
+               const TDO::DirectoryRecord  &record_,
+               const u32                    record_pos_,
+               TDO::DevStream              &stream_)
+    {
+      u32 type;
+      std::string lc_filepath;
+
+      (void)record_pos_;
+      (void)stream_;
+
+      lc_filepath = nonstd::string::as_lowercase(filepath_.string());
+      if(lc_filepath == "rom_tags")
+        {
+          found_rom_tags = true;
+          rom_tags_capacity = static_cast<u64>(record_.block_count) * record_.block_size;
+        }
+      else if(lc_filepath == "signatures")
+        {
+          found_signatures = true;
+          signatures_capacity = static_cast<u64>(record_.block_count) * record_.block_size;
+        }
+      else if(lc_filepath == "system/kernel/boot_code")
+        found_boot_code = true;
+      else if(lc_filepath == "system/kernel/misc_code")
+        found_misc_code = true;
+      else if(lc_filepath == "system/kernel/os_code")
+        found_os_code = true;
+
+      type = romtag_type_for_path(lc_filepath, include_banner_romtag);
+      if(type != 0)
+        generated_romtag_count++;
+    }
+  };
+
+  class ROMTagsGenerator final : public TDO::FSWalker::Callbacks
+  {
+  public:
+    TDO::ROMTagVec romtags;
+    bool           include_banner_romtag;
+    std::uint8_t   digest_check_count;
+
+  public:
+    ROMTagsGenerator(const bool         include_banner_romtag_,
+                     const std::uint8_t digest_check_count_)
+      : romtags(),
+        include_banner_romtag(include_banner_romtag_),
+        digest_check_count(digest_check_count_)
+    {
+    }
+
+  public:
+    void
+    operator()(const std::filesystem::path &filepath_,
+               const TDO::DirectoryRecord  &record_,
+               const u32                    record_pos_,
+               TDO::DevStream              &stream_)
+    {
+      u32 type;
+
+      type = romtag_type_for_path(nonstd::string::as_lowercase(filepath_.string()),
+                                  include_banner_romtag);
+      if(type == 0)
+        return;
+
+      if(record_.avatar_list.empty())
+        throw Error(fmt::format("ROM tag candidate has no avatars: {}",
+                                filepath_.string()));
+      if(record_.avatar_list[0] == 0)
+        throw Error(fmt::format("ROM tag candidate has invalid avatar 0: {}",
+                                filepath_.string()));
+
+      TDO::ROMTag romtag{};
+
+      romtag.type        = type;
+      romtag.sub_systype = RSANODE;
+      romtag.size        = record_.byte_count;
+      romtag.offset      = record_.avatar_list[0] - 1;
+      switch(type)
+        {
+        case RSA_SIGNATURE_BLOCK:
+          romtag.type_specific = digest_check_count;
+          break;
+        case RSA_BLOCKS_ALWAYS:
+          romtag.offset = record_.avatar_list[0];
+          romtag.size = record_.block_count;
+          break;
+        case RSA_OS:
+          apply_os_romtag_version(stream_,romtag,record_);
+          break;
+        case RSA_NEWKNEWNEWGNUBOOT:
+          {
+            u64 allocated_size;
+            std::vector<char> buf;
+            std::optional<u64> boot_size;
+
+            allocated_size = static_cast<u64>(record_.block_count) * record_.block_size;
+            stream_.read_data_bytes_from_block(buf,
+                                               record_.avatar_list[0],
+                                               allocated_size);
+
+            boot_size = boot_code_romtag_size(buf);
+            if(!boot_size)
+              boot_size = TDO::round_up(record_.byte_count,sizeof(u32));
+            apply_boot_romtag_version(romtag,
+                                      record_.byte_count);
+            if(boot_size && (*boot_size != record_.byte_count))
+              {
+                fmt::print("    - correcting boot_code size to {}\n",
+                           *boot_size);
+                romtag.size = *boot_size;
+                update_record_sizes(stream_,
+                                     record_pos_,
+                                     romtag.size,
+                                    record_.block_count);
+              }
+          }
+          break;
+        }
+
+      romtags.emplace_back(romtag);
+    }
+  };
+
+  static
+  u32
+  romtag_sort_key(const TDO::ROMTag &tag_)
+  {
+    switch(tag_.type)
+      {
+      case RSA_NEWKNEWNEWGNUBOOT:
+        return 0;
+      case RSA_OS:
+        return 1;
+      case RSA_BILLSTUFF:
+        return 2;
+      case RSA_BLOCKS_ALWAYS:
+        return 3;
+      case RSA_MISCCODE:
+        return 4;
+      case RSA_APPSPLASH:
+        return 5;
+      case RSA_SIGNATURE_BLOCK:
+        return 6;
+      }
+
+    return 100;
+  }
+
+  static
+  void
+  pad_image_and_update_disclabel(TDO::FileStream &stream_)
+  {
+    TDO::DiscLabel dl;
+
+    fmt::print("  - Pad image and update disc label\n"
+               "    - original size: {}b\n",
+               stream_.size_in_bytes());
+    stream_.resize_multiple(TDO::LOG_BLOCK_SIZE);
+    fmt::print("    - padded size:  {}b\n",
+               stream_.size_in_bytes());
+
+    dl = stream_.disc_label();
+    {
+      // size_in_device_blocks() returns s64. dl.volume_block_count is
+      // u32 (the OperaFS disc-label field type). Range-check before
+      // narrowing so a legitimately-too-large image, or the -1 sentinel
+      // propagated from a failed tellg, becomes a loud error rather
+      // than silent truncation that ships a signed image whose label
+      // disagrees with its actual size.
+      const s64 blocks = stream_.size_in_device_blocks();
+      if((blocks < 0) ||
+         (blocks > static_cast<s64>(std::numeric_limits<uint32_t>::max())))
+        throw Error("image device block count does not fit in disc label volume_block_count (uint32)");
+      dl.volume_block_count = static_cast<uint32_t>(blocks);
+    }
+
+    stream_.data_block_seek(stream_.disc_label_block());
+    stream_.write(dl);
+  }
+
+  static
+  void
+  add_3dt_mark(TDO::FileStream &stream_,
+               const std::string &action_)
+  {
+    std::string mark;
+    const u64 mark_offset = 0x100;
+
+    mark = fmt::format("{} with 3dt v{}.{}.{}",
+                       action_,
+                       VERSION_MAJOR,
+                       VERSION_MINOR,
+                       VERSION_PATCH);
+     mark.resize(64,'\0');
+
+     fmt::print("  - Setting location {} to '{}'\n",
+               mark_offset,
+               mark.c_str());
+    stream_.data_byte_seek(mark_offset);
+    stream_.write(mark.c_str(),mark.size());
+  }
+
+  // True for ROM tag types whose `offset` field is calculated by this
+  // tool as (first_data_block - 1) and so must satisfy the bounds
+  // enforced by safe_romtag_first_data_block. Other tag types (e.g.
+  // RSA_BILLSTUFF, which stores a unique-id XOR; RSA_BLOCKS_ALWAYS,
+  // which stores avatar_list[0] directly) carry domain-specific values
+  // in `offset` and must not be passed through that helper.
+  static
+  bool
+  romtag_offset_is_block_index_minus_one(const TDO::ROMTag &tag_)
+  {
+    switch(tag_.type)
+      {
+      case RSA_OS:
+      case RSA_MISCCODE:
+      case RSA_NEWKNEWNEWGNUBOOT:
+      case RSA_APPSPLASH:
+      case RSA_SIGNATURE_BLOCK:
+        return true;
+      default:
+        return false;
+      }
+  }
+
+  static
+  void
+  write_romtags(TDO::FileStream      &stream_,
+                const TDO::ROMTagVec &romtags_)
+  {
+    stream_.data_block_seek(stream_.romtags_block());
+    for(auto &tag : romtags_)
+      {
+        if(romtag_offset_is_block_index_minus_one(tag))
+          fmt::print("    - type: {}; offset: {}; size: {}b\n",
+                     TDO::ROMTag::type_str(tag.type),
+                     TDO::safe_romtag_first_data_block(stream_,tag,
+                                                       TDO::ROMTag::type_str(tag.type).c_str()),
+                     tag.size);
+        else
+          fmt::print("    - type: {}; offset: {:#010x}; size: {}b\n",
+                     TDO::ROMTag::type_str(tag.type),
+                     tag.offset,
+                     tag.size);
+        stream_.write(tag);
+      }
+    stream_.write(TDO::ROMTag{});
+  }
+
+  static
+  std::optional<TDO::ROMTag>
+  find_romtag(const TDO::ROMTagVec &romtags_,
+              const u8              type_)
+  {
+    for(const auto &romtag : romtags_)
+      if(romtag.type == type_)
+        return romtag;
+
+    return {};
+  }
+
+  static
+  void
+  add_billstuff_romtag(TDO::FileStream &stream_,
+                       TDO::ROMTagVec  &romtags_)
+  {
+    TDO::ROMTag billstuff{};
+
+    billstuff.sub_systype = RSANODE;
+    billstuff.type        = RSA_BILLSTUFF;
+    billstuff.offset      = (stream_.disc_label().volume_unique_identifier ^
+                             stream_.disc_label().root_unique_identifier);
+
+    romtags_.emplace_back(billstuff);
+  }
+
+  static
+  void
+  sort_romtags(TDO::ROMTagVec &romtags_)
+  {
+    std::stable_sort(romtags_.begin(),
+                     romtags_.end(),
+                     [](const TDO::ROMTag &lhs_,
+                        const TDO::ROMTag &rhs_)
+                     {
+                       return (romtag_sort_key(lhs_) < romtag_sort_key(rhs_));
+                     });
+  }
+
+  static
+  TDO::ROMTagVec
+  generate_romtags_for_image(TDO::FileStream &stream_,
+                            const bool       include_banner_romtag_,
+                            const bool       include_billstuff_romtag_,
+                            const std::uint8_t digest_check_count_)
+  {
+    ROMTagsGenerator tags(include_banner_romtag_,digest_check_count_);
+    TDO::FSWalker fswalker(stream_,tags,false);
+
+    fswalker.walk();
+
+    if(include_billstuff_romtag_)
+      add_billstuff_romtag(stream_,tags.romtags);
+    sort_romtags(tags.romtags);
+
+    return tags.romtags;
+  }
+
+  static
+  void
+  preflight_layout_special_files(TDO::FileStream           &stream_,
+                                 const TDO::ROMTagVec      &romtags_,
+                                 const SpecialFileCapacity &capacity_)
+  {
+    if(!capacity_.found_rom_tags)
+      throw Error("image is missing file: rom_tags");
+
+    const u64 romtags_size =
+      ((static_cast<u64>(romtags_.size()) + 1) * sizeof(TDO::ROMTag)) + RSA512_SIG_SIZE;
+    if(romtags_size > capacity_.rom_tags_capacity)
+      throw Error("rom_tags file too small, increase size and rebuild image");
+
+    const auto sig_romtag = find_romtag(romtags_,RSA_SIGNATURE_BLOCK);
+    if(!sig_romtag)
+      return;
+
+    if(!capacity_.found_signatures)
+      throw Error("image is missing file: signatures");
+
+    const u64 num_digests = safe_signature_digest_count(stream_);
+    const u64 file_size = TDO::signature_file_size_for_digest_count(num_digests);
+    const u64 record_size = TDO::signature_record_size_for_digest_count(num_digests);
+    if(file_size > capacity_.signatures_capacity)
+      throw Error("signatures file too small, increase size and rebuild image");
+    if(sig_romtag->size < record_size)
+      throw Error("signatures file too small, increase size and rebuild image");
+  }
+
+  static
+  void
+  update_layout_signatures_record(TDO::FileStream           &stream_,
+                                  const SpecialFileCapacity &capacity_)
+  {
+    if(!capacity_.found_signatures)
+      return;
+
+    const u64 num_digests = safe_signature_digest_count(stream_);
+    const u64 file_size = TDO::signature_file_size_for_digest_count(num_digests);
+    const u64 record_size =
+      std::max<u64>(capacity_.signatures_record_size,
+                    TDO::signature_record_size_for_digest_count(num_digests));
+
+    if(file_size > capacity_.signatures_capacity)
+      throw Error("signatures file too small, increase size and rebuild image");
+
+    update_record_sizes(stream_,
+                        capacity_.signatures_record_pos,
+                        record_size,
+                        capacity_.signatures_block_count);
+  }
+
+  static
+  void
+  update_romtags_file(TDO::FileStream &stream_,
+                      const u32        size_)
+  {
+    ROMTagsFileUpdater updater;
+    TDO::FSWalker fsw(stream_,updater);
+
+    updater.romtags_file_size = size_;
+    fsw.walk();
+  }
+
+  static
+  void
+  preflight_signing_image(TDO::FileStream &stream_,
+                          const bool       include_banner_romtag_,
+                          const bool       include_billstuff_romtag_)
+  {
+    SigningPreflight preflight(include_banner_romtag_);
+    TDO::FSWalker fsw(stream_,preflight);
+
+    if(!stream_.has_romtags())
+      throw Error("image does not contain ROMTags");
+
+    fsw.walk();
+
+    if(!preflight.found_rom_tags)
+      throw Error("image is missing file: rom_tags");
+    if(!preflight.found_signatures)
+      throw Error("image is missing file: signatures");
+    if(!preflight.found_boot_code)
+      throw Error("image is missing file: system/kernel/boot_code");
+    if(!preflight.found_os_code)
+      throw Error("image is missing file: system/kernel/os_code");
+    if(!preflight.found_misc_code)
+      throw Error("image is missing file: system/kernel/misc_code");
+    if(include_billstuff_romtag_)
+      preflight.generated_romtag_count++;
+
+    const u64 padded_size = TDO::round_up(stream_.size_in_device_blocks() * TDO::BLOCK_SIZE,
+                                      TDO::LOG_BLOCK_SIZE);
+    const u64 volume_block_count = padded_size / TDO::BLOCK_SIZE;
+    const u64 num_digests = safe_digest_count_for_volume_blocks(volume_block_count);
+    const u64 signature_size = TDO::signature_file_size_for_digest_count(num_digests);
+    if(signature_size > preflight.signatures_capacity)
+      throw Error("signatures file too small, increase size and rebuild image");
+
+    // Account for generated ROMTags, the terminating ROMTag, and the cross-app
+    // signature stored immediately after the terminator.
+    const u64 romtags_size = ((preflight.generated_romtag_count + 2) * sizeof(TDO::ROMTag));
+    if((romtags_size + RSA512_SIG_SIZE) > preflight.rom_tags_capacity)
+      throw Error("rom_tags file too small, increase size and rebuild image");
+  }
+
+  static
+  void
+  generate_and_write_romtags(TDO::FileStream &stream_,
+                            const bool       include_banner_romtag_,
+                            const bool       include_billstuff_romtag_,
+                            const std::uint8_t digest_check_count_)
+  {
+    TDO::ROMTagVec romtags;
+
+    fmt::print("  - Generate and write ROM Tags\n");
+    romtags = generate_romtags_for_image(stream_,
+                                         include_banner_romtag_,
+                                         include_billstuff_romtag_,
+                                         digest_check_count_);
+    write_romtags(stream_,romtags);
+    update_romtags_file(stream_,romtags.size() * sizeof(TDO::ROMTag));
+  }
+
+  static
+  void
+  sign_romtag_payload(TDO::FileStream &stream_,
+                      const u8         romtag_type_,
+                      const char      *key_,
+                      const char      *label_)
+  {
+    md5_digest_t digest;
+    rsa512_sig_t sig;
+    std::vector<char> data;
+    std::optional<TDO::ROMTag> romtag;
+
+    romtag = stream_.romtag(romtag_type_);
+    if(!romtag)
+      return;
+    if(romtag->size < RSA512_SIG_SIZE)
+      throw Error(std::string(label_) + " is too small to contain a signature");
+
+    const u64 first_block = safe_romtag_payload_range(stream_,
+                                                      *romtag,
+                                                      romtag->size,
+                                                      label_);
+    stream_.read_data_bytes_from_block(data,
+                                       first_block,
+                                       romtag->size - RSA512_SIG_SIZE);
+    md5_calc(data.data(),data.size(),digest);
+    tdo_rsa_sign(key_,digest,sig);
+
+    fmt::print("  - Signing {}\n"
+               "    - MD5 digest: {}\n"
+               "    - RSA signature: {}\n",
+               label_,
+               digest,
+               sig);
+
+    stream_.data_byte_seek((first_block * TDO::BLOCK_SIZE) +
+                           (romtag->size - RSA512_SIG_SIZE));
+    stream_.write((const char*)sig,sizeof(sig));
+  }
+
+  static
+  void
+  sign_appsplash(TDO::FileStream &stream_)
+  {
+    sign_romtag_payload(stream_,RSA_APPSPLASH,TDO_KEY_APP,"BannerScreen");
+  }
+
+  static
+  void
+  sign_boot_code(TDO::FileStream &stream_)
+  {
+    md5_digest_t digest;
+    rsa512_sig_t sig;
+    std::vector<char> data;
+    std::array<char, RSA512_SIG_SIZE> encrypted_sig;
+    std::optional<TDO::ROMTag> romtag;
+
+    romtag = stream_.romtag(RSA_NEWKNEWNEWGNUBOOT);
+    if(!romtag)
+      return;
+    if(romtag->size < (RSA512_SIG_SIZE * 2))
+      throw Error("boot_code is too small to contain both signatures");
+
+    const u64 first_block = safe_romtag_payload_range(stream_,
+                                                      *romtag,
+                                                      romtag->size,
+                                                      "boot_code");
+    const u64 post_cheeze_sig_offset = romtag->size - (RSA512_SIG_SIZE * 2);
+    const u64 outer_sig_offset = romtag->size - RSA512_SIG_SIZE;
+    stream_.read_data_bytes_from_block(data,
+                                       first_block,
+                                       romtag->size);
+
+    TDO::decrypt_boot_code_range(data.data(),post_cheeze_sig_offset);
+    md5_calc(data.data(),post_cheeze_sig_offset,digest);
+    tdo_rsa_sign(TDO_KEY_3DO,digest,sig);
+
+    fmt::print("  - Signing decrypted boot_code\n"
+               "    - MD5 digest: {}\n"
+               "    - RSA signature: {}\n",
+               digest,
+               sig);
+
+    std::memcpy(encrypted_sig.data(),sig,sizeof(sig));
+    TDO::encrypt_boot_code_range(encrypted_sig.data(),
+                                 encrypted_sig.size(),
+                                 post_cheeze_sig_offset);
+
+    stream_.data_byte_seek((first_block * TDO::BLOCK_SIZE) +
+                           post_cheeze_sig_offset);
+    stream_.write(encrypted_sig.data(),encrypted_sig.size());
+
+    data.clear();
+    stream_.read_data_bytes_from_block(data,
+                                       first_block,
+                                       outer_sig_offset);
+    md5_calc(data.data(),data.size(),digest);
+    tdo_rsa_sign(TDO_KEY_3DO,digest,sig);
+
+    fmt::print("  - Signing encrypted boot_code\n"
+               "    - MD5 digest: {}\n"
+               "    - RSA signature: {}\n",
+               digest,
+               sig);
+
+    stream_.data_byte_seek((first_block * TDO::BLOCK_SIZE) +
+                           outer_sig_offset);
+    stream_.write((const char*)sig,sizeof(sig));
+  }
+
+  static
+  void
+  sign_system_payloads(TDO::FileStream &stream_)
+  {
+    sign_boot_code(stream_);
+    sign_romtag_payload(stream_,RSA_OS,TDO_KEY_3DO,"os_code");
+    sign_romtag_payload(stream_,RSA_MISCCODE,TDO_KEY_3DO,"misc_code");
+  }
+
+  static
+  std::vector<char>
+  generate_signatures_file_data(TDO::FileStream &stream_)
+  {
+    u64 num_digests;
+    u64 volume_block_count;
+    md5_digest_t digest;
+    std::vector<char> buf;
+    std::vector<char> signatures;
+
+    volume_block_count = stream_.disc_label().volume_block_count;
+    num_digests        = safe_signature_digest_count(stream_);
+
+    signatures.resize(num_digests * sizeof(digest));
+
+    fmt::print("  - Generate and sign signatures file with APP key\n"
+               "    - block count: {}\n"
+               "    - num digests: {}\n",
+               volume_block_count,
+               num_digests);
+    for(u64 i = 0; i < num_digests; i++)
+      {
+        s64 block_pos;
+
+        block_pos = ((i * TDO::LOG_BLOCK_SIZE) / TDO::BLOCK_SIZE);
+
+        buf.clear();
+        stream_.read_data_blocks(buf,block_pos,(TDO::LOG_BLOCK_SIZE / TDO::BLOCK_SIZE));
+
+        md5_calc(buf.data(),buf.size(),digest);
+
+        std::memcpy(&signatures[i * sizeof(digest)],digest,sizeof(digest));
+      }
+
+    return signatures;
+  }
+
+  static
+  void
+  update_signature_romtag_size(TDO::FileStream &stream_,
+                               const u32        signatures_record_size_)
+  {
+    bool found;
+
+    found = false;
+    stream_.data_block_seek(stream_.romtags_block());
+    while(true)
+      {
+        u64 offset;
+        TDO::ROMTag romtag;
+
+        offset = stream_.file_tell();
+        stream_.read(romtag);
+        if((romtag.sub_systype == 0) || (romtag.type == 0))
+          break;
+        if(romtag.type != RSA_SIGNATURE_BLOCK)
+          continue;
+
+        stream_.file_seek(offset);
+        stream_.data_byte_skip(offsetof(TDO::ROMTag,size));
+        stream_.write(signatures_record_size_);
+        found = true;
+        break;
+      }
+
+    if(!found)
+      throw Error("signatures ROM tag not found");
+  }
+
+  static
+  u64
+  signature_file_capacity(TDO::FileStream &stream_)
+  {
+    SignaturesFileCapacity capacity;
+    TDO::FSWalker fsw(stream_,capacity);
+
+    fsw.walk();
+    if(!capacity.found)
+      throw Error("signatures file not found");
+
+    return capacity.byte_count;
+  }
+
+  static
+  void
+  zero_signature_digests(std::vector<char> &signatures_,
+                         const u64          start_block_,
+                         const u64          byte_count_)
+  {
+    if(byte_count_ == 0)
+      return;
+
+    const u64 start_byte = start_block_ * TDO::BLOCK_SIZE;
+    const u64 end_byte = start_byte + byte_count_;
+    const u64 first_digest = start_byte / TDO::LOG_BLOCK_SIZE;
+    const u64 last_digest = (end_byte - 1) / TDO::LOG_BLOCK_SIZE;
+
+    for(u64 digest = first_digest; digest <= last_digest; digest++)
+      {
+        const u64 offset = digest * sizeof(md5_digest_t);
+
+        if((offset + sizeof(md5_digest_t)) > signatures_.size())
+          break;
+        std::fill(signatures_.begin() + offset,
+                  signatures_.begin() + offset + sizeof(md5_digest_t),
+                  0);
+      }
+  }
+
+  static
+  void
+  zero_mutable_signature_digests(TDO::FileStream &stream_,
+                                 std::vector<char> &signatures_)
+  {
+    std::optional<TDO::ROMTag> sig_romtag;
+
+    sig_romtag = stream_.romtag(RSA_SIGNATURE_BLOCK);
+    if(sig_romtag)
+      {
+        const u64 first_block =
+          safe_romtag_first_data_block(stream_,*sig_romtag,"signatures");
+        zero_signature_digests(signatures_,first_block,sig_romtag->size);
+      }
+  }
+
+  static
+  void
+  recreate_layout_signatures_file(TDO::FileStream &stream_)
+  {
+    md5_digest_t digest;
+    rsa512_sig_t sig;
+    u64 file_size;
+    u64 num_digests;
+    std::optional<TDO::ROMTag> sig_romtag;
+    std::vector<char> signatures;
+
+    sig_romtag = stream_.romtag(RSA_SIGNATURE_BLOCK);
+    if(!sig_romtag)
+      return;
+
+    signatures = generate_signatures_file_data(stream_);
+    zero_mutable_signature_digests(stream_,signatures);
+
+    num_digests = safe_signature_digest_count(stream_);
+    file_size = std::max<u64>(TDO::signature_file_size_for_digest_count(num_digests),
+                              sig_romtag->size);
+    if(file_size > signature_file_capacity(stream_))
+      throw Error("signatures file too small, increase size and rebuild image");
+    if((signatures.size() + sizeof(sig)) > file_size)
+      throw Error("signatures file too small, increase size and rebuild image");
+
+    signatures.resize(file_size);
+
+    md5_calc(signatures.data(),file_size - sizeof(sig),digest);
+    tdo_rsa_sign(TDO_KEY_APP,digest,sig);
+
+    fmt::print("    - signatures size: {}b\n"
+               "    - MD5 digest: {}\n"
+               "    - RSA signature: {}\n",
+               file_size,
+               digest,
+               sig);
+
+    std::memcpy(&signatures[file_size - sizeof(sig)],sig,sizeof(sig));
+
+    const u64 sig_offset =
+      safe_romtag_first_data_block(stream_,*sig_romtag,"signatures");
+    for(u64 i = 0; i < TDO::div_round_up(signatures.size(),TDO::BLOCK_SIZE); i++)
+      {
+        const u64 offset = i * TDO::BLOCK_SIZE;
+        const u64 bytes_left = signatures.size() - offset;
+        const u64 bytes_to_write = std::min<u64>(TDO::BLOCK_SIZE,bytes_left);
+
+        stream_.data_block_seek(sig_offset + i);
+        stream_.write(&signatures[offset],bytes_to_write);
+      }
+  }
+
+  static
+  void
+  resize_signatures_file_record(TDO::FileStream &stream_)
+  {
+    u64 file_size;
+    u64 num_digests;
+    u64 record_size;
+
+    std::optional<TDO::ROMTag> sig_romtag;
+    sig_romtag = stream_.romtag(RSA_SIGNATURE_BLOCK);
+    if(!sig_romtag)
+      throw Error("signatures ROM tag not found");
+
+    // Keep the logical record size separate from the physical file capacity;
+    // appdigest.c intentionally makes them differ at 512-digest boundaries.
+    num_digests = safe_signature_digest_count(stream_);
+    file_size = TDO::signature_file_size_for_digest_count(num_digests);
+    record_size = std::max<u64>(sig_romtag->size,
+                                TDO::signature_record_size_for_digest_count(num_digests));
+    file_size = std::max(file_size,record_size);
+    if(file_size > signature_file_capacity(stream_))
+      throw Error("signatures file too small, increase size and rebuild image");
+
+    update_signature_romtag_size(stream_,TDO::checked_narrow_u64_to_u32(record_size,
+                                                                        "signatures record size"));
+
+    SignaturesFileUpdater sfu;
+    TDO::FSWalker fsw(stream_,sfu);
+
+    sfu.signatures_block_count = TDO::div_round_up(file_size,TDO::BLOCK_SIZE);
+    sfu.signatures_record_size = TDO::checked_narrow_u64_to_u32(record_size,
+                                                                "signatures record size");
+    fsw.walk();
+  }
+
+  static
+  void
+  sign_disclabel_romtags_bootcode(TDO::FileStream &stream_)
+  {
+    md5_digest_t digest;
+    rsa512_sig_t signature;
+    std::vector<char> data;
+    std::optional<TDO::ROMTag> romtag;
+
+    romtag = stream_.romtag(RSA_NEWKNEWNEWGNUBOOT);
+    if(!romtag)
+      throw Error("boot_code ROM tag not found");
+
+    stream_.read_data_bytes_from_block(data,
+                                       stream_.disc_label_block(),
+                                       stream_.disc_label_size_in_bytes());
+    stream_.read_data_bytes_from_block(data,
+                                       stream_.romtags_block(),
+                                       stream_.romtags_size_in_bytes());
+    stream_.read_data_bytes_from_block(data,
+                                       safe_romtag_first_data_block(stream_,*romtag,"boot_code"),
+                                       romtag->size);
+
+    md5_calc(data.data(),data.size(),digest);
+    tdo_rsa_sign(TDO_KEY_APP,digest,signature);
+
+    fmt::print("  - Signing DiscLabel + ROMTags + BootCode with APP key\n"
+               "    - MD5 digest: {}\n"
+               "    - RSA signature: {}\n",
+               digest,
+               signature);
+
+    stream_.data_block_seek(stream_.romtags_block());
+    stream_.data_byte_skip(stream_.romtags_size_in_bytes());
+    stream_.write((char*)signature,sizeof(signature));
+  }
+}
+
+void
+TDO::recreate_layout_special_files(const std::filesystem::path &filepath_,
+                                   const bool                   sign_payloads_,
+                                   const bool                   mark_,
+                                   const bool                   include_banner_romtag_,
+                                   const bool                   include_billstuff_romtag_,
+                                   const std::uint8_t           digest_check_count_)
+{
+  SpecialFileCapacity capacity;
+  TDO::ROMTagVec romtags;
+  TDO::FileStream stream;
+
+  stream.open(filepath_,std::ios::in|std::ios::out);
+  require_iso2048_image(stream);
+
+  fmt::print("{}:\n",filepath_);
+  fmt::print("  - Recreate layout special files\n");
+
+  {
+    TDO::FSWalker fsw(stream,capacity,false);
+
+    fsw.walk();
+  }
+  pad_image_and_update_disclabel(stream);
+  update_layout_signatures_record(stream,capacity);
+  romtags = generate_romtags_for_image(stream,
+                                       include_banner_romtag_,
+                                       include_billstuff_romtag_,
+                                       digest_check_count_);
+  preflight_layout_special_files(stream,romtags,capacity);
+  if(mark_)
+    add_3dt_mark(stream,"packed and signed");
+
+  fmt::print("  - Write layout ROM Tags\n");
+  write_romtags(stream,romtags);
+  update_romtags_file(stream,romtags.size() * sizeof(TDO::ROMTag));
+
+  if(sign_payloads_)
+    {
+      sign_system_payloads(stream);
+      sign_appsplash(stream);
+    }
+
+  if(stream.romtag(RSA_NEWKNEWNEWGNUBOOT))
+    sign_disclabel_romtags_bootcode(stream);
+  recreate_layout_signatures_file(stream);
+
+  stream.close();
+}
+
+void
+TDO::mark_disc_image(const std::filesystem::path &filepath_,
+                     const std::string           &action_)
+{
+  TDO::FileStream stream;
+
+  stream.open(filepath_,std::ios::in|std::ios::out);
+  require_iso2048_image(stream);
+
+  fmt::print("{}:\n",filepath_);
+  add_3dt_mark(stream,action_);
+
+  stream.close();
+}
+
+void
+TDO::sign_disc_image(const std::filesystem::path &filepath_,
+                     const bool                   mark_,
+                     const bool                   preflight_,
+                     const bool                   include_banner_romtag_,
+                     const bool                   include_billstuff_romtag_,
+                     const std::uint8_t           digest_check_count_)
+{
+  TDO::FileStream stream;
+
+  stream.open(filepath_,std::ios::in|std::ios::out);
+  require_iso2048_image(stream);
+
+  fmt::print("{}:\n",filepath_);
+
+  if(preflight_)
+    preflight_signing_image(stream,
+                           include_banner_romtag_,
+                           include_billstuff_romtag_);
+
+  pad_image_and_update_disclabel(stream);
+  if(mark_)
+    add_3dt_mark(stream,"signed");
+  generate_and_write_romtags(stream,
+                            include_banner_romtag_,
+                            include_billstuff_romtag_,
+                            digest_check_count_);
+  sign_system_payloads(stream);
+  sign_appsplash(stream);
+  resize_signatures_file_record(stream);
+  sign_disclabel_romtags_bootcode(stream);
+  recreate_layout_signatures_file(stream);
+
+  stream.close();
+}

--- a/src/tdo_disc_signer.hpp
+++ b/src/tdo_disc_signer.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "error.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+namespace TDO
+{
+  void recreate_layout_special_files(const std::filesystem::path &filepath,
+                                      bool                         sign_payloads = false,
+                                      bool                         mark = false,
+                                      bool                         banner_romtag = true,
+                                      bool                         billstuff_romtag = false,
+                                      std::uint8_t                 digest_check_count = 0);
+  void mark_disc_image(const std::filesystem::path &filepath,
+                       const std::string           &action);
+  void sign_disc_image(const std::filesystem::path &filepath,
+                        bool                         mark = false,
+                        bool                         preflight = true,
+                        bool                         banner_romtag = true,
+                        bool                         billstuff_romtag = false,
+                        std::uint8_t                 digest_check_count = 0);
+}

--- a/src/tdo_disc_unpacker.cpp
+++ b/src/tdo_disc_unpacker.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -16,15 +16,19 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#include "copy_stream.hpp"
 #include "error.hpp"
 #include "tdo_directory_header.hpp"
 #include "tdo_directory_record.hpp"
+#include "tdo_disc_format.hpp"
 #include "tdo_disc_label.hpp"
 #include "tdo_disc_unpacker.hpp"
+#include "tdo_safe_narrow.hpp"
+
+#include "fmt.hpp"
 
 #include <fstream>
 #include <cctype>
+#include <vector>
 
 
 namespace fs = std::filesystem;
@@ -32,10 +36,10 @@ namespace fs = std::filesystem;
 class TDO::DiscUnpacker::Impl final : public TDO::FSWalker::Callbacks
 {
 public:
-  Impl(std::istream                &is_,
+  Impl(std::iostream               &ios_,
        TDO::DiscUnpacker::Callback &cb_)
     : _cb(cb_),
-      _walker(is_,*this),
+      _walker(ios_,*this),
       _dstpath()
   {
   }
@@ -45,31 +49,46 @@ public:
   }
 
 public:
-  Error
+  void
   unpack(const fs::path &dstpath_)
   {
     _dstpath = dstpath_;
-    return _walker.walk();
+    _walker.walk();
   }
 
 public:
   void
   begin()
   {
+    _cb.begin();
   }
 
   void
   end()
   {
+    _cb.end();
   }
 
 
 public:
   void
-  operator()(const std::filesystem::path&,
-             const TDO::DirectoryHeader&,
-             TDO::DevStream&)
+  operator()(const std::filesystem::path &path_,
+             const TDO::DirectoryHeader  &header_,
+             TDO::DevStream              &stream_)
   {
+    // file_tell() returns s64; sizeof(TDO::DirectoryHeader) is size_t.
+    // The DiscUnpacker::Callback::directory third parameter is u32.
+    // With images that can exceed 4 GiB (the v2 walker permits
+    // intermediate positions up to s64), the implicit narrowing
+    // through unsigned arithmetic would silently wrap. Compute the
+    // header position in s64 and route through checked_narrow.
+    const s64 header_pos =
+      stream_.file_tell() - static_cast<s64>(sizeof(TDO::DirectoryHeader));
+    _cb.directory(path_,
+                  header_,
+                  TDO::checked_narrow_s64_to_u32(header_pos,
+                                                 "directory header position"),
+                  stream_);
   }
 
   void
@@ -80,6 +99,30 @@ public:
   {
     fs::path fullpath = _dstpath / path_;
 
+    {
+      std::error_code ec_dst;
+      std::error_code ec_full;
+      const fs::path canonical_dst  = fs::weakly_canonical(_dstpath,ec_dst);
+      const fs::path canonical_full = fs::weakly_canonical(fullpath,ec_full);
+      // Fail closed: a single shared error_code would let the second
+      // call's success silently clear a failure on the first, and the
+      // empty canonical_dst would then make every prefix comparison
+      // pass. Reject any case where we cannot determine containment.
+      if(ec_dst || ec_full || canonical_dst.empty())
+        throw Error("refusing to write: cannot canonicalize destination path: " +
+                    fullpath.string());
+
+      const std::string a = canonical_dst.generic_string();
+      const std::string b = canonical_full.generic_string();
+      const bool same = (a == b);
+      const bool prefixed = ((b.size() > a.size()) &&
+                             (b.compare(0,a.size(),a) == 0) &&
+                             (a.back() == '/' || b[a.size()] == '/'));
+      if(!same && !prefixed)
+        throw Error("refusing to write outside destination: " +
+                    fullpath.string());
+    }
+
     _cb.before(path_,record_,dr_file_pos_,stream_);
     if(record_.is_directory())
       {
@@ -88,28 +131,65 @@ public:
     else
       {
         std::ofstream os;
-        std::uint32_t sector_start;
-        std::uint32_t sector_end;
-        std::uint32_t bytes_left;
+        std::uint64_t bytes_left;
+        std::uint64_t byte_pos;
+        std::vector<char> buf;
+
+        bytes_left = record_.byte_count;
+        if((bytes_left > 0) && record_.avatar_list.empty())
+          throw Error("file record has byte_count > 0 but no avatars: " +
+                      fullpath.string());
 
         os.open(fullpath,std::ios::binary|std::ios::trunc);
+        if(!os.is_open())
+          throw Error("failed to open output file: " + fullpath.string());
 
-        bytes_left   = record_.byte_count;
-        sector_start = record_.avatar_list[0];
-        sector_end   = sector_start + record_.block_count;
-        for(uint32_t sector = sector_start; sector < sector_end; sector++)
+        if(bytes_left > 0)
           {
-            std::uint32_t n;
+            byte_pos = static_cast<std::uint64_t>(record_.avatar_list[0]) *
+                       stream_.device_block_data_size();
+            buf.resize(std::min<std::uint64_t>(bytes_left,64*1024));
+          }
+        else
+          {
+            byte_pos = 0;
+          }
 
-            stream_.data_block_seek(sector);
-            n = std::min(record_.block_size,bytes_left);
-            util::copy_stream(stream_.istream(),os,n);
+        while(bytes_left > 0)
+          {
+            const std::uint64_t n = std::min<std::uint64_t>(bytes_left,buf.size());
+            stream_.read_data_bytes(buf.data(),
+                                    static_cast<s64>(byte_pos),
+                                    static_cast<s64>(n));
+            os.write(buf.data(),n);
+            if(!os)
+              throw Error("failed to write output file: " + fullpath.string());
+            byte_pos   += n;
             bytes_left -= n;
           }
 
         os.close();
+        if(os.fail())
+          throw Error("failed to close output file: " + fullpath.string());
       }
     _cb.after(path_,record_,0);
+  }
+
+  Error
+  invalid_filename(const std::filesystem::path &parent_,
+                   const std::string           &filename_,
+                   const TDO::DirectoryRecord  &record_,
+                   const std::uint32_t          dr_file_pos_,
+                   const Error                 &err_,
+                   TDO::DevStream              &stream_)
+  {
+    const fs::path path = TDO::display_path(parent_,filename_);
+
+    _cb.before(path,record_,dr_file_pos_,stream_);
+    _cb.after(path,record_,1);
+    fmt::print(stderr,"3dt: {} - {}\n",err_.str,path.generic_string());
+
+    return Error();
   }
 
 private:
@@ -122,21 +202,21 @@ private:
 
 namespace TDO
 {
-  DiscUnpacker::DiscUnpacker(std::istream &is_,
-                             Callback     &cb_)
+  DiscUnpacker::DiscUnpacker(std::iostream &ios_,
+                             Callback      &cb_)
   {
-    _impl = std::make_unique<Impl>(is_,cb_);
+    _impl = std::make_unique<Impl>(ios_,cb_);
   }
 
   DiscUnpacker::~DiscUnpacker()
   {
   }
 
-  Error
+  void
   DiscUnpacker::unpack(const fs::path &dstpath_)
   {
     fs::create_directories(dstpath_);
 
-    return _impl->unpack(dstpath_);
+    _impl->unpack(dstpath_);
   }
 }

--- a/src/tdo_disc_unpacker.hpp
+++ b/src/tdo_disc_unpacker.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -39,22 +39,28 @@ namespace TDO
 
       virtual ~Callback() = default;
 
+      virtual void begin() {};
+      virtual void end() {};
       virtual void before(const std::filesystem::path &path,
                           const TDO::DirectoryRecord  &record,
                           const uint32_t               record_pos,
-                          TDO::DevStream              &stream) = 0;
+                          TDO::DevStream              &stream) {};
       virtual void after(const std::filesystem::path &path,
                          const TDO::DirectoryRecord  &record,
-                         const int                    err) = 0;
+                         const int                    err) {};
+      virtual void directory(const std::filesystem::path &path,
+                             const TDO::DirectoryHeader &header,
+                             const uint32_t              header_pos,
+                             TDO::DevStream             &stream) {};
     };
 
   public:
-    DiscUnpacker(std::istream &is,
-                 Callback     &cb);
+    DiscUnpacker(std::iostream &s,
+                 Callback      &cb);
     ~DiscUnpacker();
 
   public:
-    Error unpack(const std::filesystem::path &dstpath);
+    void unpack(const std::filesystem::path &dstpath);
 
   private:
     class Impl;

--- a/src/tdo_file_stream.cpp
+++ b/src/tdo_file_stream.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -21,7 +21,7 @@
 namespace TDO
 {
   FileStream::FileStream()
-    : DevStream(_ifs)
+    : DevStream(_fs)
   {
 
   }
@@ -31,28 +31,19 @@ namespace TDO
     close();
   }
 
-  Error
-  FileStream::open(const std::filesystem::path &filepath_)
+  void
+  FileStream::open(const std::filesystem::path &filepath_,
+                   const std::ios::openmode     mode_)
   {
     close();
 
-    _ifs.open(filepath_,std::ios::binary);
-    if(!_ifs.good())
-      return {};
+    _fs.open(filepath_,std::ios::binary|mode_);
+    if(!_fs)
+      throw Error("failed to open");
 
-    try
-      {
-        setup();
-      }
-    catch(const Error &err)
-      {
-        close();
-        return err;
-      }
+    setup();
 
     _filepath = filepath_;
-
-    return {};
   }
 
   const
@@ -62,16 +53,16 @@ namespace TDO
     return _filepath;
   }
 
-  std::istream&
-  FileStream::istream()
+  std::iostream&
+  FileStream::iostream()
   {
-    return _ifs;
+    return _fs;
   }
 
   void
   FileStream::close()
   {
-    if(_ifs.is_open())
-      _ifs.close();
+    if(_fs.is_open())
+      _fs.close();
   }
 }

--- a/src/tdo_file_stream.hpp
+++ b/src/tdo_file_stream.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -33,17 +33,18 @@ namespace TDO
     ~FileStream();
 
   public:
-    Error open(const std::filesystem::path &filepath);
+    void open(const std::filesystem::path &filepath,
+              const std::ios::openmode     mode = std::ios::in);
     void  close();
 
   public:
     const std::filesystem::path& filepath() const;
 
   public:
-    std::istream& istream();
+    std::iostream& iostream();
 
   private:
     std::filesystem::path _filepath;
-    std::ifstream         _ifs;
+    std::fstream          _fs;
   };
 }

--- a/src/tdo_filesystem_stats.cpp
+++ b/src/tdo_filesystem_stats.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -19,6 +19,7 @@
 #include "tdo_filesystem_stats.hpp"
 
 #include "tdo_fs_walker.hpp"
+#include "tdo_safe_narrow.hpp"
 
 
 class FSStatsCollector final : public TDO::FSWalker::Callbacks
@@ -59,18 +60,37 @@ public:
     total_data_size += record_.byte_count;
   }
 
-public:
   Error
+  invalid_filename(const std::filesystem::path&,
+                   const std::string&,
+                   const TDO::DirectoryRecord &record_,
+                   const uint32_t,
+                   const Error&,
+                   TDO::DevStream&)
+  {
+    file_count++;
+    total_data_size += record_.byte_count;
+
+    return {};
+  }
+
+public:
+  void
   collect(TDO::DevStream &stream_)
   {
     TDO::FSWalker walker(stream_,*this);
 
-    return walker.walk();
+    walker.walk();
   }
 
 public:
-  uint32_t file_count;
-  uint32_t total_data_size;
+  // Accumulate in u64 so that a malformed image whose records claim
+  // more bytes than 32-bit can express is detected at collect() time
+  // rather than silently wrapping into a plausible-looking value.
+  // The OperaFS image-size invariant is u32-bounded; overflowing u32
+  // here means the image is malformed.
+  uint64_t file_count;
+  uint64_t total_data_size;
 };
 
 namespace TDO
@@ -81,19 +101,16 @@ namespace TDO
   {
   }
 
-  Error
+  void
   FilesystemStats::collect(TDO::DevStream &stream_)
   {
-    Error err;
     FSStatsCollector collector;
 
-    err = collector.collect(stream_);
-    if(err)
-      return err;
+    collector.collect(stream_);
 
-    file_count      = collector.file_count;
-    total_data_size = collector.total_data_size;
-
-    return {};
+    file_count      = TDO::checked_narrow_u64_to_u32(collector.file_count,
+                                                     "filesystem file_count");
+    total_data_size = TDO::checked_narrow_u64_to_u32(collector.total_data_size,
+                                                     "filesystem total_data_size");
   }
 }

--- a/src/tdo_filesystem_stats.hpp
+++ b/src/tdo_filesystem_stats.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -29,7 +29,7 @@ namespace TDO
     FilesystemStats();
 
   public:
-    Error collect(DevStream &reader_);
+    void collect(DevStream &reader_);
 
   public:
     uint32_t file_count;

--- a/src/tdo_fs_walker.cpp
+++ b/src/tdo_fs_walker.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -17,13 +17,15 @@
 */
 
 #include "error.hpp"
+#include "fmt.hpp"
 #include "tdo_romtag.hpp"
 #include "tdo_fs_walker.hpp"
 
 #include <cstring>
 #include <filesystem>
+#include <limits>
 #include <string>
-#include <vector>
+#include <unordered_set>
 
 
 namespace fs = std::filesystem;
@@ -31,18 +33,74 @@ typedef TDO::FSWalker::Callbacks Callbacks;
 
 
 static
+bool
+romtag_size_is_byte_count(const TDO::ROMTag &tag_)
+{
+  switch(tag_.type)
+    {
+    case RSA_BLOCKS_ALWAYS:
+      return false;
+    }
+
+  return true;
+}
+
+static
 void
 update_record(const TDO::ROMTagVec &tags_,
               TDO::DirectoryRecord &dr_)
 {
+  bool matched = false;
+  uint32_t matched_avatar = 0;
+  uint32_t matched_byte_count = 0;
+
   for(const auto &tag : tags_)
     {
-      for(uint32_t i = 0; i <= dr_.last_avatar_index; i++)
+      if(!romtag_size_is_byte_count(tag))
+        continue;
+      // Skip tags whose offset+1 would wrap in u32 space; comparing
+      // such a wrapped value against avatar_list[i] could produce a
+      // false match on a record whose first avatar is 0 and let a
+      // malformed tag overwrite byte_count with arbitrary data.
+      if(tag.offset == std::numeric_limits<uint32_t>::max())
+        continue;
+
+      // Iterate over avatar_list directly rather than through
+      // last_avatar_index. The parser maintains
+      // avatar_list.size() == last_avatar_index + 1, but ranging on
+      // the container removes the indirect dependency and is robust
+      // against any future caller that constructs a DirectoryRecord
+      // without going through DevStream::read().
+      for(const uint32_t avatar : dr_.avatar_list)
         {
-          if(tag.offset+1 == dr_.avatar_list[i])
+          if(tag.offset+1 == avatar)
             {
-              dr_.byte_count = tag.size;
-              return;
+              if(matched)
+                {
+                  // Multiple ROMTags claim the same DirectoryRecord
+                  // (each via some avatar in the record's
+                  // avatar_list). Keep the first match (preserving
+                  // previous behavior) and warn rather than silently
+                  // picking last-writer-wins. Report both avatars:
+                  // when two tags hit different avatars of the same
+                  // record, naming only the first match's block
+                  // sends users hunting for a non-existent collision.
+                  fmt::print(stderr,
+                             "3dt: warning: multiple ROM tags reference directory record "
+                             "(kept avatar {} size {}b, ignoring avatar {} size {}b)\n",
+                             matched_avatar,
+                             matched_byte_count,
+                             avatar,
+                             tag.size);
+                }
+              else
+                {
+                  dr_.byte_count = tag.size;
+                  matched = true;
+                  matched_avatar = avatar;
+                  matched_byte_count = tag.size;
+                }
+              break;
             }
         }
     }
@@ -83,6 +141,57 @@ decode_v1_filename(const TDO::DirectoryRecord &dr_,
 }
 
 static
+std::string
+display_path(const fs::path &path_)
+{
+  if(path_.empty())
+    return "/";
+  return path_.generic_string();
+}
+
+static
+Error
+validate_v1_dir_block_link(const char              *name_,
+                           const std::int32_t      block_,
+                           const std::uint32_t     block_count_,
+                           const fs::path         &path_)
+{
+  const std::string path = display_path(path_);
+
+  if(block_ < -1)
+    return {std::string("invalid OperaFS directory header ") + name_ +
+            " for " + path};
+  if((block_ != -1) && (static_cast<std::uint32_t>(block_) >= block_count_))
+    return {std::string("invalid OperaFS directory header ") + name_ +
+            " for " + path};
+
+  return Error();
+}
+
+static
+Error
+validate_v1_dir_block_prev(const TDO::DirectoryHeader &header_,
+                           const std::int32_t         expected_prev_block_,
+                           const std::uint32_t        block_count_,
+                           const fs::path            &path_)
+{
+  Error err;
+  const std::string path = display_path(path_);
+
+  err = validate_v1_dir_block_link("prev_block",
+                                   header_.prev_block,
+                                   block_count_,
+                                   path_);
+  if(err)
+    return err;
+
+  if(header_.prev_block != expected_prev_block_)
+    return {"invalid OperaFS directory header prev_block for " + path};
+
+  return Error();
+}
+
+static
 Error
 validate_v1_dir_block_bounds(const std::int64_t block_start_,
                              const std::uint32_t block_size_,
@@ -105,11 +214,13 @@ validate_v1_dir_block_bounds(const std::int64_t block_start_,
 class Impl
 {
 public:
-  Impl(std::istream &is_,
-       Callbacks    &callbacks_)
+  Impl(std::iostream &ios_,
+       Callbacks     &callbacks_,
+       bool           use_existing_romtags_)
 
     : _callbacks(callbacks_),
-      _stream(is_)
+      _stream(ios_),
+      _use_existing_romtags(use_existing_romtags_)
   {
 
   }
@@ -122,11 +233,18 @@ public:
                       const std::int64_t    active_dir_end_,
                       const std::int64_t    dh_data_byte_pos_,
                       const std::uint32_t   dir_block_size_,
-                      const fs::path       &path_)
+                      const std::uint32_t   block_count_,
+                      const std::int32_t    prev_block_,
+                      const fs::path       &path_,
+                      std::int32_t         &next_block_,
+                      bool                 &last_in_dir_)
   {
     TDO::DirectoryHeader dh;
     std::int64_t data_byte_pos;
     Error err;
+
+    next_block_ = -1;
+    last_in_dir_ = false;
 
     if(dir_block_size_ < sizeof(TDO::DirectoryHeader))
       return {"invalid OperaFS directory block: smaller than directory header"};
@@ -134,6 +252,11 @@ public:
     data_byte_pos = dh_data_byte_pos_;
     _stream.data_byte_seek(data_byte_pos);
     _stream.read(dh);
+
+    err = validate_v1_dir_block_prev(dh,prev_block_,block_count_,path_);
+    if(err)
+      return err;
+    next_block_ = dh.next_block;
 
     _callbacks(path_,dh,_stream);
 
@@ -149,14 +272,28 @@ public:
     if(err)
       return err;
     if(data_byte_pos == first_free_byte_pos)
-      return Error();
+      {
+        if(next_block_ == -1)
+          last_in_dir_ = true;
+        return Error();
+      }
 
     _stream.data_byte_seek(data_byte_pos);
 
     while(true)
       {
         const std::int64_t dr_pos = _stream.data_byte_tell();
-        const std::uint32_t dr_file_pos = _stream.file_tell();
+        // file_tell() returns s64; the callback contract takes the
+        // record's file position as uint32_t. Match the v2 walker's
+        // pattern (see walk_v2 below) and reject any v1 directory
+        // record whose file offset would not fit in u32 rather than
+        // silently narrowing — image_size is bounded only by the
+        // underlying stream and can exceed 4 GiB.
+        const s64 dr_file_pos_s64 = _stream.file_tell();
+        if((dr_file_pos_s64 < 0) ||
+           (dr_file_pos_s64 > static_cast<s64>(std::numeric_limits<uint32_t>::max())))
+          return {"invalid OperaFS v1 directory record: file position out of range"};
+        const std::uint32_t dr_file_pos = static_cast<std::uint32_t>(dr_file_pos_s64);
         TDO::DirectoryRecord dr;
         std::string decoded_filename;
         std::int64_t next_pos;
@@ -183,28 +320,43 @@ public:
         update_record(romtags_,dr);
         err = decode_v1_filename(dr,decoded_filename);
         if(err)
-          return err;
-
-        {
-          TDO::PosGuard guard(_stream);
-          _callbacks(path_ / decoded_filename,dr,dr_file_pos,_stream);
-        }
-
-        if(dr.is_directory())
           {
-            const std::int64_t child_dir_byte_pos =
-              static_cast<std::int64_t>(dr.avatar_list[0]) * label_.volume_block_size;
-
-            if((child_dir_byte_pos >= active_dir_byte_pos_) && (child_dir_byte_pos < active_dir_end_))
-              return {"invalid OperaFS directory recursion target: non-advancing child directory block"};
-
-            err = walk_v1_dir(label_,romtags_,dr,path_ / decoded_filename);
+            TDO::PosGuard guard(_stream);
+            err = _callbacks.invalid_filename(path_,
+                                              decoded_filename,
+                                              dr,
+                                              dr_file_pos,
+                                              err,
+                                              _stream);
             if(err)
               return err;
           }
+        else
+          {
+            {
+              TDO::PosGuard guard(_stream);
+              _callbacks(path_ / decoded_filename,dr,dr_file_pos,_stream);
+            }
+
+            if(dr.is_directory())
+              {
+                const std::int64_t child_dir_byte_pos =
+                  static_cast<std::int64_t>(dr.avatar_list[0]) * label_.volume_block_size;
+
+                if((child_dir_byte_pos >= active_dir_byte_pos_) && (child_dir_byte_pos < active_dir_end_))
+                  return {"invalid OperaFS directory recursion target: non-advancing child directory block"};
+
+                err = walk_v1_dir(label_,romtags_,dr,path_ / decoded_filename);
+                if(err)
+                  return err;
+              }
+          }
 
         if(dr.last_in_dir())
-          break;
+          {
+            last_in_dir_ = true;
+            break;
+          }
         if(dr.last_in_block())
           break;
         if(_stream.data_byte_tell() >= first_free_byte_pos)
@@ -224,19 +376,54 @@ public:
               const std::uint32_t   dir_block_count_,
               const fs::path       &path_)
   {
-    std::int64_t  dh_data_byte_pos;
-    const std::int64_t active_dir_byte_pos = (dir_block_ * label_.volume_block_size);
-    const std::int64_t active_dir_end =
-      active_dir_byte_pos + (static_cast<std::int64_t>(dir_block_size_) * dir_block_count_);
+    // u32 * u32 silently wraps in u32 before being widened to s64.
+    // Compute in u64 first and reject if the start or end position
+    // would not fit in s64 (the underlying stream cursor type),
+    // matching the protection on the v2 path. Both inputs are read
+    // raw from the on-disc directory record so an attacker-shaped
+    // image can drive the multiply past 4 GiB.
+    std::int64_t active_dir_byte_pos;
+    std::int64_t active_dir_end;
+    {
+      const std::uint64_t start_u64 =
+        static_cast<std::uint64_t>(dir_block_) * label_.volume_block_size;
+      const std::uint64_t span_u64 =
+        static_cast<std::uint64_t>(dir_block_size_) * dir_block_count_;
+      const std::uint64_t s64_max =
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+      if(start_u64 > s64_max)
+        return {"invalid OperaFS v1 directory: start position overflow"};
+      if(span_u64 > (s64_max - start_u64))
+        return {"invalid OperaFS v1 directory: end position overflow"};
+      active_dir_byte_pos = static_cast<std::int64_t>(start_u64);
+      active_dir_end      = static_cast<std::int64_t>(start_u64 + span_u64);
+    }
     TDO::PosGuard pos_guard(_stream);
+    std::int32_t block;
+    std::int32_t prev_block;
+    std::unordered_set<std::uint32_t> visited;
 
     if((dir_block_count_ != 0) && (dir_block_size_ == 0))
       return {"invalid OperaFS directory metadata: zero directory block size"};
+    if(dir_block_count_ == 0)
+      return Error();
 
-    dh_data_byte_pos = active_dir_byte_pos;
-    for(std::uint32_t block = 0; block < dir_block_count_; block++)
+    block = 0;
+    prev_block = -1;
+    while(block != -1)
       {
         Error err;
+        std::int32_t next_block;
+        std::int64_t dh_data_byte_pos;
+        bool last_in_dir;
+
+        if(static_cast<std::uint32_t>(block) >= dir_block_count_)
+          return {"invalid OperaFS directory header next_block for " + display_path(path_)};
+        if(!visited.insert(static_cast<std::uint32_t>(block)).second)
+          return {"invalid OperaFS directory header next_block loop for " + display_path(path_)};
+
+        dh_data_byte_pos =
+          active_dir_byte_pos + (static_cast<std::int64_t>(dir_block_size_) * block);
 
         err = walk_v1_dir_block(label_,
                                 romtags_,
@@ -244,10 +431,27 @@ public:
                                 active_dir_end,
                                 dh_data_byte_pos,
                                 dir_block_size_,
-                                path_);
+                                dir_block_count_,
+                                prev_block,
+                                path_,
+                                next_block,
+                                last_in_dir);
         if(err)
           return err;
-        dh_data_byte_pos += dir_block_size_;
+        if(last_in_dir)
+          break;
+
+        err = validate_v1_dir_block_link("next_block",
+                                         next_block,
+                                         dir_block_count_,
+                                         path_);
+        if(err)
+          return err;
+        if(next_block == -1)
+          break;
+
+        prev_block = block;
+        block = next_block;
       }
 
     return Error();
@@ -284,38 +488,93 @@ public:
   walk_v2(const TDO::DiscLabel &label_,
           const fs::path       &path_)
   {
-    std::uint32_t pos;
-    Error err;
+    s64 pos;
+    s64 image_size;
+    std::unordered_set<s64> visited;
 
-    pos = label_.root_directory_avatar_list[0] * label_.root_directory_block_size;
+    if(label_.root_directory_block_size == 0)
+      return {"invalid OperaFS v2 root directory: zero block size"};
+
+    image_size = _stream.size_in_bytes();
+    // Compute the root-directory file position in u64 to avoid signed
+    // overflow UB. Both fields are u32 read raw from the disc label, so
+    // their product fits in u64 (max (2^32-1)^2 < 2^64) but can exceed
+    // INT64_MAX (max ~9.22e18 < (2^32-1)^2 ~1.84e19). Range-check before
+    // narrowing to s64.
+    {
+      const u64 pos_u64 = (static_cast<u64>(label_.root_directory_avatar_list[0]) *
+                           static_cast<u64>(label_.root_directory_block_size));
+      if(pos_u64 > static_cast<u64>(std::numeric_limits<s64>::max()))
+        return {"invalid OperaFS v2 root directory: position overflow"};
+      pos = static_cast<s64>(pos_u64);
+    }
+    if((pos < 0) || (pos >= image_size))
+      return {"invalid OperaFS v2 root directory: position out of bounds"};
+
     while(true)
       {
         TDO::DirectoryRecord dr;
         TDO::LinkedMemFileEntry lmfe;
+        s64 next_pos;
+
+        if(!visited.insert(pos).second)
+          return {"invalid OperaFS v2 directory link: revisited offset"};
+
         _stream.data_byte_seek(pos);
         _stream.read(lmfe);
 
         if(lmfe.fingerprint == FINGERPRINT_FILEBLOCK)
           {
+            // The Callbacks operator() takes the file position as
+            // const uint32_t. pos is now s64 and bounded by
+            // image_size, which can exceed 4 GiB; refuse rather than
+            // silently narrowing.
+            if((pos < 0) ||
+               (pos > static_cast<s64>(std::numeric_limits<uint32_t>::max())))
+              return {"invalid OperaFS v2 directory entry: position out of range"};
+
+            std::string decoded_filename;
+            const void *terminator =
+              memchr(lmfe.filename,'\0',sizeof(lmfe.filename));
+            if(terminator != nullptr)
+              decoded_filename.assign(lmfe.filename,
+                                      static_cast<const char*>(terminator) -
+                                      lmfe.filename);
+            else
+              decoded_filename.assign(lmfe.filename,sizeof(lmfe.filename));
+
             dr.flags = 0;
             dr.unique_identifier = lmfe.unique_identifier;
             dr.type = lmfe.type;
             dr.block_size = label_.volume_block_size;
             dr.byte_count = lmfe.byte_count;
-            dr.block_count = lmfe.byte_count;
+            dr.block_count = lmfe.block_count;
             dr.burst = 0;
             dr.gap = 0;
             memcpy(dr.filename,lmfe.filename,sizeof(dr.filename));
             dr.last_avatar_index = 0;
-            dr.avatar_list.push_back(pos + lmfe.header_block_count);
+            // avatar_list elements are uint32_t; pos is now s64 and
+            // bounded only by image_size, which can exceed 4 GiB.
+            // Reject any v2 entry whose first-avatar offset would not
+            // fit in uint32_t rather than silently narrowing.
+            {
+              const s64 first_avatar = pos + static_cast<s64>(lmfe.header_block_count);
+              if((first_avatar < 0) ||
+                 (first_avatar > static_cast<s64>(std::numeric_limits<uint32_t>::max())))
+                return {"invalid OperaFS v2 file entry: avatar position out of range"};
+              dr.avatar_list.push_back(static_cast<uint32_t>(first_avatar));
+            }
 
             TDO::PosGuard guard(_stream);
-            _callbacks(path_ / dr.filename,dr,pos,_stream);
+            _callbacks(path_ / decoded_filename,dr,static_cast<uint32_t>(pos),_stream);
           }
 
-        if(lmfe.flink_offset < pos)
+        next_pos = static_cast<s64>(lmfe.flink_offset);
+        if(next_pos <= pos)
           break;
-        pos = lmfe.flink_offset;
+        if(next_pos >= image_size)
+          return {"invalid OperaFS v2 directory link: flink_offset out of bounds"};
+        pos = next_pos;
       }
 
     return Error();
@@ -331,9 +590,10 @@ public:
 
     _stream.setup();
 
-    _stream.read(dl);
+    dl = _stream.disc_label();
 
-    romtags = _stream.romtags();
+    if(_use_existing_romtags)
+      romtags = _stream.romtags();
 
     _callbacks.begin();
     switch(dl.volume_structure_version)
@@ -355,36 +615,36 @@ public:
 private:
   Callbacks      &_callbacks;
   TDO::DevStream  _stream;
+  bool            _use_existing_romtags;
 };
 
 namespace TDO
 {
-  FSWalker::FSWalker(std::istream &is_,
-                     Callbacks    &callbacks_)
+  FSWalker::FSWalker(std::iostream &ios_,
+                     Callbacks     &callbacks_,
+                     bool           use_existing_romtags_)
     : _callbacks(callbacks_),
-      _is(is_)
+      _ios(ios_),
+      _use_existing_romtags(use_existing_romtags_)
   {
   }
 
   FSWalker::FSWalker(DevStream &stream_,
-                     Callbacks &callbacks_)
+                     Callbacks &callbacks_,
+                     bool       use_existing_romtags_)
     : _callbacks(callbacks_),
-      _is(stream_.istream())
+      _ios(stream_.iostream()),
+      _use_existing_romtags(use_existing_romtags_)
   {
   }
 
-  Error
+  void
   FSWalker::walk()
   {
-    try
-      {
-        Impl impl(_is,_callbacks);
+    Impl impl(_ios,_callbacks,_use_existing_romtags);
 
-        return impl.walk();
-      }
-    catch(const Error &err)
-      {
-        return err;
-      }
+    Error err = impl.walk();
+    if(err)
+      throw err;
   }
 }

--- a/src/tdo_fs_walker.hpp
+++ b/src/tdo_fs_walker.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -24,8 +24,9 @@
 #include <filesystem>
 #include <functional>
 #include <istream>
+#include <string>
 
-
+// TODO: Add way to exit walk
 namespace TDO
 {
   class FSWalker
@@ -33,28 +34,40 @@ namespace TDO
   public:
     struct Callbacks
     {
-      virtual void begin() = 0;
-      virtual void end() = 0;
+      virtual void begin() {};
+      virtual void end() {};
       virtual void operator()(const std::filesystem::path&,
                               const TDO::DirectoryHeader&,
-                              TDO::DevStream&) = 0;
+                              TDO::DevStream&) {};
       virtual void operator()(const std::filesystem::path&,
                               const TDO::DirectoryRecord&,
                               const uint32_t,
-                              TDO::DevStream&) = 0;
+                              TDO::DevStream&) {};
+      virtual Error invalid_filename(const std::filesystem::path&,
+                                     const std::string&,
+                                     const TDO::DirectoryRecord&,
+                                     const uint32_t,
+                                     const Error &err,
+                                     TDO::DevStream&)
+      {
+        return err;
+      };
     };
 
   public:
-    FSWalker(std::istream &is,
-             Callbacks    &callbacks);
+    FSWalker(std::iostream &ios,
+             Callbacks     &callbacks,
+             bool           use_existing_romtags = true);
     FSWalker(DevStream &stream,
-             Callbacks &callbacks);
+             Callbacks &callbacks,
+             bool       use_existing_romtags = true);
 
   public:
-    Error walk();
+    void walk();
 
   private:
-    Callbacks    &_callbacks;
-    std::istream &_is;
+    Callbacks     &_callbacks;
+    std::iostream &_ios;
+    bool           _use_existing_romtags;
   };
 }

--- a/src/tdo_keys.cpp
+++ b/src/tdo_keys.cpp
@@ -1,0 +1,129 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#define HAVE_C99INCLUDES
+
+#include "bigd.h"
+#include "md5.h"
+
+#include "error.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+static const char M1_RETAIL_3DO_N_STR[] = "B19462B00D8D6E1EC909AB385E06FE034BFD282E9FFDC584838C15F12593DD1E3A8B5626F1B9D0ED0C384EF6C5D14512BD72DDB85B44080E0472C03D0AFC4C97";
+static const char M1_RETAIL_3DO_D_STR[] = "42F7CD9BCD109805BE150A60107D9C8F8BB9A5CCA78361588EEF665AF1ABE887DBC2593D0868F364A93C8CB8CC6F4BCC6A3DE57E04B17AC52F2649939C453F61";
+static const char M1_RETAIL_3DO_P_STR[] = "E1BE29DE79315A1CD384C61DB3BACA5227C2D5A2020899283328C8E9C9B53BB1";
+static const char M1_RETAIL_3DO_Q_STR[] = "C9619D5BBAEB0DEBCC6D144E380C987108C33FA379BB0CE1F714A7E92DF0C6C7";
+static const char M1_RETAIL_3DO_E_STR[] = "10001";
+
+static const char M1_RETAIL_APP_N_STR[] = "BC0B199086C7F26CBC9D50F404944DB4789FCBFCF7AD8DBC2120898ABEAAF311EEA20229035608841FA41073ABBD5D37500C60B53BFB46605740381B72C9DB71";
+static const char M1_RETAIL_APP_D_STR[] = "18B2207E61A51ACA7B0EF215CA102C105A9329F824130FFD38208CCFC2F0B2915B8AD1E7772334381737D232B183C869C34940BC8769C97E18D7B0E78C492991";
+static const char M1_RETAIL_APP_P_STR[] = "CBBA701095E52D2D96F4153328F7B85D147D273D1033AE034721F1B09A96FED5";
+static const char M1_RETAIL_APP_Q_STR[] = "EC4A6C856F69EA7F910C4327E4586DCFAEC8C6E7AC875A435AD6EDB7476AD02D";
+static const char M1_RETAIL_APP_E_STR[] = "10001";
+
+static const char M1_RETAIL_MSG_PREFIX_STR[] = "1ffffffffffffffffffffffffffffffffffffffffffffffffffffff003020300c06082a864886f70d020505000410";
+
+extern "C"
+{
+
+static
+BIGD
+bigd_from_hex_str(const char *s_)
+{
+  BIGD bigd;
+
+  bigd = bdNew();
+
+  bdConvFromHex(bigd,s_);
+
+  return bigd;
+}
+
+BIGD
+tdo_keys_m1_retail_3do_n(void)
+{
+  return bigd_from_hex_str(M1_RETAIL_3DO_N_STR);
+}
+
+BIGD
+tdo_keys_m1_retail_3do_d(void)
+{
+  return bigd_from_hex_str(M1_RETAIL_3DO_D_STR);
+}
+
+BIGD
+tdo_keys_m1_retail_app_n(void)
+{
+  return bigd_from_hex_str(M1_RETAIL_APP_N_STR);
+}
+
+BIGD
+tdo_keys_m1_retail_app_d(void)
+{
+  return bigd_from_hex_str(M1_RETAIL_APP_D_STR);
+}
+
+BIGD
+tdo_keys_m1_retail_message(md5_digest_t digest_)
+{
+  std::string str;
+  str.reserve(sizeof(M1_RETAIL_MSG_PREFIX_STR) - 1 + 32);
+  str += M1_RETAIL_MSG_PREFIX_STR;
+  static const char HEX[] = "0123456789abcdef";
+  for(int i = 0; i < 16; i++)
+    {
+      str += HEX[digest_[i] >> 4];
+      str += HEX[digest_[i] & 0xF];
+    }
+
+  return bigd_from_hex_str(str.c_str());
+}
+
+BIGD
+tdo_keys_n(const char *key_)
+{
+  if(std::strcmp(key_,"3do") == 0)
+    return tdo_keys_m1_retail_3do_n();
+  if(std::strcmp(key_,"app") == 0)
+    return tdo_keys_m1_retail_app_n();
+  throw Error("unknown key: " + std::string(key_));
+}
+
+BIGD
+tdo_keys_d(const char *key_)
+{
+  if(std::strcmp(key_,"3do") == 0)
+    return tdo_keys_m1_retail_3do_d();
+  if(std::strcmp(key_,"app") == 0)
+    return tdo_keys_m1_retail_app_d();
+  throw Error("unknown key: " + std::string(key_));
+}
+
+BIGD
+tdo_keys_m(const char   *key_,
+           md5_digest_t  digest_)
+{
+  if((std::strcmp(key_,"3do") != 0) && (std::strcmp(key_,"app") != 0))
+    throw Error("unknown key: " + std::string(key_));
+  return tdo_keys_m1_retail_message(digest_);
+}
+
+} // extern "C"

--- a/src/tdo_keys.h
+++ b/src/tdo_keys.h
@@ -1,0 +1,42 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include "bigd.h"
+#include "md5.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+BIGD tdo_keys_m1_retail_3do_n(void);
+BIGD tdo_keys_m1_retail_3do_d(void);
+BIGD tdo_keys_m1_retail_app_n(void);
+BIGD tdo_keys_m1_retail_app_d(void);
+
+BIGD tdo_keys_m1_retail_message(md5_digest_t digest);
+
+BIGD tdo_keys_n(const char *key);
+BIGD tdo_keys_d(const char *key);
+BIGD tdo_keys_m(const char *key, md5_digest_t digest);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/tdo_romtag.cpp
+++ b/src/tdo_romtag.cpp
@@ -1,0 +1,123 @@
+#include "tdo_romtag.hpp"
+
+#include "error.hpp"
+#include "fmt.hpp"
+#include "tdo_dev_stream.hpp"
+
+#include <limits>
+
+
+std::string
+TDO::ROMTag::type_str(const uint8_t type_)
+{
+  switch(type_)
+    {
+    case RSA_MUST_RSA:
+      return "MUST_RSA";
+    case RSA_NEWKNEWNEWGNUBOOT:
+      return "NEWKNEWNEWGNUBOOT";
+    case RSA_OS:
+      return "OS";
+    case RSA_BILLSTUFF:
+      return "BILLSTUFF";
+    case RSA_BLOCKS_ALWAYS:
+      return "BLOCKS_ALWAYS";
+    case RSA_MISCCODE:
+      return "MISCCODE";
+    case RSA_SIGNATURE_BLOCK:
+      return "SIGNATURE_BLOCK";
+    case RSA_APPSPLASH:
+      return "APPSPLASH";
+    case RSA_DEPOTCONFIG:
+      return "DEPOTCONFIG";
+    case RSA_DEVICE_INFO:
+      return "DEVICE_INFO";
+    case RSA_DEV_PERMS:
+      return "DEV_PERMS";
+    case RSA_BOOT_OVERLAY:
+      return "BOOT_OVERLAY";
+
+    case RSA_M2_OS:
+      return "M2_OS";
+    case RSA_M2_MISCCODE:
+      return "M2_MISCCODE";
+    case RSA_M2_DRIVER:
+      return "M2_DRIVER";
+    case RSA_M2_DEVDIPIR:
+      return "M2_DEVDIPIR";
+    case RSA_M2_APPBANNER:
+      return "M2_APPBANNER";
+    case RSA_M2_APP_KEYS:
+      return "M2_APP_KEYS";
+    case RSA_OPERA_CD_IMAGE:
+      return "OPERA_CD_IMAGE";
+    case RSA_M2_ICON:
+      return "M2_ICON";
+    }
+
+  return fmt::format("{:#04x}",type_);
+}
+
+std::string
+TDO::ROMTag::type_str() const
+{
+  return type_str(type);
+}
+
+u64
+TDO::safe_romtag_first_data_block(TDO::DevStream    &stream_,
+                                  const TDO::ROMTag &tag_,
+                                  const char        *label_)
+{
+  const u64 file_blocks = stream_.device_block_count();
+  if(tag_.offset == std::numeric_limits<uint32_t>::max())
+    throw Error(std::string(label_) + " ROM tag offset would wrap on +1");
+  // offset + 1 must point at file data, not the disc-label / romtags
+  // reserved region. The signer rejects avatar == 0 upstream
+  // (tdo_disc_signer.cpp), so an offset of zero here only arises from
+  // a malformed image. Reject it explicitly with a clearer message
+  // than letting downstream code read romtag bytes as tag data.
+  if(tag_.offset == 0)
+    throw Error(std::string(label_) +
+                " ROM tag offset is zero (first data block 1 overlaps reserved region)");
+  if((file_blocks > 0) && (static_cast<u64>(tag_.offset) + 1 >= file_blocks))
+    throw Error(std::string(label_) + " ROM tag offset is past end of image");
+
+  return (static_cast<u64>(tag_.offset) + 1);
+}
+
+u64
+TDO::safe_romtag_payload_range(TDO::DevStream    &stream_,
+                               const TDO::ROMTag &tag_,
+                               const u64          payload_size_bytes_,
+                               const char        *label_)
+{
+  const u64 first_block = safe_romtag_first_data_block(stream_,tag_,label_);
+  if(payload_size_bytes_ == 0)
+    return first_block;
+
+  const u64 data_block_size = stream_.device_block_data_size();
+  if(data_block_size == 0)
+    throw Error(std::string(label_) + " stream has zero data-block size");
+
+  const s64 image_size_signed = stream_.size_in_bytes();
+  if(image_size_signed < 0)
+    throw Error(std::string(label_) + " image size unavailable");
+  const u64 image_size = static_cast<u64>(image_size_signed);
+
+  // first_block * data_block_size in u64. file_blocks already bounded
+  // first_block above, but the multiplication itself is the gate when
+  // device_block_count() returned 0 (sentinel) — guard it explicitly.
+  if(first_block > (std::numeric_limits<u64>::max() / data_block_size))
+    throw Error(std::string(label_) +
+                " ROM tag payload start overflows file offset math");
+  const u64 start_offset = first_block * data_block_size;
+  if(start_offset > image_size)
+    throw Error(std::string(label_) +
+                " ROM tag payload starts past end of image");
+  if(payload_size_bytes_ > (image_size - start_offset))
+    throw Error(std::string(label_) +
+                " ROM tag payload extends past end of image");
+
+  return first_block;
+}

--- a/src/tdo_romtag.hpp
+++ b/src/tdo_romtag.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2021, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -18,13 +18,19 @@
 
 #pragma once
 
+#include "types_ints.h"
+
 #include <cstdint>
 #include <vector>
+#include <string>
 
 namespace TDO
 {
+  class DevStream;
+
   struct ROMTag
   {
+  public:
     uint8_t sub_systype;
     uint8_t type;
     uint8_t version;
@@ -36,9 +42,41 @@ namespace TDO
     uint32_t offset;
     uint32_t size;
     uint32_t reserved3[4];
+
+  public:
+    static std::string type_str(const uint8_t);
+    std::string type_str() const;
   };
 
   typedef std::vector<TDO::ROMTag> ROMTagVec;
+
+  // Validate a ROMTag.offset and return offset+1 in u64 space, throwing
+  // on out-of-range values. Used wherever we treat a ROMTag's first
+  // payload block as the avatar of a signed region.
+  //
+  // tag_.offset is u32, so the only "out of u32 range" value is
+  // 0xFFFFFFFF itself; we reject it specifically because offset+1 in
+  // u32 space wraps to 0 and silently redirects reads/writes onto the
+  // disc label.
+  u64
+  safe_romtag_first_data_block(TDO::DevStream    &stream_,
+                               const TDO::ROMTag &tag_,
+                               const char        *label_);
+
+  // Validate the full payload range of a ROMTag against the image
+  // size: returns the first data block (offset+1) like
+  // safe_romtag_first_data_block, but additionally rejects payloads
+  // whose start or end falls past the end of the underlying image.
+  // The signer reads/writes the full [first_block .. first_block +
+  // payload_size_bytes_) range; without an explicit end-bound check
+  // the only enforcement is whatever the underlying stream rejects on
+  // I/O. Use this for any signing or verification path that consumes
+  // the whole ROMTag payload.
+  u64
+  safe_romtag_payload_range(TDO::DevStream    &stream_,
+                            const TDO::ROMTag &tag_,
+                            const u64          payload_size_bytes_,
+                            const char        *label_);
 }
 
 

--- a/src/tdo_rsa.cpp
+++ b/src/tdo_rsa.cpp
@@ -1,0 +1,72 @@
+#include "tdo_rsa.h"
+
+#include "bigd.h"
+#include "md5.h"
+
+#include <cstring>
+
+struct Bigd
+{
+  BIGD bd;
+
+  Bigd(BIGD bd_ = nullptr)
+    : bd(bd_)
+  {
+  }
+
+  ~Bigd()
+  {
+    if(bd)
+      bdFree(&bd);
+  }
+
+  Bigd(const Bigd&)            = delete;
+  Bigd& operator=(const Bigd&) = delete;
+
+  Bigd(Bigd&& other_) noexcept
+    : bd(other_.bd)
+  {
+    other_.bd = nullptr;
+  }
+
+  Bigd&
+  operator=(Bigd&& other_) noexcept
+  {
+    if(this != &other_)
+      {
+        if(bd)
+          bdFree(&bd);
+        bd = other_.bd;
+        other_.bd = nullptr;
+      }
+    return *this;
+  }
+
+  operator BIGD() const
+  {
+    return bd;
+  }
+};
+
+extern "C"
+{
+
+void
+tdo_rsa_sign(const char         *key_,
+             const md5_digest_t  digest_,
+             rsa512_sig_t        sig_)
+{
+  md5_digest_t digest;
+  std::memcpy(digest,digest_,sizeof(digest));
+
+  Bigd n(tdo_keys_n(key_));
+  Bigd d(tdo_keys_d(key_));
+  Bigd m(tdo_keys_m(key_,digest));
+  Bigd s(bdNew());
+
+  bdModExp(s,m,d,n);
+
+  bdConvToOctets(s,sig_,sizeof(rsa512_sig_t));
+}
+
+}

--- a/src/tdo_rsa.h
+++ b/src/tdo_rsa.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "md5.h"
+#include "tdo_keys.h"
+
+#define RSA512_SIG_SIZE (512 / 8)
+#define TDO_KEY_3DO "3do"
+#define TDO_KEY_APP "app"
+
+typedef unsigned char rsa512_sig_t[RSA512_SIG_SIZE];
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+  
+void
+tdo_rsa_sign(const char         *key,
+             const md5_digest_t  digest,
+             rsa512_sig_t        sig);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/tdo_safe_narrow.hpp
+++ b/src/tdo_safe_narrow.hpp
@@ -1,0 +1,129 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include "error.hpp"
+#include "types_ints.h"
+
+#include <limits>
+#include <string>
+
+namespace TDO
+{
+  // Narrow an s64 value to u32 with overflow detection. The 3DO
+  // OperaFS targets a 32-bit platform; many on-disc fields are u32
+  // and intermediate arithmetic uses s64 to keep overflow detectable.
+  // Throws Error("<label_> does not fit in 32-bit unsigned: <value>")
+  // when value_ is negative or exceeds UINT32_MAX.
+  inline u32
+  checked_narrow_s64_to_u32(const s64          value_,
+                            const std::string &label_)
+  {
+    if((value_ < 0) ||
+       (value_ > static_cast<s64>(std::numeric_limits<u32>::max())))
+      throw Error(label_ +
+                  " does not fit in 32-bit unsigned: " +
+                  std::to_string(value_));
+    return static_cast<u32>(value_);
+  }
+
+  // Narrow a u64 value to s64 with overflow detection. Used when a
+  // computation done in unsigned 64-bit (to avoid signed-overflow UB)
+  // must be converted back to s64 for a downstream signed API.
+  // Throws Error("<label_> does not fit in 64-bit signed: <value>")
+  // when value_ exceeds INT64_MAX.
+  inline s64
+  checked_narrow_u64_to_s64(const u64          value_,
+                            const std::string &label_)
+  {
+    if(value_ > static_cast<u64>(std::numeric_limits<s64>::max()))
+      throw Error(label_ +
+                  " does not fit in 64-bit signed: " +
+                  std::to_string(value_));
+    return static_cast<s64>(value_);
+  }
+
+  // Narrow a u64 value to u32 with overflow detection. The 3DO
+  // OperaFS targets a 32-bit platform; many on-disc fields are u32
+  // and intermediate arithmetic uses u64 (rather than s64) when the
+  // value is known non-negative and the concern is just upper bound.
+  // Throws Error("<label_> does not fit in 32-bit unsigned: <value>")
+  // when value_ exceeds UINT32_MAX.
+  inline u32
+  checked_narrow_u64_to_u32(const u64          value_,
+                            const std::string &label_)
+  {
+    if(value_ > static_cast<u64>(std::numeric_limits<u32>::max()))
+      throw Error(label_ +
+                  " does not fit in 32-bit unsigned: " +
+                  std::to_string(value_));
+    return static_cast<u32>(value_);
+  }
+
+  // Narrow a u32 value to u8 with overflow detection. Used when an on-disc
+  // OperaFS field is documented as 1 byte (record_type, volume_flags,
+  // volume_structure_version) but the source representation is wider
+  // (e.g. JSON manifest value comes through as u32). A manifest that
+  // specifies a value > 255 is malformed; throwing here surfaces it
+  // rather than silently truncating to a different byte than the user
+  // wrote.
+  inline u8
+  checked_narrow_u32_to_u8(const u32          value_,
+                           const std::string &label_)
+  {
+    if(value_ > static_cast<u32>(std::numeric_limits<u8>::max()))
+      throw Error(label_ +
+                  " does not fit in 8-bit unsigned: " +
+                  std::to_string(value_));
+    return static_cast<u8>(value_);
+  }
+
+  // Checked u32 multiplication: returns a_*b_ in u32, throwing on
+  // overflow. Uses __builtin_mul_overflow, portable across every
+  // compiler this project targets (gcc, clang, MinGW). The error
+  // message reports the mathematically correct product so the user
+  // sees the offending value, matching the wording used by the
+  // checked_narrow_* helpers above.
+  inline u32
+  checked_mul_u32(const u32          a_,
+                  const u32          b_,
+                  const std::string &label_)
+  {
+    u32 result;
+    if(__builtin_mul_overflow(a_,b_,&result))
+      throw Error(label_ +
+                  " does not fit in 32-bit unsigned: " +
+                  std::to_string(static_cast<u64>(a_) * b_));
+    return result;
+  }
+
+  // Checked u32 addition. Same shape as checked_mul_u32.
+  inline u32
+  checked_add_u32(const u32          a_,
+                  const u32          b_,
+                  const std::string &label_)
+  {
+    u32 result;
+    if(__builtin_add_overflow(a_,b_,&result))
+      throw Error(label_ +
+                  " does not fit in 32-bit unsigned: " +
+                  std::to_string(static_cast<u64>(a_) + b_));
+    return result;
+  }
+}

--- a/src/temp_path.hpp
+++ b/src/temp_path.hpp
@@ -1,0 +1,47 @@
+/*
+  ISC License
+
+  Copyright (c) 2025, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#pragma once
+
+#include "error.hpp"
+#include "fmt.hpp"
+
+#include <filesystem>
+#include <random>
+#include <string>
+
+static inline
+std::filesystem::path
+temp_path_for(const std::filesystem::path &path_)
+{
+  // The .tmpN suffix scheme would be predictable to a same-user
+  // attacker who can pre-populate the slots. Mix in two random_device
+  // samples per attempt so the candidate names are not enumerable
+  // from the input filename alone. Matches the style used in
+  // create_temp_dir() in subcommand_repack.cpp (commit 9d8659c).
+  std::random_device rd;
+  for(std::uint32_t i = 0; i < 1000; i++)
+    {
+      std::filesystem::path path = path_;
+      path += fmt::format(".tmp{:08x}{:08x}",rd(),rd());
+      if(!std::filesystem::exists(path))
+        return path;
+    }
+
+  throw Error("failed to create temporary output path");
+}

--- a/src/types_ints.h
+++ b/src/types_ints.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <stdint.h>
+
+#define S8_MIN  INT8_MIN
+#define S8_MAX  INT8_MAX
+#define S16_MIN INT16_MIN
+#define S16_MAX INT16_MAX
+#define S32_MIN INT32_MIN
+#define S32_MAX INT32_MAX
+#define S64_MIN INT64_MIN
+#define S64_MAX INT64_MAX
+
+#define U8_MIN  UINT8_MIN
+#define U8_MAX  UINT8_MAX
+#define U16_MIN UINT16_MIN
+#define U16_MAX UINT16_MAX
+#define U32_MIN UINT32_MIN
+#define U32_MAX UINT32_MAX
+#define U64_MIN UINT64_MIN
+#define U64_MAX UINT64_MAX
+
+typedef uint8_t     u8;
+typedef int8_t      s8;
+typedef volatile u8 vu8;
+typedef volatile s8 vs8;
+
+typedef uint16_t     u16;
+typedef int16_t      s16;
+typedef volatile u16 vu16;
+typedef volatile s16 vs16;
+
+typedef uint32_t     u32;
+typedef int32_t      s32;
+typedef volatile u32 vu32;
+typedef volatile s32 vs32;
+
+typedef uint64_t     u64;
+typedef int64_t      s64;
+typedef volatile u64 vu64;
+typedef volatile s64 vs64;
+
+typedef uint8_t const  cu8;
+typedef int8_t const   cs8;
+typedef volatile u8 const cvu8;
+typedef volatile s8 const cvs8;
+
+typedef uint16_t const  cu16;
+typedef int16_t const   cs16;
+typedef volatile u16 const cvu16;
+typedef volatile s16 const cvs16;
+
+typedef uint32_t const  cu32;
+typedef int32_t const   cs32;
+typedef volatile u32 const cvu32;
+typedef volatile s32 const cvs32;
+
+typedef uint64_t const  cu64;
+typedef int64_t const   cs64;
+typedef volatile u64 const cvu64;
+typedef volatile s64 const cvs64;
+
+typedef float        f32;
+typedef double       f64;
+typedef volatile f32 vf32;
+typedef volatile f64 vf64;
+typedef float const  cf32;
+typedef double const cf64;
+typedef volatile f32 const cvf32;
+typedef volatile f64 const cvf64;

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#define VERSION_MAJOR 1
+#define VERSION_MINOR 2
+#define VERSION_PATCH 0


### PR DESCRIPTION
    - Add pack, sign, repack, verify, sign-file, romtags, and related CLI flows.
    - Implement OperaFS packing, signing, ROMTag generation, and digest table verification.
    - Add RSA/MD5 helpers, boot-code crypto, stream abstractions, and filesystem walking.
    - Vendor required crypto/utility dependencies and document OperaFS formats.